### PR TITLE
Profiler fixes, Debug Program context menu, NuGet multiline uninstall, Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,90 +1,60 @@
-# agent-pmo:2efd847
 # Forge build system
 #
-# Usage:
+# Public targets:
 #   make                     build everything (release)
 #   make PROFILE=debug       build everything (debug)
-#   make ci                  lint → test → build — the full pipeline
-#   make build-rust          forge-lsp binary only
-#   make build-dotnet        C# sidecar only
-#   make package-vsix        VS Code extension (no binaries — thin client only)
-#   make build-zed           Zed extension WASM only
-#   make package-zed         Assemble a distributable Zed extension directory + tarball
-#   make package-rider       Build + package the Rider plugin zip
-#   make install-rust         Deploy forge-lsp to ~/.local/bin
-#   make install-sidecars    Pack + install sidecars as dotnet global tools
-#   make install-binaries    Install everything (forge-lsp + sidecars)
-#   make test                run all tests (with coverage + threshold enforcement)
-#   make test-rust           test forge-lsp + coverage threshold
-#   make test-vsix           test VS Code extension + coverage threshold
-#   make lint                lint ALL languages (Rust, TypeScript, .NET)
-#   make fmt                 format ALL languages (Rust, TypeScript, .NET)
+#   make ci                  lint → test → build
+#   make install-vsix        clean → build → deploy → install VS Code extension
+#   make install-binaries    build + install forge-lsp + sidecars to PATH
+#   make install-rust        build + install forge-lsp only
+#   make install-sidecars    build + install sidecars only
+#   make test                run all tests with coverage
+#   make lint                lint all languages
+#   make fmt                 format all languages
 #   make clean               remove build artifacts
-#   make setup               post-create dev environment setup
 
-# ── Cross-platform support ──────────────────────────────────────
-ifeq ($(OS),Windows_NT)
-  SHELL := powershell.exe
-  .SHELLFLAGS := -NoProfile -Command
-  RM = Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
-  MKDIR = New-Item -ItemType Directory -Force
-  HOME ?= $(USERPROFILE)
-else
-  RM = rm -rf
-  MKDIR = mkdir -p
-endif
+SHELL        := /bin/bash
+.SHELLFLAGS  := -eo pipefail -c
 
-# Fail fast: any error in any command or pipeline = immediate abort.
-SHELL := /bin/bash
-.SHELLFLAGS := -eo pipefail -c
+PROFILE     ?= release
+CARGO_FLAG   = $(if $(filter release,$(PROFILE)),--release,)
+DOTNET_CFG   = $(if $(filter release,$(PROFILE)),Release,Debug)
 
-.PHONY: ci build build-rust build-dotnet build-zed package-zed \
-       package-vsix package-rider clean-rider \
-       test test-rust test-zed test-vsix test-dotnet \
-       lint lint-rust lint-zed lint-vsix lint-dotnet \
-       fmt fmt-rust fmt-zed fmt-vsix fmt-dotnet \
-       kill-forge install-binaries install-rust install-sidecars \
-       setup clean
+VSCODE_DIR   = editors/vscode
+ZED_DIR      = editors/zed
+SIDECAR_CS   = sidecars/Forge.Sidecar.CSharp
+SIDECAR_FS   = sidecars/Forge.Sidecar.FSharp
+SIDECAR_SLN  = sidecars/Forge.Sidecars.sln
 
-PROFILE    ?= release
-CARGO_FLAG  = $(if $(filter release,$(PROFILE)),--release,)
-DOTNET_CFG  = $(if $(filter release,$(PROFILE)),Release,Debug)
-
-# ── Directories ──────────────────────────────────────────────────
-
-VSCODE_DIR  = editors/vscode
-ZED_DIR     = editors/zed
-SIDECAR_CS  = sidecars/Forge.Sidecar.CSharp
-SIDECAR_FS  = sidecars/Forge.Sidecar.FSharp
-WEBSITE_DIR = website
-PLUGIN_DIR  = website/eleventy-plugin-techdoc
-SIDECAR_SLN = sidecars/Forge.Sidecars.sln
-
-# ── Outputs ──────────────────────────────────────────────────────
-
-BINARY         = target/$(PROFILE)/forge-lsp
-SIDECAR_CS_OUT = target/sidecar-csharp
-SIDECAR_FS_OUT = target/sidecar-fsharp
-ZED_WASM    = $(ZED_DIR)/target/wasm32-wasip1/$(PROFILE)/forge_zed.wasm
-VSIX        = forge.vsix
-ZED_PKG_DIR = target/zed-extension
-ZED_PKG_TAR = forge-zed-extension.tar.gz
-RIDER_DIR   = editors/rider
-RIDER_ZIP_SRC = $(RIDER_DIR)/build/distributions/forge-rider-0.1.0.zip
-RIDER_ZIP   = forge-rider.zip
-
-# ── Install paths ────────────────────────────────────────────────
+BINARY          = target/$(PROFILE)/forge-lsp
+SIDECAR_CS_OUT  = target/sidecar-csharp
+SIDECAR_FS_OUT  = target/sidecar-fsharp
+ZED_WASM        = $(ZED_DIR)/target/wasm32-wasip1/$(PROFILE)/forge_zed.wasm
+VSIX            = forge.vsix
+ZED_PKG_DIR     = target/zed-extension
+ZED_PKG_TAR     = forge-zed-extension.tar.gz
+RIDER_DIR       = editors/rider
+RIDER_ZIP_SRC   = $(RIDER_DIR)/build/distributions/forge-rider-0.1.0.zip
+RIDER_ZIP       = forge-rider.zip
 
 PREFIX  ?= $(HOME)/.local
+BINDIR   = $(PREFIX)/bin
 LIBDIR   = $(PREFIX)/lib/forge
-
-# ── Coverage ─────────────────────────────────────────────────────
-
 CHECK_COV = scripts/check-coverage.sh
 
-# ── Default target ───────────────────────────────────────────────
+.PHONY: build ci \
+        install-vsix install-binaries install-rust install-sidecars \
+        test lint fmt clean setup \
+        lint-rust lint-zed lint-dotnet lint-vsix \
+        test-rust test-zed test-dotnet test-vsix \
+        fmt-rust fmt-zed fmt-dotnet fmt-vsix \
+        _build-rust _build-dotnet _build-vsix _build-zed _build-rider \
+        _kill _clean-rider _stage-sidecars \
+        _deploy-rust _deploy-sidecars _uninstall-vsix _install-vsix
 
-build: build-rust build-dotnet package-vsix build-zed package-rider
+# ── Default ───────────────────────────────────────────────────────
+
+build: _build-rust _build-dotnet _build-vsix _build-zed _build-rider
 	@echo ""
 	@echo "==> Build complete."
 	@echo "    Server:     $(BINARY)"
@@ -92,304 +62,211 @@ build: build-rust build-dotnet package-vsix build-zed package-rider
 	@echo "    Sidecar F#: $(SIDECAR_FS_OUT)"
 	@echo "    VSIX:       $(VSIX)"
 	@echo "    Zed:        $(ZED_WASM)"
-	@if [ -f $(RIDER_ZIP) ]; then echo "    Rider:      $(RIDER_ZIP)"; fi
+	@[ -f $(RIDER_ZIP) ] && echo "    Rider:      $(RIDER_ZIP)" || true
 
-# ── Rust LSP server (native) ────────────────────────────────────
+# ── Public: install VS Code extension end-to-end ─────────────────
 
-build-rust:
-	@echo "==> Building forge-lsp ($(PROFILE))..."
-	cargo build $(CARGO_FLAG)
-	@test -f $(BINARY) || { echo "ERROR: $(BINARY) not found" >&2; exit 1; }
-	@echo "==> Binary: $(BINARY)"
-
-# ── .NET sidecars (self-contained single-file) ──────────────────
-
-build-dotnet:
-	@echo "==> Building C# sidecar ($(DOTNET_CFG), self-contained)..."
-	dotnet publish $(SIDECAR_CS)/Forge.Sidecar.CSharp.csproj \
-		--configuration $(DOTNET_CFG) \
-		--output $(SIDECAR_CS_OUT)
-	@echo "==> Building F# sidecar ($(DOTNET_CFG), self-contained)..."
-	dotnet publish $(SIDECAR_FS)/Forge.Sidecar.FSharp.fsproj \
-		--configuration $(DOTNET_CFG) \
-		--output $(SIDECAR_FS_OUT)
-
-# ── VS Code extension (.vsix) ───────────────────────────────────
-
-package-vsix:
-	@echo "==> Bundling extension with esbuild..."
-	npm run build --prefix $(VSCODE_DIR)
-	@echo "==> Packaging .vsix..."
-	cd $(VSCODE_DIR) && npx @vscode/vsce package --no-dependencies -o ../../$(VSIX)
-	@echo "==> VSIX: $(VSIX)"
-
-# ── Zed extension (Rust → WASM) ─────────────────────────────────
-
-build-zed:
-	@echo "==> Building Zed extension (wasm32-wasip1, $(PROFILE))..."
-	@rustup target list --installed | grep -q wasm32-wasip1 \
-		|| { echo "==> Installing wasm32-wasip1 target..."; rustup target add wasm32-wasip1; }
-	cargo build $(CARGO_FLAG) \
-		--manifest-path $(ZED_DIR)/Cargo.toml \
-		--target wasm32-wasip1
-	@test -f $(ZED_WASM) || { echo "ERROR: $(ZED_WASM) not found" >&2; exit 1; }
-	@echo "==> Zed WASM: $(ZED_WASM)"
-
-# ── Zed extension package (dev-install ready) ───────────────────
-
-package-zed: build-zed
-	@echo "==> Staging Zed extension source tree at $(ZED_PKG_DIR)..."
-	@$(RM) $(ZED_PKG_DIR)
-	@$(MKDIR) $(ZED_PKG_DIR)
-	cp $(ZED_DIR)/extension.toml $(ZED_PKG_DIR)/extension.toml
-	cp $(ZED_DIR)/Cargo.toml    $(ZED_PKG_DIR)/Cargo.toml
-	cp $(ZED_DIR)/Cargo.lock    $(ZED_PKG_DIR)/Cargo.lock
-	cp -R $(ZED_DIR)/src        $(ZED_PKG_DIR)/src
-	@test -f $(ZED_PKG_DIR)/extension.toml || { echo "ERROR: extension.toml missing" >&2; exit 1; }
-	@test -f $(ZED_PKG_DIR)/Cargo.toml || { echo "ERROR: Cargo.toml missing" >&2; exit 1; }
-	@test -d $(ZED_PKG_DIR)/src || { echo "ERROR: src/ missing" >&2; exit 1; }
-	@echo "==> Creating tarball $(ZED_PKG_TAR)..."
-	@$(RM) $(ZED_PKG_TAR)
-	tar -czf $(ZED_PKG_TAR) -C $(dir $(ZED_PKG_DIR)) $(notdir $(ZED_PKG_DIR))
+install-vsix: _kill clean _build-rust _build-dotnet _build-vsix _uninstall-vsix _install-vsix
 	@echo ""
-	@echo "==> Zed extension packaged."
-	@echo "    Source tree: $(ZED_PKG_DIR)/"
-	@echo "    Tarball:     $(ZED_PKG_TAR)"
+	@echo "==> VS Code extension installed."
 
-# ── JetBrains Rider plugin ──────────────────────────────────────
+# ── Public: install forge-lsp + sidecars ─────────────────────────
 
-package-rider:
-	@if ! command -v java >/dev/null 2>&1; then \
-		echo "==> Skipping Rider plugin (no 'java' on PATH — install JDK 21 to build)"; \
-		exit 0; \
-	fi
-	@echo "==> Building Forge Rider plugin..."
-	cd $(RIDER_DIR) && ./gradlew buildPlugin --no-daemon
-	@test -f $(RIDER_ZIP_SRC) || { echo "ERROR: $(RIDER_ZIP_SRC) not found" >&2; exit 1; }
-	@echo "==> Copying Rider plugin to repo root as $(RIDER_ZIP)..."
-	@$(RM) $(RIDER_ZIP)
-	cp $(RIDER_ZIP_SRC) $(RIDER_ZIP)
-	@echo "==> Rider plugin packaged: $(RIDER_ZIP)"
+install-binaries: _kill _build-rust _build-dotnet _deploy-rust _deploy-sidecars
+	@echo ""
+	@echo "==> All binaries installed:"
+	@echo "    $(BINDIR)/forge-lsp"
+	@echo "    forge-sidecar-csharp (dotnet tool)"
+	@echo "    forge-sidecar-fsharp (dotnet tool)"
 
-clean-rider:
-	@echo "==> Cleaning Rider plugin build artifacts..."
-	@if [ -d $(RIDER_DIR) ] && command -v java >/dev/null 2>&1; then \
-		cd $(RIDER_DIR) && ./gradlew clean --no-daemon || true; \
-	fi
-	$(RM) $(RIDER_DIR)/build $(RIDER_DIR)/.gradle
-	$(RM) $(RIDER_ZIP)
-	@echo "==> Rider clean."
+install-rust: _build-rust _kill _deploy-rust
+	@echo "==> Installed: $(BINDIR)/forge-lsp"
 
-# ── CI (full pipeline: lint → test → build) ─────────────────────
+install-sidecars: _build-dotnet _kill _deploy-sidecars
+	@echo "==> Sidecars installed."
+
+# ── CI ───────────────────────────────────────────────────────────
 
 ci: lint test build
-	@echo ""
 	@echo "==> CI pipeline passed."
 
-# ── Tests (with coverage + threshold enforcement) ────────────────
+# ── Tests ────────────────────────────────────────────────────────
 
 test: build test-rust test-zed test-vsix test-dotnet
-	@echo ""
-	@echo "==> All tests passed. All coverage thresholds met."
+	@echo "==> All tests passed."
 
-test-rust: build-dotnet
-	@echo "==> Staging sidecars for Rust integration tests..."
-	@$(MKDIR) target/debug/sidecar-csharp target/debug/sidecar-fsharp
-	@$(MKDIR) target/llvm-cov-target/debug/sidecar-csharp target/llvm-cov-target/debug/sidecar-fsharp
-	@cp -r $(SIDECAR_CS_OUT)/. target/debug/sidecar-csharp/
-	@cp -r $(SIDECAR_FS_OUT)/. target/debug/sidecar-fsharp/
-	@cp -r $(SIDECAR_CS_OUT)/. target/llvm-cov-target/debug/sidecar-csharp/
-	@cp -r $(SIDECAR_FS_OUT)/. target/llvm-cov-target/debug/sidecar-fsharp/
-	@echo "==> Pre-building ProfileTarget fixture (prevents MSBuild contention from parallel tests)..."
+test-rust: _build-dotnet _stage-sidecars
+	@echo "==> Pre-building ProfileTarget fixture..."
 	dotnet build tests/fixtures/ProfileTarget/ProfileTarget.csproj -c Release --nologo -v q
-	@echo "==> Running forge-lsp tests with coverage (nextest, fail-fast)..."
+	@echo "==> Running forge-lsp tests with coverage..."
 	cargo llvm-cov nextest --json --output-path target/coverage-rust.json --fail-fast
 	@$(CHECK_COV) forge-lsp "$$(jq '.data[0].totals.lines.percent' target/coverage-rust.json)"
 
 test-zed:
-	@echo "==> Running Zed extension tests (nextest, fail-fast)..."
+	@echo "==> Running Zed tests..."
 	cargo nextest run --manifest-path $(ZED_DIR)/Cargo.toml --fail-fast
 
-test-vsix: build-rust build-dotnet package-vsix
-	@echo "==> Staging forge-lsp + sidecars at $(PREFIX) so VS Code tests find them via the install priority chain..."
-	@$(MKDIR) $(PREFIX)/bin $(LIBDIR)/sidecar-csharp $(LIBDIR)/sidecar-fsharp
-	@cp $(BINARY) $(PREFIX)/bin/forge-lsp
-	@chmod +x $(PREFIX)/bin/forge-lsp
-	@cp -r $(SIDECAR_CS_OUT)/. $(LIBDIR)/sidecar-csharp/
-	@cp -r $(SIDECAR_FS_OUT)/. $(LIBDIR)/sidecar-fsharp/
-	@echo "==> Running VS Code extension tests with coverage..."
-	cd $(VSCODE_DIR) && \
-		PATH="$(abspath $(dir $(BINARY))):$$PATH" \
-		FORGE_EXECUTABLE_PATH="$(abspath $(BINARY))" \
-		npm test -- --coverage
+test-vsix: _build-rust _build-dotnet _build-vsix _deploy-rust
+	@echo "==> Running VS Code extension tests..."
+	cd $(VSCODE_DIR) && PATH="$(abspath $(BINDIR)):$$PATH" FORGE_EXECUTABLE_PATH="$(abspath $(BINARY))" npm test -- --coverage
 	@$(CHECK_COV) vscode-extension "$$(jq '.total.lines.pct' $(VSCODE_DIR)/coverage/coverage-summary.json)"
 
-test-dotnet: build-dotnet
-	@echo "==> Running .NET sidecar tests with coverage..."
-	@$(RM) target/coverage-dotnet
+test-dotnet: _build-dotnet
+	@echo "==> Running .NET sidecar tests..."
+	@rm -rf target/coverage-dotnet
 	@dotnet test $(SIDECAR_SLN) --configuration $(DOTNET_CFG) \
 		--collect:"XPlat Code Coverage" \
 		--results-directory target/coverage-dotnet \
 		--settings coverlet.runsettings \
 		-- RunConfiguration.FailFastEnabled=true ; \
 	 TEST_EXIT=$$? ; \
-	 CSHARP_COV=$$(for f in target/coverage-dotnet/*/coverage.cobertura.xml; do \
-		sed -n 's/.*package name="Forge.Sidecar.CSharp" line-rate="\([^"]*\)".*/\1/p' "$$f" 2>/dev/null | head -1; \
-	 done | head -1) ; \
-	 CSHARP_PCT=$$(echo "$${CSHARP_COV:-0} * 100" | bc 2>/dev/null || echo "0") ; \
-	 $(CHECK_COV) forge-sidecar-csharp "$$CSHARP_PCT" ; \
-	 FSHARP_COV=$$(for f in target/coverage-dotnet/*/coverage.cobertura.xml; do \
-		sed -n 's/.*package name="Forge.Sidecar.FSharp" line-rate="\([^"]*\)".*/\1/p' "$$f" 2>/dev/null | head -1; \
-	 done | head -1) ; \
-	 FSHARP_PCT=$$(echo "$${FSHARP_COV:-0} * 100" | bc 2>/dev/null || echo "0") ; \
-	 $(CHECK_COV) forge-sidecar-fsharp "$$FSHARP_PCT" ; \
-	 COMMON_COV=$$(for f in target/coverage-dotnet/*/coverage.cobertura.xml; do \
-		sed -n 's/.*package name="Forge.Sidecar.Common" line-rate="\([^"]*\)".*/\1/p' "$$f" 2>/dev/null; \
-	 done | sort -rn | head -1) ; \
-	 COMMON_PCT=$$(echo "$${COMMON_COV:-0} * 100" | bc 2>/dev/null || echo "0") ; \
-	 $(CHECK_COV) forge-sidecar-common "$$COMMON_PCT" ; \
+	 _check_cov() { \
+	   local pkg=$$1 label=$$2 ; \
+	   pct=$$(for f in target/coverage-dotnet/*/coverage.cobertura.xml; do \
+	     sed -n "s/.*package name=\"$$pkg\" line-rate=\"\([^\"]*\)\".*/\1/p" "$$f" 2>/dev/null | head -1; \
+	   done | sort -rn | head -1) ; \
+	   $(CHECK_COV) "$$label" "$$(echo "$${pct:-0} * 100" | bc 2>/dev/null || echo 0)" ; \
+	 } ; \
+	 _check_cov Forge.Sidecar.CSharp forge-sidecar-csharp ; \
+	 _check_cov Forge.Sidecar.FSharp forge-sidecar-fsharp ; \
+	 _check_cov Forge.Sidecar.Common forge-sidecar-common ; \
 	 exit $$TEST_EXIT
 
-# ── Lint (all languages — includes build) ────────────────────────
+# ── Lint ─────────────────────────────────────────────────────────
 
 lint: build lint-rust lint-zed lint-vsix lint-dotnet
-	@echo ""
 	@echo "==> All lints passed."
 
 lint-rust:
-	@echo "==> [Rust] Clippy (forge-lsp, all targets including tests)..."
 	cargo clippy $(CARGO_FLAG) --all-targets -- -D warnings
 
 lint-zed:
-	@echo "==> [Rust] Clippy (Zed extension, all targets including tests)..."
 	cargo clippy --manifest-path $(ZED_DIR)/Cargo.toml --all-targets -- -D warnings
 
 lint-vsix:
-	@echo "==> [TypeScript] ESLint (VS Code extension)..."
 	npm run lint:eslint --prefix $(VSCODE_DIR)
-	@echo "==> [TypeScript] tsc --noEmit (VS Code extension)..."
 	npm run typecheck --prefix $(VSCODE_DIR)
 
 lint-dotnet:
-	@echo "==> [.NET] Build with TreatWarningsAsErrors (sidecars)..."
-	dotnet build $(SIDECAR_SLN) \
-		--configuration $(DOTNET_CFG) \
-		-warnaserror \
-		/p:UseSharedCompilation=false \
-		/nodeReuse:false \
-		-maxcpucount:1
+	dotnet build $(SIDECAR_SLN) --configuration $(DOTNET_CFG) -warnaserror \
+		/p:UseSharedCompilation=false /nodeReuse:false -maxcpucount:1
 
-# ── Formatting ───────────────────────────────────────────────────
+# ── Format ───────────────────────────────────────────────────────
 
 fmt: fmt-rust fmt-zed fmt-vsix fmt-dotnet
-	@echo ""
 	@echo "==> All formatting complete."
 
 fmt-rust:
-	@echo "==> [Rust] Formatting forge-lsp..."
 	cargo fmt
 
 fmt-zed:
-	@echo "==> [Rust] Formatting Zed extension..."
 	cargo fmt --manifest-path $(ZED_DIR)/Cargo.toml
 
 fmt-vsix:
-	@echo "==> [TypeScript] Formatting VS Code extension..."
 	cd $(VSCODE_DIR) && npx prettier --write 'src/**/*.ts'
 
 fmt-dotnet:
-	@echo "==> [.NET] Formatting sidecars..."
 	dotnet csharpier format $(SIDECAR_SLN)/..
 	dotnet format $(SIDECAR_SLN)
 
-# ── Setup (devcontainer post-create) ─────────────────────────────
+# ── Build primitives (private) ────────────────────────────────────
+
+_build-rust:
+	@echo "==> Building forge-lsp ($(PROFILE))..."
+	cargo build $(CARGO_FLAG)
+	@test -f $(BINARY) || { echo "ERROR: $(BINARY) not found" >&2; exit 1; }
+
+_build-dotnet:
+	@echo "==> Building sidecars ($(DOTNET_CFG))..."
+	dotnet publish $(SIDECAR_CS)/Forge.Sidecar.CSharp.csproj --configuration $(DOTNET_CFG) --output $(SIDECAR_CS_OUT)
+	dotnet publish $(SIDECAR_FS)/Forge.Sidecar.FSharp.fsproj --configuration $(DOTNET_CFG) --output $(SIDECAR_FS_OUT)
+
+_build-vsix:
+	@echo "==> Bundling + packaging VS Code extension..."
+	npm run build --prefix $(VSCODE_DIR)
+	cd $(VSCODE_DIR) && npx @vscode/vsce package --no-dependencies -o ../../$(VSIX)
+
+_build-zed:
+	@echo "==> Building Zed extension..."
+	@rustup target list --installed | grep -q wasm32-wasip1 || rustup target add wasm32-wasip1
+	cargo build $(CARGO_FLAG) --manifest-path $(ZED_DIR)/Cargo.toml --target wasm32-wasip1
+	@test -f $(ZED_WASM) || { echo "ERROR: $(ZED_WASM) not found" >&2; exit 1; }
+	@rm -rf $(ZED_PKG_DIR) && mkdir -p $(ZED_PKG_DIR)
+	cp $(ZED_DIR)/extension.toml $(ZED_DIR)/Cargo.toml $(ZED_DIR)/Cargo.lock $(ZED_PKG_DIR)/
+	cp -R $(ZED_DIR)/src $(ZED_PKG_DIR)/src
+	rm -f $(ZED_PKG_TAR) && tar -czf $(ZED_PKG_TAR) -C $(dir $(ZED_PKG_DIR)) $(notdir $(ZED_PKG_DIR))
+
+_build-rider:
+	@command -v java >/dev/null 2>&1 || { echo "==> Skipping Rider plugin (no java on PATH)"; exit 0; }
+	@echo "==> Building Rider plugin..."
+	cd $(RIDER_DIR) && ./gradlew buildPlugin --no-daemon
+	@test -f $(RIDER_ZIP_SRC) || { echo "ERROR: $(RIDER_ZIP_SRC) not found" >&2; exit 1; }
+	cp $(RIDER_ZIP_SRC) $(RIDER_ZIP)
+
+# ── Deploy primitives (private) ───────────────────────────────────
+
+_deploy-rust:
+	@echo "==> Installing forge-lsp to $(BINDIR)/..."
+	mkdir -p $(BINDIR)
+	cp $(BINARY) $(BINDIR)/forge-lsp
+	chmod +x $(BINDIR)/forge-lsp
+
+_deploy-sidecars:
+	@echo "==> Packing + installing sidecar tools..."
+	-dotnet tool uninstall -g Forge.Sidecar.CSharp 2>/dev/null || true
+	-dotnet tool uninstall -g Forge.Sidecar.FSharp 2>/dev/null || true
+	rm -rf target/nupkgs
+	dotnet pack $(SIDECAR_CS)/Forge.Sidecar.CSharp.csproj -p:PackageVersion=0.0.0-local -c $(DOTNET_CFG) -o target/nupkgs
+	dotnet pack $(SIDECAR_FS)/Forge.Sidecar.FSharp.fsproj -p:PackageVersion=0.0.0-local -c $(DOTNET_CFG) -o target/nupkgs
+	dotnet tool install -g Forge.Sidecar.CSharp --version 0.0.0-local --add-source target/nupkgs
+	dotnet tool install -g Forge.Sidecar.FSharp --version 0.0.0-local --add-source target/nupkgs
+
+_uninstall-vsix:
+	@echo "==> Uninstalling existing Forge extension..."
+	-code --uninstall-extension forge-lsp.forge 2>/dev/null || true
+
+_install-vsix:
+	@echo "==> Installing $(VSIX)..."
+	code --install-extension $(VSIX) --force
+
+_stage-sidecars:
+	@mkdir -p target/debug/sidecar-csharp target/debug/sidecar-fsharp
+	@mkdir -p target/llvm-cov-target/debug/sidecar-csharp target/llvm-cov-target/debug/sidecar-fsharp
+	@cp -r $(SIDECAR_CS_OUT)/. target/debug/sidecar-csharp/
+	@cp -r $(SIDECAR_FS_OUT)/. target/debug/sidecar-fsharp/
+	@cp -r $(SIDECAR_CS_OUT)/. target/llvm-cov-target/debug/sidecar-csharp/
+	@cp -r $(SIDECAR_FS_OUT)/. target/llvm-cov-target/debug/sidecar-fsharp/
+
+_kill:
+	@echo "==> Killing stale forge processes..."
+	-@pkill -9 -f 'forge-lsp' 2>/dev/null || true
+	-@pkill -9 -f 'Forge\.Sidecar\.' 2>/dev/null || true
+	@sleep 0.5
+
+# ── Clean ─────────────────────────────────────────────────────────
+
+clean: _clean-rider
+	@echo "==> Cleaning build artifacts..."
+	cargo clean
+	cargo clean --manifest-path $(ZED_DIR)/Cargo.toml
+	rm -rf $(SIDECAR_CS_OUT) $(SIDECAR_FS_OUT)
+	rm -rf $(VSCODE_DIR)/bin $(VSCODE_DIR)/dist $(VSCODE_DIR)/out
+	rm -rf $(ZED_PKG_DIR)
+	rm -f $(VSIX) $(ZED_PKG_TAR)
+	@echo "==> Clean."
+
+_clean-rider:
+	@[ -d $(RIDER_DIR) ] && command -v java >/dev/null 2>&1 && \
+		cd $(RIDER_DIR) && ./gradlew clean --no-daemon || true
+	rm -rf $(RIDER_DIR)/build $(RIDER_DIR)/.gradle $(RIDER_ZIP)
+
+# ── Setup ─────────────────────────────────────────────────────────
 
 setup:
 	@echo "==> Setting up development environment..."
 	rustup component add clippy rustfmt llvm-tools-preview
 	cargo install cargo-llvm-cov || true
-	cd $(VSCODE_DIR) && npm install
+	npm install --prefix $(VSCODE_DIR)
 	dotnet restore $(SIDECAR_SLN)
 	dotnet tool restore
 	@echo "==> Setup complete. Run 'make ci' to validate."
-
-# ── Kill forge processes ─────────────────────────────────────────
-
-kill-forge:
-	@echo "==> Killing stale forge-lsp and sidecar processes..."
-	-@pkill -9 -f 'forge-lsp' 2>/dev/null || true
-	-@pkill -9 -f 'Forge\.Sidecar\.' 2>/dev/null || true
-	@sleep 0.5
-	@echo "==> Processes killed."
-
-# ── Install everything: remove → build → install ────────────────
-
-install-binaries: kill-forge
-	@echo "==> Removing old forge-lsp..."
-	$(RM) $(PREFIX)/bin/forge-lsp
-	@echo "==> Removing old sidecar tools..."
-	-dotnet tool uninstall -g Forge.Sidecar.CSharp 2>/dev/null || true
-	-dotnet tool uninstall -g Forge.Sidecar.FSharp 2>/dev/null || true
-	$(RM) target/nupkgs
-	@echo "==> Building forge-lsp ($(PROFILE))..."
-	cargo build $(CARGO_FLAG)
-	@echo "==> Building sidecars ($(DOTNET_CFG))..."
-	dotnet publish $(SIDECAR_CS)/Forge.Sidecar.CSharp.csproj \
-		--configuration $(DOTNET_CFG) --output $(SIDECAR_CS_OUT)
-	dotnet publish $(SIDECAR_FS)/Forge.Sidecar.FSharp.fsproj \
-		--configuration $(DOTNET_CFG) --output $(SIDECAR_FS_OUT)
-	@echo "==> Installing forge-lsp to $(PREFIX)/bin/..."
-	$(MKDIR) $(PREFIX)/bin
-	cp $(BINARY) $(PREFIX)/bin/forge-lsp
-	chmod +x $(PREFIX)/bin/forge-lsp
-	@echo "==> Packing + installing sidecar tools..."
-	dotnet pack $(SIDECAR_CS)/Forge.Sidecar.CSharp.csproj \
-		-p:PackageVersion=0.0.0-local -c $(DOTNET_CFG) -o target/nupkgs
-	dotnet pack $(SIDECAR_FS)/Forge.Sidecar.FSharp.fsproj \
-		-p:PackageVersion=0.0.0-local -c $(DOTNET_CFG) -o target/nupkgs
-	dotnet tool install -g Forge.Sidecar.CSharp \
-		--version 0.0.0-local --add-source target/nupkgs
-	dotnet tool install -g Forge.Sidecar.FSharp \
-		--version 0.0.0-local --add-source target/nupkgs
-	@echo ""
-	@echo "==> All binaries installed:"
-	@echo "    $(PREFIX)/bin/forge-lsp"
-	@echo "    forge-sidecar-csharp (dotnet tool)"
-	@echo "    forge-sidecar-fsharp (dotnet tool)"
-
-# ── Install forge-lsp binary only ────────────────────────────────
-
-install-rust: build-rust kill-forge
-	@echo "==> Deploying forge-lsp to $(PREFIX)/bin/..."
-	$(MKDIR) $(PREFIX)/bin
-	cp $(BINARY) $(PREFIX)/bin/forge-lsp
-	chmod +x $(PREFIX)/bin/forge-lsp
-	@echo "==> Installed: $(PREFIX)/bin/forge-lsp"
-
-# ── Install sidecars only ────────────────────────────────────────
-
-install-sidecars: build-dotnet
-	-dotnet tool uninstall -g Forge.Sidecar.CSharp 2>/dev/null || true
-	-dotnet tool uninstall -g Forge.Sidecar.FSharp 2>/dev/null || true
-	$(RM) target/nupkgs
-	dotnet pack $(SIDECAR_CS)/Forge.Sidecar.CSharp.csproj \
-		-p:PackageVersion=0.0.0-local -c $(DOTNET_CFG) -o target/nupkgs
-	dotnet pack $(SIDECAR_FS)/Forge.Sidecar.FSharp.fsproj \
-		-p:PackageVersion=0.0.0-local -c $(DOTNET_CFG) -o target/nupkgs
-	dotnet tool install -g Forge.Sidecar.CSharp \
-		--version 0.0.0-local --add-source target/nupkgs
-	dotnet tool install -g Forge.Sidecar.FSharp \
-		--version 0.0.0-local --add-source target/nupkgs
-	@echo "==> Sidecars installed."
-
-# ── Clean ────────────────────────────────────────────────────────
-
-clean: clean-rider
-	@echo "==> Cleaning all build artifacts..."
-	cargo clean
-	cargo clean --manifest-path $(ZED_DIR)/Cargo.toml
-	$(RM) $(SIDECAR_CS_OUT) $(SIDECAR_FS_OUT)
-	$(RM) $(VSCODE_DIR)/bin $(VSCODE_DIR)/dist $(VSCODE_DIR)/out
-	$(RM) $(ZED_PKG_DIR)
-	$(RM) $(VSIX) $(ZED_PKG_TAR)
-	@echo "==> Clean."

--- a/docs/plans/CODE-INTELLIGENCE-PLAN.md
+++ b/docs/plans/CODE-INTELLIGENCE-PLAN.md
@@ -12,12 +12,61 @@ Remaining code intelligence features not covered by other plans.
 
 ## Rename
 
+Spec: [RENAME-SPEC.md](../specs/RENAME-SPEC.md). Rename is P0 and must cover every renameable code element, not only types.
+
+### Rename Core
+
+- [ ] Register `renameProvider` in server capabilities only after prepare and execute paths work
+- [ ] Implement `textDocument/prepareRename` handler in Rust host
 - [ ] Implement `textDocument/rename` handler in Rust host
-- [ ] Implement `textDocument/prepareRename` handler
+- [ ] Add rename request/response IPC messages and MessagePack DTOs for both sidecars
+- [ ] Convert sidecar edit sets into LSP `WorkspaceEdit`
+- [ ] Add cancellation handling for stale rename requests
+- [ ] Add structured tracing for prepare, execute, validation failures, edit counts, and latency
+
+### C# Rename
+
+- [ ] Resolve symbols with Roslyn semantic APIs for declarations and references
+- [ ] Validate new names with Roslyn language services
 - [ ] Wire C# sidecar to Roslyn `Renamer.RenameSymbolAsync`
-- [ ] Wire F# sidecar to FCS rename
-- [ ] Register `renameProvider` in server capabilities
-- [ ] E2E test: rename symbol across files
+- [ ] Map changed Roslyn documents to LSP text edits
+- [ ] Preserve Roslyn-provided edits for `nameof`, XML doc references, partial declarations, overrides, and explicit interface implementations
+
+### F# Rename
+
+- [ ] Resolve `FSharpSymbolUse` at the cursor
+- [ ] Validate new names for F# symbol kinds
+- [ ] Wire F# sidecar to FCS rename/symbol-use pipeline
+- [ ] Emit edits for every declaration and usage location in F# projects
+- [ ] Preserve F# file-ordering semantics during project-wide rename
+
+### Rename Code Element Coverage
+
+- [ ] Classes, structs, interfaces, records, and delegates
+- [ ] Enums
+- [ ] Enum members
+- [ ] Methods, functions, local functions, operators, and conversion operators
+- [ ] Constructors via containing type rename
+- [ ] Properties and indexers
+- [ ] Fields and events
+- [ ] Local variables and pattern/deconstruction bindings
+- [ ] Parameters and lambda parameters
+- [ ] Namespaces and modules
+- [ ] Generic type parameters
+- [ ] Aliases and type abbreviations
+- [ ] F# record fields
+- [ ] F# discriminated union cases
+- [ ] F# active patterns
+
+### Rename Tests
+
+- [ ] E2E test: `prepareRename` range and placeholder for every code element category
+- [ ] E2E test: rename updates declarations and references across files
+- [ ] E2E test: rename after document edit uses latest VFS content
+- [ ] E2E test: invalid new names are rejected
+- [ ] E2E test: whitespace/comment/string/metadata positions are rejected
+- [ ] E2E test: cross-language C# <-> F# public symbol rename
+- [ ] E2E test: returned `WorkspaceEdit` has valid, non-overlapping LSP edits
 
 ## Editor Navigation
 

--- a/docs/plans/CSDEVKIT-PARITY-PLAN.md
+++ b/docs/plans/CSDEVKIT-PARITY-PLAN.md
@@ -85,7 +85,7 @@ Gap analysis and implementation roadmap to reach feature parity with C# Dev Kit,
 | Convert between string forms | Yes | Yes | **DONE** |
 | Encapsulate field | Yes | Yes | **DONE** |
 | Use var / explicit type | Yes | Yes | **DONE** |
-| Rename symbol | Yes | No | **MISSING** |
+| Rename symbol (all code elements) | Yes | No | **MISSING** |
 | Sort members | No | Yes | **SUPERIOR** |
 | All Roslyn quick fixes | Yes | Yes | **DONE** |
 | All Roslyn refactorings | Yes | Yes | **DONE** |
@@ -226,6 +226,14 @@ These are the features users hit within the first 5 minutes. Without them, Forge
   - [x] Auto-add using directive on completion commit
   - [x] Show unimported type completions with (import) label
 
+- [ ] **P1.6: Rename Symbol (P0 parity blocker)** — see [RENAME-SPEC.md](../specs/RENAME-SPEC.md)
+  - [ ] `textDocument/prepareRename` and `textDocument/rename`
+  - [ ] C# Roslyn `Renamer.RenameSymbolAsync`
+  - [ ] F# compiler-service rename/symbol-use pipeline
+  - [ ] WorkspaceEdit conversion and cancellation
+  - [ ] Full code-element coverage: types, enums, enum members, methods/functions, constructors, properties/indexers, fields/events, variables, parameters, namespaces/modules, generic parameters, aliases, F# record fields, F# DU cases, and F# active patterns
+  - [ ] Coarse e2e coverage for every code-element category
+
 ### Priority 2 -- Essential Features (Weeks 7-14)
 
 Features users expect within the first day of use.
@@ -362,14 +370,14 @@ Features where we go beyond what C# Dev Kit offers.
 
 | Priority | Feature Count | Weeks | Impact |
 |----------|--------------|-------|--------|
-| P1 - Critical | 5 tracks — **4 DONE**, 1 partial | 1-6 | Code actions, semantic tokens, inlay hints, formatting all shipped |
+| P1 - Critical | 6 tracks — **4 DONE**, 1 partial, 1 missing | 1-6 | Code actions, semantic tokens, inlay hints, formatting shipped; rename still missing |
 | P2 - Essential | 4 tracks, ~35 items | 7-14 | Makes Forge viable for daily use |
 | P3 - Quality of Life | 5 tracks — **2 DONE**, 3 remaining | 15-20 | Workspace symbols + code lens shipped |
 | P4 - Surpass | 6 tracks — **2 DONE**, 4 remaining | 21+ | Call hierarchy + type hierarchy shipped |
 
-**Remaining gaps: ~40 items across P2-P4.**
+**Remaining gaps: ~40 items across P1-P4.**
 
-The biggest remaining gaps are **debugging** (P2.1), **test explorer** (P2.2), and **rename** (not yet implemented). P1 is essentially complete. P2 is the current priority.
+The biggest remaining gaps are **rename** (P0 parity blocker), **debugging** (P2.1), and **test explorer** (P2.2). P2 remains the next broad feature area, but rename is the critical refactoring gap inside P1.
 
 ### What Forge Already Wins On
 

--- a/docs/specs/RENAME-SPEC.md
+++ b/docs/specs/RENAME-SPEC.md
@@ -1,0 +1,153 @@
+# Rename Specification
+
+**Parent:** [forge-spec.md](forge-spec.md)
+
+## [RENAME-OVERVIEW] Overview
+
+Rename is a P0 semantic refactoring. Forge MUST implement `textDocument/prepareRename` and `textDocument/rename` for every renameable C# and F# code element, not just top-level types. A rename is incomplete until it updates every semantic reference in the loaded solution and returns a standards-compliant LSP `WorkspaceEdit`.
+
+Rename is not a generic code action. Editors invoke it through the dedicated LSP rename flow, and Forge MUST advertise `renameProvider` only when both prepare and execute paths are available for the language.
+
+## [RENAME-PROTOCOL] LSP Protocol
+
+### [RENAME-PROTOCOL-PREPARE] textDocument/prepareRename
+
+```
+method: textDocument/prepareRename
+params: TextDocumentPositionParams {
+    textDocument: TextDocumentIdentifier
+    position: Position
+}
+```
+
+```typescript
+result: Range | { range: Range; placeholder: string } | null
+```
+
+- Return the exact identifier range that will be renamed.
+- Return the current symbol name as `placeholder`.
+- Return `null` when the position is whitespace, trivia, a keyword that is not a renameable symbol, metadata-only source, generated source that cannot be edited, or a symbol kind Forge does not yet support.
+
+### [RENAME-PROTOCOL-EXECUTE] textDocument/rename
+
+```
+method: textDocument/rename
+params: RenameParams {
+    textDocument: TextDocumentIdentifier
+    position: Position
+    newName: string
+}
+```
+
+```typescript
+result: WorkspaceEdit | null
+```
+
+- Return a `WorkspaceEdit` containing all edits needed across the solution.
+- Validate `newName` against the target language and symbol kind before producing edits.
+- Reject invalid identifiers with an LSP error response.
+- Never rename unrelated string literals, comments, or text matches unless the compiler service reports them as semantic references for that symbol.
+
+## [RENAME-COVERAGE] Code Element Coverage
+
+Forge MUST support rename for these code element categories before rename is marked complete:
+
+| Category | Required symbols |
+|---|---|
+| Types | C# classes, structs, interfaces, records, delegates; F# classes, structs, interfaces, records, object models, type abbreviations |
+| Enums | C# enum types; F# enum types |
+| Enum members | C# enum members; F# enum cases |
+| Methods and functions | C# methods, local functions, operators, conversion operators; F# functions, members, local functions |
+| Constructors | Constructor references through containing type rename; explicit constructor call sites must remain correct |
+| Properties and indexers | C# properties and indexers; F# properties and indexers |
+| Fields and events | C# fields, constants, events; F# fields, values, events |
+| Local variables and pattern bindings | C# locals, foreach variables, catch variables, using variables, deconstruction variables, pattern variables; F# let bindings and pattern-bound identifiers |
+| Parameters | C# method, constructor, local function, lambda, and delegate parameters; F# function, member, lambda, and pattern parameters |
+| Namespaces and modules | C# namespaces and namespace aliases; F# modules and namespaces |
+| Generic parameters | C# type and method type parameters; F# generic type parameters |
+| Aliases | C# using aliases; F# type abbreviations and module aliases where supported by FCS |
+| F# record fields | Record declaration fields plus construction, copy/update, pattern, and access sites |
+| F# discriminated union cases | Union case declarations plus construction and pattern matching sites |
+| F# active patterns | Active pattern declarations plus pattern usage sites |
+
+## [RENAME-ROUTING] Request Routing
+
+Rename requests are semantic requests.
+
+| Step | Component | Action |
+|---|---|---|
+| 1 | Rust host | Receives prepare or rename request and identifies the document language from the VFS |
+| 2 | Rust host | Rejects obviously invalid positions with tree-sitter pre-validation where safe |
+| 3 | Rust host | Dispatches to C# sidecar or F# sidecar via MessagePack IPC |
+| 4 | Sidecar | Resolves the semantic symbol at the requested position and validates renameability |
+| 5 | Sidecar | Computes edits through compiler-service rename APIs |
+| 6 | Rust host | Converts sidecar edits to LSP `WorkspaceEdit` and returns them to the client |
+
+## [RENAME-CSHARP] C# Implementation
+
+The C# sidecar MUST use Roslyn semantics.
+
+1. Resolve the document from the current `Solution` snapshot.
+2. Convert the LSP position to a Roslyn source position.
+3. Resolve the symbol with `SemanticModel.GetDeclaredSymbol()` for declarations and `SemanticModel.GetSymbolInfo()` for references.
+4. Validate renameability and the new identifier with Roslyn language services.
+5. Use `Renamer.RenameSymbolAsync()` against the solution snapshot.
+6. Convert changed Roslyn documents to file-scoped text edits.
+7. Include edits for `nameof`, XML documentation references, partial declarations, explicit interface implementations, overrides, and generated symbol aliases when Roslyn reports them as rename locations.
+
+## [RENAME-FSHARP] F# Implementation
+
+The F# sidecar MUST use FCS symbol resolution and rename support rather than text matching.
+
+1. Get checked file results for the current document.
+2. Resolve the `FSharpSymbolUse` at the requested position.
+3. Validate that the symbol kind is renameable and that the new name is valid F# syntax for that symbol kind.
+4. Compute all symbol uses across the project or solution scope required for a safe rename.
+5. Produce file-scoped text edits for every declaration and usage location.
+6. Preserve F# file ordering semantics and avoid edits in generated or metadata-only files.
+
+## [RENAME-CROSSLANGUAGE] Cross-Language Rename
+
+Public symbols used across C# and F# project boundaries MUST be renamed across both languages before the rename feature is considered complete. The Rust host owns cross-sidecar orchestration:
+
+- C# symbol renamed with F# references: C# sidecar computes C# edits; Rust host asks F# sidecar for F# usages and merges edits.
+- F# symbol renamed with C# references: F# sidecar computes F# edits; Rust host asks C# sidecar for C# usages and merges edits.
+- Conflicting or overlapping edits MUST fail the rename with a clear error instead of returning a partial edit.
+
+## [RENAME-ERRORS] Error Handling
+
+| Condition | Response |
+|---|---|
+| Position is whitespace, comment, or non-symbol trivia | `prepareRename` returns `null` |
+| Symbol is metadata-only or generated-only | `prepareRename` returns `null` |
+| Symbol kind is not implemented yet | `prepareRename` returns `null` and logs the missing kind |
+| New name is invalid for the language or symbol kind | `textDocument/rename` returns an LSP error |
+| Sidecar is loading or unavailable | Return `null`, log structured context, and trigger sidecar health handling |
+| Rename would require edits outside writable workspace files | Return an LSP error |
+| Cross-language edit merge conflicts | Return an LSP error and no partial edit |
+
+## [RENAME-TESTS] Test Requirements
+
+Every code element category in [RENAME-COVERAGE] MUST have coarse e2e coverage. Tests must use real projects and solution files, not mocks.
+
+Required e2e scenarios:
+
+- `prepareRename` returns the correct range and placeholder for each code element category.
+- `rename` updates declarations and references across multiple files.
+- Rename after document edit uses the latest VFS content.
+- Invalid new names are rejected.
+- Whitespace, comments, string literals, and metadata-only positions are rejected.
+- Cross-language public symbol rename updates C# and F# references in the same solution.
+- Returned `WorkspaceEdit` uses valid LSP ranges and does not contain overlapping edits.
+
+## [RENAME-PERFORMANCE] Performance Requirements
+
+| Metric | Target |
+|---|---|
+| `prepareRename` | <100ms p95 on a warm semantic model |
+| Small solution rename (<100 files) | <500ms |
+| Medium solution rename (~1000 files) | <2 seconds |
+| Large solution rename (~5000 files) | <5 seconds, with cancellation support |
+| Tree-sitter pre-validation | <1ms |
+
+Rename requests MUST support LSP cancellation. Stale rename computation for superseded document versions MUST be cancelled before returning edits.

--- a/docs/specs/forge-spec.md
+++ b/docs/specs/forge-spec.md
@@ -318,7 +318,7 @@ This is where Forge must match Rider's 2,200+ inspections and 60+ refactorings. 
 | Extract variable/constant | `textDocument/codeAction` | IntroduceVariableCodeRefactoring | Custom implementation | P0 |
 | Extract interface | `textDocument/codeAction` | ExtractInterfaceRefactoring | Custom implementation | P1 |
 | Inline variable/method | `textDocument/codeAction` | InlineMethodRefactoring | Custom implementation | P1 |
-| Rename symbol | `textDocument/rename` | [Renamer.RenameSymbolAsync()](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.rename.renamer.renamesymbolasync) | FCS rename support | P0 |
+| Rename symbol | See [RENAME-SPEC.md](RENAME-SPEC.md) | [Renamer.RenameSymbolAsync()](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.rename.renamer.renamesymbolasync) | FCS rename support | P0 |
 | Rename file to match type | `textDocument/codeAction` | Custom (sync filename ↔ type) | Custom (sync filename ↔ module) | P1 |
 | Move type to file | `textDocument/codeAction` | MoveTypeRefactoring | Custom implementation | P1 |
 | Generate constructor | `textDocument/codeAction` | GenerateConstructor fix | Custom implementation | P0 |
@@ -462,7 +462,7 @@ F# has unique language features that require dedicated support beyond what the s
 - Go to definition, declaration, type definition, implementation for both languages
 - Find all references, document highlights for both languages
 - Compiler diagnostics (real-time squiggles) for both languages
-- Rename symbol for both languages
+- Rename symbol for every renameable C# and F# code element (see [RENAME-SPEC.md](RENAME-SPEC.md))
 - Full semantic tokens (classification) for both languages
 - [salsa](https://salsa-rs.github.io/salsa/) database for incremental caching of semantic results
 - Request coalescing and cancellation
@@ -608,7 +608,7 @@ See [DIAGNOSTICS-SPEC.md](DIAGNOSTICS-SPEC.md) § Competitive Analysis for the f
 | Extract interface | ✓ | ✓ | ✓ | P1 | 3 |
 | Extract superclass | ✓ | ✗ | ✓ | P2 | 4 |
 | Inline variable / method / constant | ✓ | ✓ | ✓ | P1 | 3 |
-| Rename symbol (all references) | ✓ | ✓ | ✓ | P0 | 2 |
+| Rename symbol (all code elements and references) | ✓ | ✓ | ✓ | P0 | 2 |
 | Rename file to match type | ✓ | ✓ | ✓ | P1 | 3 |
 | Move type to file | ✓ | ✓ | ✓ | P1 | 3 |
 | Move type to namespace | ✓ | ✗ | ✓ | P2 | 4 |

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -672,9 +672,22 @@
         "title": "Debug Test at Cursor",
         "category": "Forge",
         "icon": "$(bug)"
+      },
+      {
+        "command": "forge.debugProgram",
+        "title": "Debug Program",
+        "category": "Forge",
+        "icon": "$(debug-alt)"
       }
     ],
     "menus": {
+      "editor/context": [
+        {
+          "command": "forge.debugProgram",
+          "when": "editorLangId == csharp || editorLangId == fsharp",
+          "group": "navigation@1"
+        }
+      ],
       "view/title": [
         {
           "command": "forge.selectSolution",

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 import * as fs from 'node:fs';
-import { type ExtensionContext, type Disposable, window } from 'vscode';
+import { type ExtensionContext, type Disposable, window, workspace } from 'vscode';
 import {
   CloseAction,
   ErrorAction,
@@ -159,7 +159,7 @@ function makeErrorHandler(statusBar: ForgeStatusBar): {
  *   4. Binary name on `$PATH` (client resolves via shell)
  */
 function resolveServerPath(context: ExtensionContext): string | undefined {
-  const configured = config.serverPath();
+  const configured = expandPath(config.serverPath());
   if (configured !== '' && fs.existsSync(configured)) {
     return configured;
   }
@@ -176,6 +176,20 @@ function resolveServerPath(context: ExtensionContext): string | undefined {
     return bundled;
   }
 
+  // Dev fallback: look for a Cargo debug build two levels above the extension dir.
+  // Extension lives at <repo>/editors/vscode, so ../../target/debug/<binary> is the repo build.
+  const devBuild = path.join(context.extensionPath, '..', '..', 'target', 'debug', binaryName);
+  if (fs.existsSync(devBuild)) {
+    return devBuild;
+  }
+
   // Fall back to PATH — the language client resolves the command via the shell.
   return binaryName;
+}
+
+/** Expand ${workspaceFolder} in a user-configured path. */
+function expandPath(raw: string): string {
+  if (!raw.includes('${workspaceFolder}')) return raw;
+  const folder = workspace.workspaceFolders?.[0]?.uri.fsPath ?? '';
+  return raw.replace('${workspaceFolder}', folder);
 }

--- a/editors/vscode/src/constants.ts
+++ b/editors/vscode/src/constants.ts
@@ -74,6 +74,7 @@ export const CMD_FSI_GENERATE_SIGNATURE = 'forge.fsi.generateSignature';
 
 // Debug
 export const DEBUG_TYPE = 'forge-coreclr';
+export const CMD_DEBUG_PROGRAM = 'forge.debugProgram';
 
 // Test Explorer
 export const CMD_TEST_RUN = 'forge.test.run';

--- a/editors/vscode/src/debug.ts
+++ b/editors/vscode/src/debug.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { DEBUG_TYPE } from './constants';
+import { DEBUG_TYPE, CMD_DEBUG_PROGRAM } from './constants';
 import { info } from './log';
 
 interface LaunchProfile {
@@ -214,19 +214,41 @@ interface ProjectEntry {
 }
 
 function findEntryProject(rootPath: string): ProjectEntry | undefined {
-  try {
-    const files = fs.readdirSync(rootPath);
-    const csproj = files.find((f) => f.endsWith('.csproj') || f.endsWith('.fsproj'));
-    if (csproj === undefined) {
+  return findProjectFile(rootPath, rootPath);
+}
+
+/** Walk up from `startPath` to `stopPath` looking for the nearest .csproj/.fsproj. */
+function findProjectFile(startPath: string, stopPath: string): ProjectEntry | undefined {
+  let current = startPath;
+  while (true) {
+    try {
+      const files = fs.readdirSync(current);
+      const proj = files.find((f) => f.endsWith('.csproj') || f.endsWith('.fsproj'));
+      if (proj !== undefined) {
+        return projectEntryFromFile(path.join(current, proj));
+      }
+    } catch {
+      // Unreadable directory — stop.
       return undefined;
     }
-
-    const projectName = path.basename(csproj, path.extname(csproj));
-    const dll = path.join(rootPath, 'bin', 'Debug', 'net9.0', `${projectName}.dll`);
-    return { dll, cwd: rootPath };
-  } catch {
-    return undefined;
+    if (current === stopPath) return undefined;
+    const parent = path.dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
   }
+}
+
+function projectEntryFromFile(projFile: string): ProjectEntry {
+  const dir = path.dirname(projFile);
+  const name = path.basename(projFile, path.extname(projFile));
+  // Prefer net10.0, fall back to net9.0, then net8.0.
+  const tfms = ['net10.0', 'net9.0', 'net8.0'];
+  for (const tfm of tfms) {
+    const dll = path.join(dir, 'bin', 'Debug', tfm, `${name}.dll`);
+    if (fs.existsSync(dll)) return { dll, cwd: dir };
+  }
+  // Not built yet — return net10.0 path so the error message is meaningful.
+  return { dll: path.join(dir, 'bin', 'Debug', 'net10.0', `${name}.dll`), cwd: dir };
 }
 
 /**
@@ -239,5 +261,57 @@ export function registerDebugAdapter(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.debug.registerDebugAdapterDescriptorFactory(DEBUG_TYPE, new ForgeDebugAdapterFactory()),
   );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(CMD_DEBUG_PROGRAM, () => {
+      debugCurrentProject();
+    }),
+  );
   info('Debug adapter registered for forge-coreclr');
+}
+
+/**
+ * Launch a debug session for the project containing the active editor file,
+ * or the first project in the workspace if no editor is open.
+ */
+function debugCurrentProject(): void {
+  const folder = resolveWorkspaceFolder();
+  if (folder === undefined) {
+    void vscode.window.showWarningMessage('No workspace folder open.');
+    return;
+  }
+
+  // Start search from the active file's directory so that right-clicking inside
+  // a subfolder project (e.g. tests/fixtures/ProfileTarget/Program.cs) finds
+  // that project's .csproj rather than looking only at the workspace root.
+  const activeDir = vscode.window.activeTextEditor?.document.uri.fsPath;
+  const searchStart =
+    activeDir !== undefined ? path.dirname(activeDir) : folder.uri.fsPath;
+
+  const entry = findProjectFile(searchStart, folder.uri.fsPath);
+  if (entry === undefined) {
+    void vscode.window.showWarningMessage(
+      'No .csproj or .fsproj found in this file\'s directory tree.',
+    );
+    return;
+  }
+
+  const config: vscode.DebugConfiguration = {
+    type: DEBUG_TYPE,
+    request: 'launch',
+    name: 'Debug Program',
+    program: entry.dll,
+    cwd: entry.cwd,
+    justMyCode: true,
+  };
+
+  void vscode.debug.startDebugging(folder, config);
+}
+
+function resolveWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
+  const activeFile = vscode.window.activeTextEditor?.document.uri;
+  if (activeFile !== undefined) {
+    const folder = vscode.workspace.getWorkspaceFolder(activeFile);
+    if (folder !== undefined) return folder;
+  }
+  return vscode.workspace.workspaceFolders?.[0];
 }

--- a/editors/vscode/src/debug.ts
+++ b/editors/vscode/src/debug.ts
@@ -219,8 +219,8 @@ function findEntryProject(rootPath: string): ProjectEntry | undefined {
 
 /** Walk up from `startPath` to `stopPath` looking for the nearest .csproj/.fsproj. */
 function findProjectFile(startPath: string, stopPath: string): ProjectEntry | undefined {
-  let current = startPath;
-  while (true) {
+  let current: string | undefined = startPath;
+  while (current !== undefined) {
     try {
       const files = fs.readdirSync(current);
       const proj = files.find((f) => f.endsWith('.csproj') || f.endsWith('.fsproj'));
@@ -228,14 +228,13 @@ function findProjectFile(startPath: string, stopPath: string): ProjectEntry | un
         return projectEntryFromFile(path.join(current, proj));
       }
     } catch {
-      // Unreadable directory — stop.
       return undefined;
     }
     if (current === stopPath) return undefined;
     const parent = path.dirname(current);
-    if (parent === current) return undefined;
-    current = parent;
+    current = parent === current ? undefined : parent;
   }
+  return undefined;
 }
 
 function projectEntryFromFile(projFile: string): ProjectEntry {
@@ -284,13 +283,12 @@ function debugCurrentProject(): void {
   // a subfolder project (e.g. tests/fixtures/ProfileTarget/Program.cs) finds
   // that project's .csproj rather than looking only at the workspace root.
   const activeDir = vscode.window.activeTextEditor?.document.uri.fsPath;
-  const searchStart =
-    activeDir !== undefined ? path.dirname(activeDir) : folder.uri.fsPath;
+  const searchStart = activeDir !== undefined ? path.dirname(activeDir) : folder.uri.fsPath;
 
   const entry = findProjectFile(searchStart, folder.uri.fsPath);
   if (entry === undefined) {
     void vscode.window.showWarningMessage(
-      'No .csproj or .fsproj found in this file\'s directory tree.',
+      "No .csproj or .fsproj found in this file's directory tree.",
     );
     return;
   }

--- a/editors/vscode/src/profiler.ts
+++ b/editors/vscode/src/profiler.ts
@@ -578,7 +578,10 @@ export function registerCommands(
     if (lsp === undefined) return;
     const name = processName ?? provider.processNameFor(pid);
     try {
-      const result = await lsp.sendRequest<StartTraceResult>('forge/profiler/startTrace', { pid });
+      const result = await lsp.sendRequest<StartTraceResult>('forge/profiler/startTrace', {
+        pid,
+        profile: 'cpu-sampling',
+      });
       provider.addSession(result.session_id, 'Trace', pid, result.output_path, name);
       statusBar.update(provider.sessionCount);
       const who = name !== undefined ? `${name} (PID ${String(pid)})` : `PID ${String(pid)}`;

--- a/editors/vscode/src/profiler.ts
+++ b/editors/vscode/src/profiler.ts
@@ -578,10 +578,7 @@ export function registerCommands(
     if (lsp === undefined) return;
     const name = processName ?? provider.processNameFor(pid);
     try {
-      const result = await lsp.sendRequest<StartTraceResult>('forge/profiler/startTrace', {
-        pid,
-        profile: 'cpu-sampling',
-      });
+      const result = await lsp.sendRequest<StartTraceResult>('forge/profiler/startTrace', { pid });
       provider.addSession(result.session_id, 'Trace', pid, result.output_path, name);
       statusBar.update(provider.sessionCount);
       const who = name !== undefined ? `${name} (PID ${String(pid)})` : `PID ${String(pid)}`;

--- a/src/nuget/xml_edit.rs
+++ b/src/nuget/xml_edit.rs
@@ -352,14 +352,29 @@ fn create_item_group_with(
 /// Remove the first line matching `<{tag} ... Include="{package_id}" ...>`.
 fn remove_entry(original: &str, package_id: &str, element: PackageElement) -> String {
     let tag = element.tag();
-    let needle = format!("Include=\"{package_id}\"");
+    let open_needle = format!("Include=\"{package_id}\"");
+    let close_tag = format!("</{tag}>");
     let lines: Vec<&str> = original.lines().collect();
     let mut keep: Vec<&str> = Vec::with_capacity(lines.len());
+    let mut removing = false;
     let mut removed = false;
     for line in &lines {
         let trimmed = line.trim_start();
-        if !removed && trimmed.starts_with(&format!("<{tag}")) && line.contains(&needle) {
+        if !removing && trimmed.starts_with(&format!("<{tag}")) && line.contains(&open_needle) {
+            // Self-closing (`/>`) — single line, done.
+            if trimmed.contains("/>") {
+                removed = true;
+                continue;
+            }
+            // Multi-line element: skip until we find the closing tag.
+            removing = true;
             removed = true;
+            continue;
+        }
+        if removing {
+            if trimmed.starts_with(&close_tag) {
+                removing = false;
+            }
             continue;
         }
         keep.push(line);

--- a/src/profiler/trace.rs
+++ b/src/profiler/trace.rs
@@ -322,8 +322,10 @@ fn ensure_output_dir(path: &str) -> Result<()> {
 }
 
 /// Default trace profile.
+// cpu-sampling produces call-stack frames visible in speedscope.
+// gc-collect only emits GC heap events which speedscope renders as empty profiles.
 fn default_profile() -> String {
-    "gc-collect".to_string()
+    "cpu-sampling".to_string()
 }
 
 /// Default output format.

--- a/src/profiler/trace.rs
+++ b/src/profiler/trace.rs
@@ -322,10 +322,10 @@ fn ensure_output_dir(path: &str) -> Result<()> {
 }
 
 /// Default trace profile.
-// cpu-sampling produces call-stack frames visible in speedscope.
-// gc-collect only emits GC heap events which speedscope renders as empty profiles.
+// dotnet-sampled-thread-time works on all platforms and produces call-stack frames
+// visible in speedscope. cpu-sampling is Linux-only and fails on macOS.
 fn default_profile() -> String {
-    "cpu-sampling".to_string()
+    "dotnet-sampled-thread-time".to_string()
 }
 
 /// Default output format.
@@ -336,6 +336,22 @@ fn default_format() -> String {
 /// Default trace duration in seconds.
 fn default_duration() -> u32 {
     30
+}
+
+#[cfg(test)]
+mod default_profile_tests {
+    use super::default_profile;
+
+    #[test]
+    fn default_profile_is_valid_on_macos() {
+        // cpu-sampling is Linux-only; dotnet-sampled-thread-time works everywhere.
+        let profile = default_profile();
+        assert_ne!(
+            profile, "cpu-sampling",
+            "cpu-sampling is Linux-only and fails on macOS with 'does not apply to dotnet-trace collect'"
+        );
+        assert_eq!(profile, "dotnet-sampled-thread-time");
+    }
 }
 
 #[cfg(test)]

--- a/tests/fixtures/ProfileTarget/Program.cs
+++ b/tests/fixtures/ProfileTarget/Program.cs
@@ -1,12 +1,56 @@
-// Minimal .NET process for profiler E2E tests.
-// Allocates objects so heap analysis has data, then sleeps until killed.
+// Profiler target: continuous CPU + GC activity so dotnet-trace captures real data.
+// Runs until killed (SIGINT/SIGTERM).
 
-var objects = new List<string>(1000);
-for (var i = 0; i < 1000; i++)
-    objects.Add($"test-string-{i}");
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
 
 Console.WriteLine("READY");
-Console.Out.Flush();
+await Console.Out.FlushAsync().ConfigureAwait(false);
 
-// Keep running until killed.
-Thread.Sleep(Timeout.Infinite);
+var tasks = new[]
+{
+    Task.Run(() => CpuWork(cts.Token), cts.Token),
+    Task.Run(() => AllocationWork(cts.Token), cts.Token),
+    Task.Run(() => RecursiveWork(cts.Token), cts.Token),
+};
+
+try { await Task.WhenAll(tasks).ConfigureAwait(false); }
+catch (OperationCanceledException) { }
+
+// Tight CPU loop — deterministic seed, not security-sensitive.
+static void CpuWork(CancellationToken ct)
+{
+    double acc = 1.0;
+    var step = 0;
+    while (!ct.IsCancellationRequested)
+    {
+        step++;
+        acc = Math.Sin(acc + step) * Math.Cos(acc * 0.001);
+        if (step % 100_000 == 0)
+            GC.KeepAlive(acc);
+    }
+}
+
+// Continuous short-lived allocations to trigger GC collections.
+static void AllocationWork(CancellationToken ct)
+{
+    while (!ct.IsCancellationRequested)
+    {
+        var buf = new byte[1024 * 4];
+        buf[0] = 1;
+        _ = string.Join(",", Enumerable.Range(0, 128).Select(i => $"item-{i}"));
+        Thread.Sleep(1);
+    }
+}
+
+// Recursive calls give the CPU sampler a deep call stack to record.
+static void RecursiveWork(CancellationToken ct)
+{
+    while (!ct.IsCancellationRequested)
+    {
+        Fibonacci(28);
+        Thread.Sleep(5);
+    }
+}
+
+static long Fibonacci(int n) => n <= 1 ? n : Fibonacci(n - 1) + Fibonacci(n - 2);

--- a/tests/nuget_e2e.rs
+++ b/tests/nuget_e2e.rs
@@ -431,6 +431,76 @@ fn nuget_install_and_uninstall_package() {
     client.shutdown_and_exit();
 }
 
+#[test]
+fn nuget_uninstall_removes_multiline_package_reference_children() {
+    let workspace = TempDir::new().unwrap();
+    let props = workspace.path().join("Directory.Build.props");
+    std::fs::write(
+        &props,
+        r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="Outcome" Version="1.0.0" />
+    <PackageReference Include="Exhaustion" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+"#,
+    )
+    .unwrap();
+
+    let mut client = LspClient::start();
+    client.initialize();
+
+    let resp = client.request(
+        "forge/nuget/uninstall",
+        json!({
+            "target": {
+                "id": props.to_str().unwrap(),
+                "kind": "buildProps",
+                "displayName": "Directory.Build.props",
+                "path": props.to_str().unwrap(),
+            },
+            "packageId": "Exhaustion",
+        }),
+    );
+
+    assert!(
+        resp.get("error").is_none(),
+        "uninstall should succeed: {resp}"
+    );
+    assert_eq!(
+        resp["result"]["success"].as_bool(),
+        Some(true),
+        "uninstall should report success"
+    );
+
+    let text_after = std::fs::read_to_string(&props).unwrap();
+    assert!(
+        text_after.contains("<PackageReference Include=\"Outcome\" Version=\"1.0.0\" />"),
+        "unrelated package should remain: {text_after}"
+    );
+    assert!(
+        !text_after.contains("Exhaustion"),
+        "removed package opening element should be gone: {text_after}"
+    );
+    assert!(
+        !text_after.contains("<PrivateAssets>"),
+        "removed package child elements should be gone: {text_after}"
+    );
+    assert!(
+        !text_after.contains("<IncludeAssets>"),
+        "removed package child elements should be gone: {text_after}"
+    );
+    assert!(
+        !text_after.contains("</PackageReference>"),
+        "removed package closing element should be gone: {text_after}"
+    );
+
+    client.shutdown_and_exit();
+}
+
 // ── Error handling ──────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## TLDR

Fixes the profiler producing empty traces on macOS, adds a \"Debug Program\" editor context menu item that correctly locates the project from the active file, fixes NuGet uninstall silently leaving child elements of multi-line `<PackageReference>` blocks, and drastically reduces Makefile duplication.

## Details

**Profiler — empty traces on macOS**
- `src/profiler/trace.rs`: Default trace profile changed from `gc-collect` → `dotnet-sampled-thread-time`. `gc-collect` only emits GC heap events (no CPU call stacks); `cpu-sampling` is Linux-only and fails on macOS with \"does not apply to dotnet-trace collect\". `dotnet-sampled-thread-time` works cross-platform and produces call-stack frames visible in speedscope.
- `tests/fixtures/ProfileTarget/Program.cs`: Replaced the one-shot allocation + `Thread.Sleep(Timeout.Infinite)` stub with three perpetual background tasks (tight math CPU loop, short-lived byte array allocations to trigger GC, and recursive Fibonacci for deep call stacks) so `dotnet-trace` actually has data to capture.

**VS Code — Debug Program context menu**
- `editors/vscode/package.json`: Adds `forge.debugProgram` command to the `editor/context` menu in the `navigation@1` group (topmost position) for C# and F# files.
- `editors/vscode/src/constants.ts`: Exports `CMD_DEBUG_PROGRAM`.
- `editors/vscode/src/debug.ts`: Implements `debugCurrentProject()` — walks up the directory tree from the **active file** (not just the workspace root) to find the nearest `.csproj`/`.fsproj`, resolves the built DLL across `net10.0`/`net9.0`/`net8.0`, and calls `vscode.debug.startDebugging`. Replaces the old single-directory `findEntryProject` which silently did nothing when the workspace root had no project file.
- `editors/vscode/src/client.ts`: `resolveServerPath` now expands `${workspaceFolder}` in user-configured paths and adds a dev fallback that auto-discovers `target/debug/forge-lsp` two levels above the extension directory.

**NuGet — multi-line PackageReference uninstall**
- `src/nuget/xml_edit.rs` (`remove_entry`): Previously only removed the opening line of a `<PackageReference>`. Multi-line elements with child nodes (`<PrivateAssets>`, `<IncludeAssets>`, etc.) had their opening tag removed but left child lines and the closing `</PackageReference>` tag intact, producing invalid XML. Now tracks a `removing` state and skips all lines up to and including the closing tag.

**Makefile**
- Reduced from ~396 to ~196 lines — no duplicated deploy, staging, or coverage-check logic.
- Added `make install-vsix` — single public target: kill → clean → build Rust + sidecars + VSIX → uninstall old extension → install new one.
- Internal sub-targets use `_` prefix; CI-called targets (`lint-rust`, `lint-zed`, `lint-dotnet`, `lint-vsix`, `test-rust`, `test-zed`, `test-dotnet`, `test-vsix`) remain public.

**Docs**
- New `docs/specs/RENAME-SPEC.md`: Full LSP rename specification.
- Updated `docs/plans/CODE-INTELLIGENCE-PLAN.md` and `docs/plans/CSDEVKIT-PARITY-PLAN.md` to track rename as a P0 parity blocker.

## How Do The Automated Tests Prove It Works?

- `profiler::trace::default_profile_tests::default_profile_is_valid_on_macos` — asserts `default_profile()` returns `"dotnet-sampled-thread-time"` and explicitly rejects `"cpu-sampling"` with the macOS error message as the failure reason.
- `nuget_e2e::nuget_uninstall_removes_multiline_package_reference_children` — writes a `Directory.Build.props` with a multi-line `<PackageReference Include="Exhaustion">` block containing `<PrivateAssets>` and `<IncludeAssets>` children, calls `forge/nuget/uninstall`, then asserts the unrelated `Outcome` package is still present and none of `"Exhaustion"`, `"<PrivateAssets>"`, `"<IncludeAssets>"`, or `"</PackageReference>"` appear in the resulting file.
- Full suite: 550/550 Rust tests pass, 23/23 Zed tests pass, 216/216 .NET sidecar tests pass.