### PR TITLE
Publish VS Code extension to Marketplace via Entra ID OIDC (no PAT)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,8 +216,16 @@ jobs:
     - release
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Passwordless publish via Microsoft Entra ID OIDC — NO long-lived PAT.
+    # Binding the job to the `release` environment makes the GitHub OIDC subject
+    # deterministic (repo:OWNER/REPO:environment:release), so ONE federated
+    # credential covers every v* tag — Entra rejects tag wildcards in an explicit
+    # federated subject. Secrets (Azure app's client + tenant id, neither
+    # sensitive) live on the `release` environment. [SWR-SEC-TOKEN-PRIVILEGE]
+    environment: release
     permissions:
       contents: read
+      id-token: write
     steps:
     - uses: actions/setup-node@v4
       with:
@@ -227,30 +235,45 @@ jobs:
         path: artifacts
         pattern: vsix-*
         merge-multiple: true
-    # One `vsce publish` per platform-specific VSIX — vsce silently uses only
-    # the first when several are globbed into a single call. A hyphenated tag is
-    # published with --pre-release (the VSIX is packaged with --pre-release in
-    # the Makefile for hyphenated versions). Secret: VSCODE_MARKETPLACE_PAT.
-    - name: Publish each platform VSIX
-      env:
-        VSCE_PAT: "${{ secrets.VSCODE_MARKETPLACE_PAT }}"
+    # Exchange the GitHub Actions OIDC token for an Entra ID session (no client
+    # secret). The publisher identity has no Azure subscription role — its only
+    # authorization is Marketplace publisher membership — hence
+    # allow-no-subscriptions.
+    - uses: azure/login@v2
+      with:
+        client-id: "${{ secrets.AZURE_CLIENT_ID }}"
+        tenant-id: "${{ secrets.AZURE_TENANT_ID }}"
+        allow-no-subscriptions: true
+    # One `vsce publish` per platform-specific VSIX — vsce silently uses only the
+    # first when several are globbed into a single call. We mint an Azure DevOps
+    # / Marketplace-scoped Entra access token from the OIDC session and hand it to
+    # vsce via VSCE_PAT (kept off argv + masked). 499b84ac-... is Azure DevOps'
+    # fixed first-party app id that vsce authenticates against; this explicit
+    # short-lived-token path is the reliable PAT-less recipe and sidesteps the
+    # `--azure-credential` publish bug (microsoft/vscode-vsce#1023). vsce is
+    # version-pinned: a floating `npx @vscode/vsce` would fetch and run the latest
+    # release inside the job that holds the token — a supply-chain risk. A
+    # hyphenated tag is published with --pre-release (the VSIX is packaged with
+    # --pre-release in the Makefile for hyphenated versions).
+    - name: Publish each platform VSIX (Entra OIDC, no PAT)
       shell: bash
       run: |
         set -euo pipefail
-        if [ -z "${VSCE_PAT:-}" ]; then
-          echo "::error::VSCODE_MARKETPLACE_PAT is not set; cannot publish to the Marketplace"
-          exit 1
-        fi
         shopt -s globstar nullglob
         flag=""
         if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
           flag="--pre-release"
           echo "Prerelease tag ${GITHUB_REF_NAME}; publishing with --pre-release"
         fi
+        VSCE_PAT="$(az account get-access-token \
+          --resource 499b84ac-1321-427f-aa17-267ca6975798 \
+          --query accessToken -o tsv)"
+        echo "::add-mask::${VSCE_PAT}"
+        export VSCE_PAT
         published=0
         for vsix in artifacts/**/*.vsix; do
           echo "Publishing ${vsix}"
-          npx --yes @vscode/vsce publish ${flag} --packagePath "${vsix}"
+          npx --yes @vscode/vsce@3.9.2 publish ${flag} --packagePath "${vsix}"
           published=$((published + 1))
         done
         if [ "${published}" -eq 0 ]; then

--- a/docs/plans/RELEASE-PUBLISHING-OIDC-PLAN.md
+++ b/docs/plans/RELEASE-PUBLISHING-OIDC-PLAN.md
@@ -1,0 +1,168 @@
+# RELEASE-PUBLISHING-OIDC-PLAN
+
+Operational runbook for cutting a SharpLsp release that publishes the VS Code
+extension to the **VS Code Marketplace** (passwordless, Microsoft Entra ID OIDC)
+and the **Open VSX Registry** (access token). Implements the publish jobs in
+[`.github/workflows/release.yml`](../../.github/workflows/release.yml) and the
+secrets contract in [`DISTRIBUTION-SPEC.md` → `[DIST-SECRETS]`](../specs/DISTRIBUTION-SPEC.md).
+
+## How publishing works
+
+A `v*` tag push triggers `release.yml`:
+
+1. `version` → extracts version from the tag, validates manifests.
+2. `build-vsix` (matrix) → stamps the tag version, builds per-platform VSIXes.
+3. `release` → GitHub Release + `SHA256SUMS`.
+4. `publish-marketplace` → **Entra ID OIDC**, no PAT. Runs in the `release`
+   environment so its OIDC subject is `repo:Nimblesite/SharpLsp:environment:release`.
+5. `publish-openvsx` → **`OPEN_VSX_PAT`** access token (Open VSX has no OIDC path).
+
+Marketplace publisher `Nimblesite` and Open VSX namespace `Nimblesite` already
+exist and are verified, so neither needs to be created/claimed. The Marketplace
+item `nimblesite.sharplsp` is a first publish.
+
+---
+
+## Part A — Azure: Entra ID app + federated credential (one-time)
+
+Requires the `az` CLI logged into the tenant that owns the Marketplace publisher.
+Portal equivalents are noted; CLI is faster.
+
+```bash
+# 1. Create the app registration + service principal
+az ad app create --display-name "sharplsp-marketplace-publisher"
+APP_ID=$(az ad app list --display-name "sharplsp-marketplace-publisher" --query "[0].appId" -o tsv)
+OBJ_ID=$(az ad app list --display-name "sharplsp-marketplace-publisher" --query "[0].id" -o tsv)
+az ad sp create --id "$APP_ID"
+
+# 2. Capture the two ids the workflow needs (NEITHER is a secret value)
+echo "AZURE_CLIENT_ID = $APP_ID"
+echo "AZURE_TENANT_ID = $(az account show --query tenantId -o tsv)"
+
+# 3. Add the GitHub-Actions federated credential.
+#    Subject MUST be the environment form — Entra rejects tag wildcards, and the
+#    job runs in the `release` environment, so the subject is constant across tags.
+cat > /tmp/sharplsp-fic.json <<'EOF'
+{
+  "name": "github-release-environment",
+  "issuer": "https://token.actions.githubusercontent.com",
+  "subject": "repo:Nimblesite/SharpLsp:environment:release",
+  "description": "GitHub Actions OIDC -> vsce publish (release environment)",
+  "audiences": ["api://AzureADTokenExchange"]
+}
+EOF
+az ad app federated-credential create --id "$APP_ID" --parameters /tmp/sharplsp-fic.json
+```
+
+> Portal: **Entra ID → App registrations → New registration**; then
+> **Certificates & secrets → Federated credentials → Add credential →
+> "GitHub Actions deploying Azure resources"**, Entity = **Environment**,
+> Environment name = `release`, Org = `Nimblesite`, Repo = `SharpLsp`.
+
+⚠️ The subject must match GitHub's OIDC `sub` **character-for-character**. A wrong
+subject still creates successfully but fails silently at token-exchange time.
+
+## Part B — Marketplace: add the app as a publisher member (one-time)
+
+1. Go to <https://marketplace.visualstudio.com/manage> and sign in as an **Owner**
+   of the `Nimblesite` publisher.
+2. Open the publisher → **Members → Add**.
+3. Add the service principal `sharplsp-marketplace-publisher` (by name / `$APP_ID`).
+4. Assign role **Contributor** (sufficient to publish; Owner only manages members).
+
+> Skipping this is the #1 failure cause — the OIDC token is minted fine but the
+> Marketplace rejects the publish with `InvalidAccessException`.
+
+## Part C — GitHub: `release` environment + secrets (one-time)
+
+1. Repo → **Settings → Environments → New environment** → name it exactly
+   `release`. Leave **required reviewers OFF** unless you want a manual approval
+   gate before each publish (the job will pause until approved if it's on).
+2. In the `release` environment → **Add environment secret** ×2:
+   - `AZURE_CLIENT_ID` = `$APP_ID` from Part A
+   - `AZURE_TENANT_ID` = tenant id from Part A
+3. (No `VSCODE_MARKETPLACE_PAT` / `VSCE_PAT` — OIDC replaces it entirely.)
+
+```bash
+# CLI equivalent (gh >= 2.x):
+gh api -X PUT repos/Nimblesite/SharpLsp/environments/release
+gh secret set AZURE_CLIENT_ID --env release --body "$APP_ID"
+gh secret set AZURE_TENANT_ID --env release --body "$(az account show --query tenantId -o tsv)"
+```
+
+## Part D — Open VSX: access token (one-time, + rotate)
+
+Open VSX still has **no OIDC** — a long-lived token is required.
+
+1. Sign in to <https://open-vsx.org> with the Eclipse Foundation / GitHub account
+   that is a member of the `Nimblesite` namespace (the one that publishes
+   basilisk/diffr/napper). Ensure the **Eclipse Open VSX Publisher Agreement** is
+   signed (Profile → it prompts if not).
+2. **Settings → Access Tokens → Generate New Token** → copy it (shown once).
+3. Add it as a **repo** secret:
+
+```bash
+gh secret set OPEN_VSX_PAT --body "<token>"
+```
+
+> Post-2025 Open VSX tokens **expire by default** — set a calendar reminder to
+> rotate, and regenerate if a publish fails with an auth error.
+
+---
+
+## Part E — Cut the release
+
+Pre-flight (all must be true):
+- [ ] PR #49 (the fixed pipeline) is **merged to `main`**.
+- [ ] Parts A–D complete (Azure app + FIC, Marketplace member, GH env+secrets, OVSX_PAT).
+- [ ] Tag is **higher than every burned tag** — `v0.1.0`–`v0.6.0` already exist;
+      use `v0.7.0` (or higher). Reusing a burned tag will not move the published code.
+
+```bash
+git checkout main && git pull
+git tag v0.7.0           # plain tag = stable; v0.7.0-rc.1 = pre-release everywhere
+git push origin v0.7.0
+```
+
+The tag push runs `release.yml`. Watch it:
+
+```bash
+gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+```
+
+## Verification (after the run is green)
+
+```bash
+# Marketplace (expect HTTP 200 once indexed, ~1-2 min)
+curl -s -o /dev/null -w "%{http_code}\n" "https://marketplace.visualstudio.com/items?itemName=nimblesite.sharplsp"
+# Open VSX
+curl -s "https://open-vsx.org/api/nimblesite/sharplsp" | head
+# GitHub release assets
+gh release view v0.7.0
+```
+
+## Failure playbook
+
+- **`azure/login` fails** → `id-token: write` missing, or the FIC subject ≠
+  `repo:Nimblesite/SharpLsp:environment:release`, or the `release` environment /
+  its secrets don't exist.
+- **Token minted but Marketplace publish fails (`InvalidAccessException` /
+  "corporate credentials")** → the app isn't a publisher **member** (Part B), or
+  not **Contributor**. This is the `--azure-credential` bug class
+  (microsoft/vscode-vsce#1023); the workflow already uses the explicit-token form
+  to avoid it.
+- **Open VSX publish fails auth** → `OPEN_VSX_PAT` missing/expired → regenerate
+  (Part D). Account must be a member of the `Nimblesite` namespace.
+- **Re-running the SAME tag** republishes the same version → the Marketplace
+  rejects duplicates. Push a new patch tag (`v0.7.1`) after any fix instead.
+
+## TODO
+
+- [ ] Part A — Entra app + service principal + federated credential
+- [ ] Part B — Marketplace publisher member (Contributor)
+- [ ] Part C — GitHub `release` environment + `AZURE_CLIENT_ID` / `AZURE_TENANT_ID`
+- [ ] Part D — `OPEN_VSX_PAT` repo secret
+- [ ] Merge PR #49 to `main`
+- [ ] Part E — push `v0.7.0`, watch run green
+- [ ] Verify Marketplace + Open VSX + GitHub Release
+- [ ] (Follow-up) move source versions to `0.0.0-dev`; rotate OVSX_PAT on schedule

--- a/docs/specs/DISTRIBUTION-SPEC.md
+++ b/docs/specs/DISTRIBUTION-SPEC.md
@@ -250,10 +250,14 @@ Both the Rust host and the .NET sidecar MUST use the same transport on each plat
 
 ## [DIST-SECRETS]
 
-| Secret | Purpose |
-|---|---|
-| `BREW_SCOOP_PAT` | PAT with `contents:write` on `Nimblesite/homebrew-tap` and `Nimblesite/scoop-bucket` |
-| `VSCE_PAT` | VS Code Marketplace publish token |
+The VS Code Marketplace publishes **passwordless via Microsoft Entra ID OIDC** (workload identity federation) — there is **no** long-lived Marketplace PAT. The `release.yml` `publish-marketplace` job runs in the `release` GitHub Environment so its OIDC subject is the deterministic `repo:Nimblesite/SharpLsp:environment:release`, which one Entra federated credential trusts. Open VSX has **no** OIDC/trusted-publishing path (verified 2026), so it still requires a long-lived access token.
+
+| Secret / Variable | Scope | Purpose |
+|---|---|---|
+| `BREW_SCOOP_PAT` | repo | PAT with `contents:write` on `Nimblesite/homebrew-tap` and `Nimblesite/scoop-bucket` |
+| `AZURE_CLIENT_ID` | `release` env | Entra ID app (client) id — Marketplace OIDC publish. Not sensitive; no PAT involved. |
+| `AZURE_TENANT_ID` | `release` env | Entra ID tenant (directory) id — Marketplace OIDC publish. |
+| `OPEN_VSX_PAT` | repo | Open VSX access token. No OIDC path exists; long-lived token required (rotate on a schedule — post-2025 tokens expire by default). |
 
 ## [DIST-CI-SMOKE]
 


### PR DESCRIPTION
## TLDR
Publish the VS Code extension to the Marketplace via Microsoft Entra ID OIDC (no long-lived PAT); document the exact one-time setup.

## Details
**`.github/workflows/release.yml` — `publish-marketplace` job rewired to passwordless OIDC:**
- Drops `VSCE_PAT` / `VSCODE_MARKETPLACE_PAT`. Now: `azure/login@v2` (GitHub OIDC → Entra session, `allow-no-subscriptions: true`) → mints an Azure DevOps-scoped Entra token (`az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798`) → handed to `vsce` via `VSCE_PAT` env, `::add-mask::`ed, kept off argv.
- Job binds to the `release` GitHub Environment so the OIDC subject is the constant `repo:Nimblesite/SharpLsp:environment:release` — one federated credential covers every `v*` tag (Entra rejects tag wildcards in an explicit subject).
- Adds `permissions: id-token: write`. Pins `@vscode/vsce@3.9.2` (was floating `npx @vscode/vsce`). Uses the explicit-token form rather than `--azure-credential` to sidestep the unresolved publish-failure class in microsoft/vscode-vsce#1023.
- `publish-openvsx` unchanged: Open VSX has no OIDC/trusted-publishing path (verified 2026), still uses `OPEN_VSX_PAT`.

**Docs:**
- `docs/specs/DISTRIBUTION-SPEC.md` `[DIST-SECRETS]`: documents OIDC, removes `VSCE_PAT`, adds `AZURE_CLIENT_ID`/`AZURE_TENANT_ID` (release env) + `OPEN_VSX_PAT`.
- New `docs/plans/RELEASE-PUBLISHING-OIDC-PLAN.md`: runbook for Azure app + federated credential, Marketplace membership, GitHub env+secrets, Open VSX token, and the tag-push.

No product/source code changes — Rust host, sidecars, and extension TS are untouched.

## How Do The Automated Tests Prove It Works?
This is a release-pipeline (`release.yml`) + docs change; it is exercised only by an actual `v*` tag push, not by the PR test suite. Validation:
- `actionlint .github/workflows/release.yml` → exit 0, clean (the only two repo shellcheck infos are pre-existing single-quoted node `-e` scripts in `ci.yml`, untouched here).
- The PR's own CI (`Lint`, `Test Rust`, `Test .NET`, `Test VS Code`, `Validate Shipwright Manifest`) must stay green, proving the release-workflow + docs edits don't regress the build/test/lint that #49 made pass.
- End-to-end OIDC publish is proven on the first real tag (`v0.7.0`); the runbook's "Verification" section gives the post-publish `curl`/`gh release view` checks.