### PR TITLE
Scope CodeQL scans to shipping code (exclude test sources) — unblock v0.4.0 release gate

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,17 @@
+# Shared CodeQL configuration for the PR, weekly, and gated release scans
+# (referenced by .github/workflows/codeql.yml). [GITHUB-CODE-SCANNING]
+#
+# Test code is never shipped: the VSIX bundles dist/extension.js (esbuild output
+# of src/, excluding src/test) and the Rust/.NET binaries — never the TypeScript
+# test suite. So test sources must not be able to gate a release. Excluding them
+# from extraction also removes false positives such as
+# js/incomplete-url-substring-sanitization firing on Array.prototype.includes()
+# over NuGet fixture names that happen to resemble hostnames (e.g. "Zlib.Net").
+name: SharpLsp CodeQL config
+
+queries:
+  - uses: security-extended
+
+paths-ignore:
+  - '**/*.test.ts'
+  - editors/vscode/src/test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,7 +68,9 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          queries: security-extended
+          # Query suite and test-code exclusions live in the shared config so the
+          # PR, weekly, and gated release scans stay identical. [GITHUB-CODE-SCANNING]
+          config-file: ./.github/codeql/codeql-config.yml
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:


### PR DESCRIPTION
## TLDR
Scope CodeQL analysis to shipping code by excluding the TypeScript test suite, unblocking the gated `v0.4.0` release that the new CodeQL release gate failed on a test-only false positive.

## Details
The release CodeQL gate (`release.yml` → `codeql.yml` with `gate: true`, added in #84) failed `v0.4.0` on a single High finding: `js/incomplete-url-substring-sanitization` at `editors/vscode/src/test/suite/unit-dependencies.test.ts:112`. That line is `assert.ok(pkgNames.includes('Zlib.Net'))`, where `pkgNames` is a `string[]` of NuGet package names — i.e. `Array.prototype.includes` (exact element match), not a URL substring check. CodeQL's host-detection heuristic false-fired because the fixture name `Zlib.Net` resembles the domain `zlib.net`.

Test code never ships (the VSIX bundles `dist/extension.js`, the esbuild output of `src/` excluding `src/test`, plus the Rust/.NET binaries), so it must not be able to gate a release.

- **New** `.github/codeql/codeql-config.yml`: carries the `security-extended` suite and `paths-ignore` for `**/*.test.ts` and `editors/vscode/src/test`.
- **Modified** `.github/workflows/codeql.yml`: the init step references `config-file:` instead of inlining `queries:`, so the PR, weekly, and gated release scans share one config.

No source, dependency, Rust, or .NET changes.

## How Do The Automated Tests Prove It Works?
- `actionlint .github/workflows/*.yml` → exit 0; both YAML files parse.
- This PR's `Analyze (javascript-typescript)` CodeQL run re-scans with the new config: the `unit-dependencies.test.ts` alert is no longer produced (test sources are excluded from extraction), demonstrating the finding that blocked the release is gone.
- `Lint`, `Test .NET`, `Test Rust`, `Test VS Code` confirm the config change doesn't disturb build/lint/test (they don't read the CodeQL config).
- Final proof is the re-tagged `v0.4.0` release run: the gated `CodeQL release gate / Analyze (javascript-typescript)` job now passes, allowing `release` and the publish jobs to proceed.
