### PR TITLE
Fix VS Code Output panel flooding from raw, ANSI-escaped server + sidecar logs

### DIFF
--- a/docs/specs/DISTRIBUTION-SPEC.md
+++ b/docs/specs/DISTRIBUTION-SPEC.md
@@ -86,6 +86,26 @@ The first v0.1.0 release threw out of `activate()` when bundled binaries were mi
 - `editors/vscode/src/extension.ts` — outer `activate()` catch surfaces the toast; inner `activateInner()` step paths return early with toast + degraded API instead of throwing.
 - `editors/vscode/src/dotnetRuntime.ts` — `acquireDotnet10` returns `Result<string, string>`; the caller pattern-matches.
 
+## [DIST-CLEAN-OUTPUT]
+
+Editors capture the language server's `stderr` into a user-facing Output panel (VS Code: the **SharpLsp** channel). Because the Rust host inherits each sidecar's `stderr`, that single stream carries host logs *and* both sidecars' logs. The panel MUST therefore stay clean, human-readable, and level-appropriate — never a dumping ground for raw, colorized, or per-request diagnostics.
+
+**Hard rules:**
+
+1. **No ANSI escape codes reach the panel.** The captured stream is a pipe, not a TTY, so color/cursor escapes render as garbage. The Rust host gates its `tracing` stderr layer on `std::io::IsTerminal` (`.with_ansi(stderr_is_terminal)`), emitting plain text whenever stderr is not an interactive terminal. The VS Code extension additionally strips ANSI defensively before anything reaches the channel (`createAnsiStrippingChannel`).
+2. **Sidecars MUST NOT write diagnostics to `Console.Error` / `eprintfn`.** Per the project logging rule, sidecar diagnostics use structured logging (Serilog) routed to a per-sidecar rolling file under the system temp directory (`sharplsp-logs/sidecar-<name>.log`) — never the inherited stderr. The only legitimate sidecar `stdout`/`stderr` writes are the `READY:` IPC handshake, the `--version` banner, the CLI usage message, and the single actionable Roslyn-mismatch hint ([DIST-RUNTIME-ACQUIRE] portability, below).
+3. **Per-request chatter goes to the file log, not the panel.** Routine traces (e.g. the router's per-request `[Router] Handling …`) are logged at `Debug` to the rolling file. Genuinely user-facing failures still surface (via the host's `error!` on a failed sidecar request, or a `[Show Log]` action per [DIST-FAILURE-UX]).
+4. **A type-load failure is summarized once.** MSBuild surfaces a `ReflectionTypeLoadException` as a diagnostic carrying dozens of identical "Could not load file or assembly" lines, repeated once per project. Repeated lines MUST be collapsed (`SidecarLog.CollapseRepeatedLines`) and duplicate summaries de-duplicated so the log records one distinct, actionable line — not a flood.
+
+**Reasoning — why this rule exists.**
+The first releases piped the host's colorized `tracing` output and each sidecar's raw `Console.Error` straight into the Output panel. Activation filled it with `\x1b[2m…\x1b[0m` escape garbage, a per-request `[Router] Handling …` line, and ~200 near-identical type-load lines dumped from a single exception — making the panel unreadable and masking the real failure (a Roslyn version mismatch). Captured in issue #78.
+
+**Implementation reference:**
+- `src/main.rs` — `IsTerminal`-gated `.with_ansi(…)` on the stderr `tracing` layer.
+- `editors/vscode/src/output-filter.ts` — `stripAnsi` + `createAnsiStrippingChannel`, wired into the client's `outputChannel` in `editors/vscode/src/client.ts`.
+- `sidecars/SharpLsp.Sidecar.Common/Logging/SidecarLog.cs` — Serilog rolling-file configuration + `CollapseRepeatedLines`; initialized by `SidecarHost`.
+- `sidecars/SharpLsp.Sidecar.CSharp/Workspace/WorkspaceManager.cs` — `LogWorkspaceFailure` collapses and de-duplicates MSBuild workspace-load diagnostics.
+
 ## [DIST-VSIX-MODEL]
 
 The VSIX is self-contained. A user who installs the extension gets everything they need with zero additional installation steps beyond the .NET 10 runtime (which is acquired automatically per [DIST-RUNTIME-ACQUIRE]).

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -17,6 +17,7 @@ import {
 import { EXTENSION_ID, EXTENSION_NAME, SERVER_BINARY, SERVER_BINARY_WIN } from './constants.js';
 import * as config from './config.js';
 import * as log from './log.js';
+import { createAnsiStrippingChannel } from './output-filter.js';
 import { detectRuntimePlatform } from './platform.js';
 import { type SharpLspStatusBar, ServerState } from './status.js';
 
@@ -67,7 +68,10 @@ export async function start(
       { scheme: 'untitled', language: 'csharp' },
       { scheme: 'untitled', language: 'fsharp' },
     ],
-    outputChannel: log.output(),
+    // Strip ANSI escape codes from the server's raw stderr before it reaches
+    // the user-facing Output panel (issue #78). The host gates ANSI on whether
+    // stderr is a TTY, but this is defence-in-depth against any leaked codes.
+    outputChannel: createAnsiStrippingChannel(log.output()),
     traceOutputChannel: log.trace(),
     errorHandler: makeErrorHandler(statusBar),
   };

--- a/editors/vscode/src/output-filter.ts
+++ b/editors/vscode/src/output-filter.ts
@@ -1,0 +1,105 @@
+/**
+ * Output-channel filtering for the SharpLsp server log.
+ *
+ * The language client forwards the server's raw stderr into the user-facing
+ * "SharpLsp" Output panel. That stream can contain ANSI escape sequences (e.g.
+ * terminal color codes) which render as garbage in the panel. We strip them
+ * defensively before anything reaches the channel. See issue #78 / [DIST-CLEAN-OUTPUT].
+ *
+ * The stripper is a small character scanner (no regular expressions, per the
+ * project's "use real parsers, not regex" rule).
+ */
+import type { OutputChannel, ViewColumn } from 'vscode';
+
+const ESC = '\u001b';
+const BEL = '\u0007';
+
+/** A CSI sequence's final byte is in the range 0x40–0x7E (`@` … `~`). */
+function isCsiFinalByte(ch: string): boolean {
+  const code = ch.charCodeAt(0);
+  return code >= 0x40 && code <= 0x7e;
+}
+
+/** Index just past a CSI sequence (`ESC [` … final byte) starting at `open`. */
+function skipCsi(text: string, open: number): number {
+  let i = open + 1;
+  while (i < text.length && !isCsiFinalByte(text[i] ?? '')) {
+    i += 1;
+  }
+  return i + 1;
+}
+
+/** Index just past an OSC sequence (`ESC ]` … `BEL` or `ESC \`) starting at `open`. */
+function skipOsc(text: string, open: number): number {
+  let i = open + 1;
+  while (i < text.length && text[i] !== BEL && !(text[i] === ESC && text[i + 1] === '\\')) {
+    i += 1;
+  }
+  return text[i] === ESC ? i + 2 : i + 1;
+}
+
+/** Index just past the escape sequence that starts at `start` (an `ESC`). */
+function skipEscapeSequence(text: string, start: number): number {
+  const next = text[start + 1];
+  if (next === '[') {
+    return skipCsi(text, start + 1);
+  }
+  if (next === ']') {
+    return skipOsc(text, start + 1);
+  }
+  // Any other escape consumes ESC plus a single following byte.
+  return start + 2;
+}
+
+/** Remove ANSI escape sequences (color codes, cursor moves, OSC, …) from `text`. */
+export function stripAnsi(text: string): string {
+  if (!text.includes(ESC)) {
+    return text;
+  }
+  const parts: string[] = [];
+  let segmentStart = 0;
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] === ESC) {
+      parts.push(text.slice(segmentStart, i));
+      i = skipEscapeSequence(text, i);
+      segmentStart = i;
+    } else {
+      i += 1;
+    }
+  }
+  parts.push(text.slice(segmentStart));
+  return parts.join('');
+}
+
+/**
+ * Wrap an output channel so every write has ANSI escape sequences stripped.
+ * Non-writing operations (show/hide/clear/dispose) delegate unchanged.
+ */
+export function createAnsiStrippingChannel(inner: OutputChannel): OutputChannel {
+  return {
+    name: inner.name,
+    append: (value: string): void => {
+      inner.append(stripAnsi(value));
+    },
+    appendLine: (value: string): void => {
+      inner.appendLine(stripAnsi(value));
+    },
+    replace: (value: string): void => {
+      inner.replace(stripAnsi(value));
+    },
+    clear: (): void => {
+      inner.clear();
+    },
+    show: (column?: ViewColumn | boolean, preserveFocus?: boolean): void => {
+      // Forward only the non-deprecated single-argument `show` overload.
+      inner.show(typeof column === 'boolean' ? column : preserveFocus);
+    },
+    hide: (): void => {
+      inner.hide();
+    },
+    dispose: (): void => {
+      inner.dispose();
+    },
+  };
+}

--- a/editors/vscode/src/test/suite/unit-ansi.test.ts
+++ b/editors/vscode/src/test/suite/unit-ansi.test.ts
@@ -1,0 +1,80 @@
+import * as assert from 'node:assert/strict';
+import type { OutputChannel } from 'vscode';
+import { stripAnsi, createAnsiStrippingChannel } from '../../output-filter.js';
+
+const ESC = String.fromCharCode(0x1b);
+
+const noop = (): void => {
+  // no-op
+};
+
+/** A minimal in-memory OutputChannel that records what was written. */
+function fakeChannel(): { channel: OutputChannel; writes: string[] } {
+  const writes: string[] = [];
+  const channel: OutputChannel = {
+    name: 'fake',
+    append: (value: string): void => {
+      writes.push(value);
+    },
+    appendLine: (value: string): void => {
+      writes.push(value);
+    },
+    replace: (value: string): void => {
+      writes.push(value);
+    },
+    clear: noop,
+    show: noop,
+    hide: noop,
+    dispose: noop,
+  };
+  return { channel, writes };
+}
+
+suite('Output Filter — ANSI stripping', () => {
+  // ── stripAnsi() ──────────────────────────────────────────────
+  test('strips SGR color codes from a tracing line (issue #78 repro)', () => {
+    const line = `${ESC}[2m2026-06-14T04:28:01Z${ESC}[0m ${ESC}[32m INFO${ESC}[0m sharplsp: starting`;
+    assert.strictEqual(stripAnsi(line), '2026-06-14T04:28:01Z  INFO sharplsp: starting');
+  });
+
+  test('leaves plain text unchanged', () => {
+    assert.strictEqual(stripAnsi('plain message, no escapes'), 'plain message, no escapes');
+  });
+
+  test('leaves an empty string unchanged', () => {
+    assert.strictEqual(stripAnsi(''), '');
+  });
+
+  test('removes every ESC byte it encounters', () => {
+    const noisy = `${ESC}[1mbold${ESC}[0m and ${ESC}[31mred${ESC}[0m`;
+    const result = stripAnsi(noisy);
+    assert.ok(!result.includes(ESC), 'no ESC byte must remain');
+    assert.strictEqual(result, 'bold and red');
+  });
+
+  test('strips an OSC sequence terminated by BEL', () => {
+    const osc = `${ESC}]0;window title${String.fromCharCode(0x07)}body`;
+    assert.strictEqual(stripAnsi(osc), 'body');
+  });
+
+  // ── createAnsiStrippingChannel() ─────────────────────────────
+  test('appendLine reaches the inner channel with ANSI removed', () => {
+    const { channel, writes } = fakeChannel();
+    const wrapped = createAnsiStrippingChannel(channel);
+    wrapped.appendLine(`${ESC}[2mhello${ESC}[0m`);
+    assert.deepStrictEqual(writes, ['hello']);
+  });
+
+  test('append reaches the inner channel with ANSI removed', () => {
+    const { channel, writes } = fakeChannel();
+    const wrapped = createAnsiStrippingChannel(channel);
+    wrapped.append(`${ESC}[31mx${ESC}[0m`);
+    assert.deepStrictEqual(writes, ['x']);
+  });
+
+  test('preserves the inner channel name', () => {
+    const { channel } = fakeChannel();
+    const wrapped = createAnsiStrippingChannel(channel);
+    assert.strictEqual(wrapped.name, 'fake');
+  });
+});

--- a/sidecars/SharpLsp.Sidecar.CSharp/CSharpSidecar.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp/CSharpSidecar.cs
@@ -14,6 +14,7 @@ namespace SharpLsp.Sidecar.CSharp;
 internal sealed partial class CSharpSidecar : SidecarHost
 {
     public CSharpSidecar()
+        : base("csharp")
     {
         Register("workspace/open", HandleWorkspaceOpenAsync);
         Register("workspace/status", HandleWorkspaceStatusAsync);

--- a/sidecars/SharpLsp.Sidecar.CSharp/Program.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp/Program.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using Serilog;
+using SharpLsp.Sidecar.Common.Logging;
 using SharpLsp.Sidecar.CSharp;
 
 if (args.Length > 0 && args[0] == "--version")
@@ -8,15 +10,16 @@ if (args.Length > 0 && args[0] == "--version")
     return;
 }
 
+SidecarLog.Initialize("csharp");
+
 try
 {
     MSBuildInstanceSelector.Register(Console.Error);
 }
 catch (Exception ex)
 {
-    await Console
-        .Error.WriteLineAsync($"MSBuild locator failed: {ex.Message}")
-        .ConfigureAwait(false);
+    Log.Fatal(ex, "MSBuild registration failed");
+    SidecarLog.Shutdown();
     Environment.Exit(1);
 }
 
@@ -43,7 +46,8 @@ static async Task RunSidecarAsync(string[] args)
     }
     catch (Exception ex)
     {
-        await Console.Error.WriteLineAsync($"Sidecar failed: {ex.Message}").ConfigureAwait(false);
+        Log.Fatal(ex, "C# sidecar terminated unexpectedly");
+        SidecarLog.Shutdown();
         Environment.Exit(1);
     }
 }

--- a/sidecars/SharpLsp.Sidecar.CSharp/Workspace/CodeActionResolver.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp/Workspace/CodeActionResolver.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Text;
+using Serilog;
 
 namespace SharpLsp.Sidecar.CSharp.Workspace;
 
@@ -128,11 +129,11 @@ internal sealed class CodeActionResolver
                 }
                 catch (Exception ex)
                 {
-                    await Console
-                        .Error.WriteLineAsync(
-                            $"[CodeAction] Fix provider {provider.GetType().Name} failed: {ex.Message}"
-                        )
-                        .ConfigureAwait(false);
+                    Log.Debug(
+                        ex,
+                        "[CodeAction] Fix provider {Provider} failed",
+                        provider.GetType().Name
+                    );
                 }
             }
         }
@@ -160,11 +161,11 @@ internal sealed class CodeActionResolver
             }
             catch (Exception ex)
             {
-                await Console
-                    .Error.WriteLineAsync(
-                        $"[CodeAction] Refactoring provider {provider.GetType().Name} failed: {ex.Message}"
-                    )
-                    .ConfigureAwait(false);
+                Log.Debug(
+                    ex,
+                    "[CodeAction] Refactoring provider {Provider} failed",
+                    provider.GetType().Name
+                );
             }
         }
     }
@@ -327,8 +328,10 @@ internal sealed class CodeActionResolver
             CollectProvidersFromAssembly(assembly, providers);
         }
 
-        Console.Error.WriteLine(
-            $"[CodeAction] Discovered {providers.Count} {typeof(T).Name} providers"
+        Log.Debug(
+            "[CodeAction] Discovered {Count} {ProviderType} providers",
+            providers.Count,
+            typeof(T).Name
         );
         return [.. providers];
     }
@@ -343,9 +346,14 @@ internal sealed class CodeActionResolver
                 TryInstantiateProvider(type, providers);
             }
         }
-        catch (ReflectionTypeLoadException)
+        catch (ReflectionTypeLoadException ex)
         {
-            // Assembly has unresolvable types — skip it.
+            // Assembly has unresolvable types — skip it, noting why (file log only).
+            Log.Debug(
+                ex,
+                "[CodeAction] Skipped assembly {Assembly} (unresolvable types)",
+                assembly.GetName().Name
+            );
         }
     }
 

--- a/sidecars/SharpLsp.Sidecar.CSharp/Workspace/DefinitionResolver.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp/Workspace/DefinitionResolver.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Text;
+using Serilog;
 
 namespace SharpLsp.Sidecar.CSharp.Workspace;
 
@@ -355,9 +356,7 @@ internal static class DefinitionResolver
         var token = root.FindToken(position);
         if (token.Parent is null)
         {
-            await Console
-                .Error.WriteLineAsync("[Resolve] token.Parent is null")
-                .ConfigureAwait(false);
+            Log.Debug("[Resolve] token.Parent is null");
             return null;
         }
 
@@ -496,32 +495,28 @@ internal static class DefinitionResolver
             return;
         }
 
-        await Console
-            .Error.WriteLineAsync(
-                $"[Override] Looking for overrides of {containingType.Name}.{symbol.Name}"
-            )
-            .ConfigureAwait(false);
+        Log.Debug(
+            "[Override] Looking for overrides of {Type}.{Member}",
+            containingType.Name,
+            symbol.Name
+        );
 
         var derivedTypes = await SymbolFinder
             .FindDerivedClassesAsync(containingType, solution, cancellationToken: ct)
             .ConfigureAwait(false);
 
-        await Console
-            .Error.WriteLineAsync($"[Override] Found {derivedTypes.Count()} derived types")
-            .ConfigureAwait(false);
+        Log.Debug("[Override] Found {Count} derived types", derivedTypes.Count());
 
         foreach (var derived in derivedTypes)
         {
-            await Console
-                .Error.WriteLineAsync($"[Override] Checking {derived.Name}")
-                .ConfigureAwait(false);
+            Log.Debug("[Override] Checking {Type}", derived.Name);
             foreach (var member in derived.GetMembers(symbol.Name))
             {
-                await Console
-                    .Error.WriteLineAsync(
-                        $"[Override] Member {member.Name} override={member.IsOverride}"
-                    )
-                    .ConfigureAwait(false);
+                Log.Debug(
+                    "[Override] Member {Member} override={IsOverride}",
+                    member.Name,
+                    member.IsOverride
+                );
                 if (member.IsOverride)
                 {
                     AddSourceLocation(locations, member);

--- a/sidecars/SharpLsp.Sidecar.CSharp/Workspace/MetadataNavigator.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp/Workspace/MetadataNavigator.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.CSharp;
 using Microsoft.CodeAnalysis;
+using Serilog;
 
 namespace SharpLsp.Sidecar.CSharp.Workspace;
 
@@ -26,7 +27,7 @@ internal static class MetadataNavigator
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"[MetadataNav] Decompilation failed: {ex.Message}");
+            Log.Debug(ex, "[MetadataNav] Decompilation failed");
             return null;
         }
     }
@@ -124,7 +125,7 @@ internal static class MetadataNavigator
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"[MetadataNav] DecompileType failed: {ex.Message}");
+            Log.Debug(ex, "[MetadataNav] DecompileType failed");
             return "";
         }
     }
@@ -139,7 +140,11 @@ internal static class MetadataNavigator
         var typeName = BuildDecompilerTypeName(containingType);
         var fullTypeName = new ICSharpCode.Decompiler.TypeSystem.FullTypeName(typeName);
 
-        Console.Error.WriteLine($"[MetadataNav] Decompiling {fullTypeName} from {assemblyPath}");
+        Log.Debug(
+            "[MetadataNav] Decompiling {TypeName} from {AssemblyPath}",
+            fullTypeName,
+            assemblyPath
+        );
 
         var source = decompiler.DecompileTypeAsString(fullTypeName);
         return WriteToTempFile(containingType, source);
@@ -167,7 +172,7 @@ internal static class MetadataNavigator
         var filePath = Path.Combine(dir, $"{safeName}.cs");
         File.WriteAllText(filePath, source);
 
-        Console.Error.WriteLine($"[MetadataNav] Wrote decompiled source to {filePath}");
+        Log.Debug("[MetadataNav] Wrote decompiled source to {FilePath}", filePath);
 
         return filePath;
     }
@@ -194,7 +199,7 @@ internal static class MetadataNavigator
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"[MetadataNav] FindSymbol failed: {ex.Message}");
+            Log.Debug(ex, "[MetadataNav] FindSymbol failed");
             return FallbackLocation(filePath);
         }
     }

--- a/sidecars/SharpLsp.Sidecar.CSharp/Workspace/WorkspaceManager.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp/Workspace/WorkspaceManager.cs
@@ -2,6 +2,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.Text;
 using Outcome;
+using Serilog;
+using SharpLsp.Sidecar.Common.Logging;
 using SharpLsp.Sidecar.CSharp.Hover;
 using AllDiagnosticsResult = Outcome.Result<
     System.Collections.Generic.Dictionary<
@@ -54,6 +56,11 @@ internal sealed partial class WorkspaceManager : IDisposable
     // is a non-atomic read-modify-write. Concurrent didChange and workspace-load
     // mutations would drop edits, leaving Roslyn with stale text.
     private readonly SemaphoreSlim _solutionMutationLock = new(1, 1);
+
+    // Distinct workspace-load failure summaries already logged. MSBuild reports
+    // the same type-load failure once per project, so de-duplicating prevents the
+    // log flood described in issue #78.
+    private readonly HashSet<string> _loggedWorkspaceFailures = new(StringComparer.Ordinal);
 
     public void Dispose()
     {
@@ -250,15 +257,11 @@ internal sealed partial class WorkspaceManager : IDisposable
     {
         try
         {
-            await Console
-                .Error.WriteLineAsync($"[Hover] GetHoverAsync: {filePath}:{line}:{character}")
-                .ConfigureAwait(false);
+            Log.Debug("[Hover] request {File}:{Line}:{Character}", filePath, line, character);
             var document = await FindDocumentAsync(filePath, ct).ConfigureAwait(false);
             if (document is null)
             {
-                await Console
-                    .Error.WriteLineAsync($"[Hover] Document not found: {filePath}")
-                    .ConfigureAwait(false);
+                Log.Debug("[Hover] document not found: {File}", filePath);
                 return new HoverQueryResult.Ok<HoverResult?, string>(null);
             }
 
@@ -267,25 +270,20 @@ internal sealed partial class WorkspaceManager : IDisposable
             var model = await document.GetSemanticModelAsync(ct).ConfigureAwait(false);
             if (model is null)
             {
-                await Console
-                    .Error.WriteLineAsync($"[Hover] Semantic model is null: {filePath}")
-                    .ConfigureAwait(false);
+                Log.Debug("[Hover] semantic model is null: {File}", filePath);
                 return new HoverQueryResult.Ok<HoverResult?, string>(null);
             }
 
             var result = CSharpHoverBuilder.Build(model, position, ct);
-            await Console
-                .Error.WriteLineAsync(
-                    $"[Hover] Result: {(result is HoverQueryResult.Ok<HoverResult?, string> { Value: not null } ? "content" : "null")}"
-                )
-                .ConfigureAwait(false);
+            var outcome = result is HoverQueryResult.Ok<HoverResult?, string> { Value: not null }
+                ? "content"
+                : "null";
+            Log.Debug("[Hover] result: {Outcome}", outcome);
             return result;
         }
         catch (Exception ex)
         {
-            await Console
-                .Error.WriteLineAsync($"[Hover] Exception: {ex.Message}")
-                .ConfigureAwait(false);
+            Log.Debug(ex, "[Hover] request failed");
             return HoverQueryResult.Failure(ex.Message);
         }
     }
@@ -537,10 +535,9 @@ internal sealed partial class WorkspaceManager : IDisposable
             ["SkipCompilerExecution"] = "true",
         };
 
+        _loggedWorkspaceFailures.Clear();
         _workspace = MSBuildWorkspace.Create(properties);
-        _ = _workspace.RegisterWorkspaceFailedHandler(args =>
-            Console.Error.WriteLine($"Workspace warning: {args.Diagnostic.Message}")
-        );
+        _ = _workspace.RegisterWorkspaceFailedHandler(LogWorkspaceFailure);
 
         var findResult = SolutionLoader.FindSolutionOrProject(path);
         if (findResult.IsError)
@@ -567,11 +564,28 @@ internal sealed partial class WorkspaceManager : IDisposable
             _ = _solutionMutationLock.Release();
         }
 
-        await Console
-            .Error.WriteLineAsync($"Loaded {_solution.ProjectIds.Count} project(s) from {target}")
-            .ConfigureAwait(false);
+        Log.Information(
+            "Loaded {ProjectCount} project(s) from {Target}",
+            _solution.ProjectIds.Count,
+            target
+        );
 
         return new VoidResult.Ok<Unit, string>(Unit.Value);
+    }
+
+    /// <summary>
+    /// Logs an MSBuildWorkspace load failure to the rolling file at debug level.
+    /// The raw diagnostic can carry dozens of identical type-load lines and is
+    /// reported once per project; we collapse repeats and skip already-seen
+    /// summaries so it no longer floods the editor's Output panel (issue #78).
+    /// </summary>
+    private void LogWorkspaceFailure(WorkspaceDiagnosticEventArgs args)
+    {
+        var summary = SidecarLog.CollapseRepeatedLines(args.Diagnostic.Message);
+        if (_loggedWorkspaceFailures.Add(summary))
+        {
+            Log.Debug("Workspace load diagnostic: {Diagnostic}", summary);
+        }
     }
 
     /// <summary>

--- a/sidecars/SharpLsp.Sidecar.Common.Tests/MessageRouterTests.cs
+++ b/sidecars/SharpLsp.Sidecar.Common.Tests/MessageRouterTests.cs
@@ -1,0 +1,124 @@
+using System.Globalization;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using SharpLsp.Sidecar.Common.Ipc;
+using SharpLsp.Sidecar.Common.Messages;
+using ByteResult = Outcome.Result<byte[], string>;
+
+namespace SharpLsp.Sidecar.Common.Tests;
+
+public sealed class MessageRouterTests
+{
+    /// <summary>Captures rendered log messages emitted while it is the active sink.</summary>
+    private sealed class CapturingSink : ILogEventSink
+    {
+        public List<string> Messages { get; } = [];
+
+        public void Emit(LogEvent logEvent)
+        {
+            Messages.Add(logEvent.RenderMessage(CultureInfo.InvariantCulture));
+        }
+    }
+
+    private static MessageRouter EchoRouter()
+    {
+        var router = new MessageRouter();
+        router.Register(
+            "echo",
+            (payload, _) => Task.FromResult<ByteResult>(new ByteResult.Ok<byte[], string>(payload))
+        );
+        return router;
+    }
+
+    [Fact]
+    public async Task HandleAsync_routes_request_tracing_through_structured_logging()
+    {
+        // Regression guard for issue #78: routine per-request handling is logged
+        // via Serilog (a rolling file), not dumped to stderr / the Output panel.
+        var sink = new CapturingSink();
+        var original = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            var router = EchoRouter();
+            var request = new Envelope
+            {
+                Id = 1,
+                Method = "echo",
+                Payload = [1, 2, 3],
+            };
+            _ = await router.HandleAsync(request).ConfigureAwait(true);
+        }
+        finally
+        {
+            (Log.Logger as IDisposable)?.Dispose();
+            Log.Logger = original;
+        }
+
+        Assert.Contains(
+            sink.Messages,
+            message =>
+                message.Contains("[Router]", StringComparison.Ordinal)
+                && message.Contains("echo", StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public async Task HandleAsync_returns_the_handler_payload()
+    {
+        var router = EchoRouter();
+        var request = new Envelope
+        {
+            Id = 7,
+            Method = "echo",
+            Payload = [9, 9],
+        };
+
+        var response = await router.HandleAsync(request).ConfigureAwait(true);
+
+        Assert.NotNull(response);
+        Assert.Equal((uint)7, response!.Id);
+        Assert.Equal(request.Payload, response.Payload);
+        Assert.Null(response.Error);
+    }
+
+    [Fact]
+    public void Register_throws_when_a_method_is_registered_twice()
+    {
+        var router = EchoRouter();
+
+        _ = Assert.Throws<InvalidOperationException>(() =>
+            router.Register(
+                "echo",
+                (payload, _) =>
+                    Task.FromResult<ByteResult>(new ByteResult.Ok<byte[], string>(payload))
+            )
+        );
+    }
+
+    [Fact]
+    public async Task SendRequestAsync_correlates_a_response_to_its_pending_request()
+    {
+        var router = new MessageRouter();
+        using var stream = new MemoryStream();
+        var transport = new FramedTransport(stream);
+        await using (transport.ConfigureAwait(false))
+        {
+            // Begin a request (id 1) without awaiting; it parks a pending completion.
+            var pending = router.SendRequestAsync(transport, "echo", [1, 2, 3]);
+
+            // An id-only envelope is a response — HandleAsync routes it to the
+            // pending request and completes it.
+            var responseEnvelope = new Envelope { Id = 1, Payload = [4, 5, 6] };
+            _ = await router.HandleAsync(responseEnvelope).ConfigureAwait(true);
+
+            var result = await pending.ConfigureAwait(true);
+            var payload = Assert.IsType<ByteResult.Ok<byte[], string>>(result).Value;
+            Assert.Equal(responseEnvelope.Payload, payload);
+        }
+    }
+}

--- a/sidecars/SharpLsp.Sidecar.Common.Tests/SidecarLogTests.cs
+++ b/sidecars/SharpLsp.Sidecar.Common.Tests/SidecarLogTests.cs
@@ -1,0 +1,48 @@
+using SharpLsp.Sidecar.Common.Logging;
+
+namespace SharpLsp.Sidecar.Common.Tests;
+
+// Regression guard for issue #78: a Roslyn type-load failure is surfaced by
+// MSBuild as a diagnostic carrying dozens of identical "Could not load file or
+// assembly" lines. The flood must collapse to a single annotated line.
+public sealed class SidecarLogTests
+{
+    [Fact]
+    public void CollapseRepeatedLines_collapses_a_type_load_flood_to_one_line()
+    {
+        const string loader =
+            "Could not load file or assembly 'Microsoft.CodeAnalysis, Version=5.6.0.0'.";
+        var flood =
+            "Unable to load one or more of the requested types.\n"
+            + string.Join('\n', Enumerable.Repeat(loader, 70));
+
+        var collapsed = SidecarLog.CollapseRepeatedLines(flood);
+
+        var lines = collapsed.Split('\n');
+        Assert.Equal(2, lines.Length);
+        Assert.Equal("Unable to load one or more of the requested types.", lines[0]);
+        Assert.Contains(loader, lines[1], StringComparison.Ordinal);
+        Assert.Contains("(repeated 70 times)", lines[1], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CollapseRepeatedLines_preserves_distinct_lines_in_order()
+    {
+        Assert.Equal("alpha\nbeta\ngamma", SidecarLog.CollapseRepeatedLines("alpha\nbeta\ngamma"));
+    }
+
+    [Fact]
+    public void CollapseRepeatedLines_normalizes_carriage_returns_before_collapsing()
+    {
+        Assert.Equal(
+            "same (repeated 2 times)\nunique",
+            SidecarLog.CollapseRepeatedLines("same\r\nsame\r\nunique")
+        );
+    }
+
+    [Fact]
+    public void CollapseRepeatedLines_leaves_a_single_line_untouched()
+    {
+        Assert.Equal("only one line", SidecarLog.CollapseRepeatedLines("only one line"));
+    }
+}

--- a/sidecars/SharpLsp.Sidecar.Common/Ipc/MessageRouter.cs
+++ b/sidecars/SharpLsp.Sidecar.Common/Ipc/MessageRouter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using MessagePack;
+using Serilog;
 using SharpLsp.Sidecar.Common.Messages;
 using ByteResult = Outcome.Result<byte[], string>;
 
@@ -50,9 +51,7 @@ public sealed class MessageRouter
         }
         catch (Exception ex)
         {
-            await Console
-                .Error.WriteLineAsync($"HandleAsync error: {ex.Message}")
-                .ConfigureAwait(false);
+            Log.Error(ex, "Router failed to handle envelope (id={Id})", envelope.Id);
             return envelope.Id is not null
                 ? new Envelope { Id = envelope.Id, Error = ex.Message }
                 : null;
@@ -112,30 +111,32 @@ public sealed class MessageRouter
     {
         if (!_handlers.TryGetValue(request.Method!, out var handler))
         {
-            await Console
-                .Error.WriteLineAsync($"[Router] Unknown method: {request.Method}")
-                .ConfigureAwait(false);
+            Log.Warning("[Router] Unknown method: {Method}", request.Method);
             return new Envelope { Id = request.Id, Error = $"Unknown method: {request.Method}" };
         }
 
         try
         {
-            await Console
-                .Error.WriteLineAsync($"[Router] Handling {request.Method} (id={request.Id})")
-                .ConfigureAwait(false);
+            Log.Debug("[Router] Handling {Method} (id={Id})", request.Method, request.Id);
             var result = await handler(request.Payload, ct).ConfigureAwait(false);
             return result.Match(
                 payload =>
                 {
-                    Console.Error.WriteLine(
-                        $"[Router] {request.Method} (id={request.Id}) => OK ({payload.Length} bytes)"
+                    Log.Debug(
+                        "[Router] {Method} (id={Id}) => OK ({Bytes} bytes)",
+                        request.Method,
+                        request.Id,
+                        payload.Length
                     );
                     return new Envelope { Id = request.Id, Payload = payload };
                 },
                 error =>
                 {
-                    Console.Error.WriteLine(
-                        $"[Router] {request.Method} (id={request.Id}) => Error: {error}"
+                    Log.Debug(
+                        "[Router] {Method} (id={Id}) => Error: {Error}",
+                        request.Method,
+                        request.Id,
+                        error
                     );
                     return new Envelope { Id = request.Id, Error = error };
                 }
@@ -143,11 +144,7 @@ public sealed class MessageRouter
         }
         catch (Exception ex)
         {
-            await Console
-                .Error.WriteLineAsync(
-                    $"[Router] {request.Method} (id={request.Id}) => Exception: {ex.Message}"
-                )
-                .ConfigureAwait(false);
+            Log.Error(ex, "[Router] {Method} (id={Id}) threw", request.Method, request.Id);
             return new Envelope { Id = request.Id, Error = ex.Message };
         }
     }

--- a/sidecars/SharpLsp.Sidecar.Common/Logging/SidecarLog.cs
+++ b/sidecars/SharpLsp.Sidecar.Common/Logging/SidecarLog.cs
@@ -1,0 +1,89 @@
+using System.Globalization;
+using Serilog;
+
+namespace SharpLsp.Sidecar.Common.Logging;
+
+/// <summary>
+/// Process-wide structured logging for sidecars (replaces raw
+/// <c>Console.Error</c> diagnostics). Implements [DIST-CLEAN-OUTPUT].
+///
+/// The Rust host inherits the sidecar's stderr straight into the editor's
+/// user-facing Output panel, so routine diagnostics written to stderr flood it
+/// (issue #78). Instead, sidecars log to a per-sidecar rolling file under the
+/// system temp directory; genuinely user-facing signals (e.g. a Roslyn version
+/// mismatch) are surfaced separately and intentionally.
+/// </summary>
+public static class SidecarLog
+{
+    private const string OutputTemplate =
+        "{Timestamp:yyyy-MM-ddTHH:mm:ss.fffZ} [{Level:u3}] {Message:lj}{NewLine}{Exception}";
+
+    private static int _initialized;
+
+    /// <summary>
+    /// Configures the global <see cref="Log.Logger" /> exactly once. Subsequent
+    /// calls are no-ops, so it is safe to call from both process startup and the
+    /// host constructor.
+    /// </summary>
+    /// <param name="name">Identifies the sidecar (e.g. "csharp"); names the log file.</param>
+    public static void Initialize(string name)
+    {
+        if (Interlocked.Exchange(ref _initialized, 1) == 1)
+        {
+            return;
+        }
+
+        var logDirectory = Path.Combine(Path.GetTempPath(), "sharplsp-logs");
+        _ = Directory.CreateDirectory(logDirectory);
+
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.File(
+                Path.Combine(logDirectory, $"sidecar-{name}.log"),
+                rollingInterval: RollingInterval.Day,
+                shared: true,
+                outputTemplate: OutputTemplate,
+                formatProvider: CultureInfo.InvariantCulture
+            )
+            .CreateLogger();
+    }
+
+    /// <summary>Flushes and closes the global logger. Safe to call when uninitialized.</summary>
+    public static void Shutdown()
+    {
+        Log.CloseAndFlush();
+    }
+
+    /// <summary>
+    /// Collapses repeated identical lines in <paramref name="text" /> into a single
+    /// line annotated with a repeat count, preserving first-seen order.
+    ///
+    /// A <c>ReflectionTypeLoadException</c> surfaced by MSBuild can carry dozens of
+    /// identical "Could not load file or assembly" lines; this keeps the log to one
+    /// line per distinct message instead of a flood.
+    /// </summary>
+    public static string CollapseRepeatedLines(string text)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var order = new List<string>();
+        foreach (var rawLine in text.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (counts.TryAdd(line, 1))
+            {
+                order.Add(line);
+            }
+            else
+            {
+                counts[line]++;
+            }
+        }
+
+        return string.Join('\n', order.Select(line => Annotate(line, counts[line])));
+    }
+
+    private static string Annotate(string line, int count)
+    {
+        return count > 1 ? $"{line} (repeated {count} times)" : line;
+    }
+}

--- a/sidecars/SharpLsp.Sidecar.Common/SharpLsp.Sidecar.Common.csproj
+++ b/sidecars/SharpLsp.Sidecar.Common/SharpLsp.Sidecar.Common.csproj
@@ -14,5 +14,7 @@
     <ItemGroup>
         <PackageReference Include="MessagePack" Version="3.1.7" />
         <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
+        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     </ItemGroup>
 </Project>

--- a/sidecars/SharpLsp.Sidecar.Common/SidecarHost.cs
+++ b/sidecars/SharpLsp.Sidecar.Common/SidecarHost.cs
@@ -1,5 +1,7 @@
 using MessagePack;
+using Serilog;
 using SharpLsp.Sidecar.Common.Ipc;
+using SharpLsp.Sidecar.Common.Logging;
 using SharpLsp.Sidecar.Common.Messages;
 using ByteResult = Outcome.Result<byte[], string>;
 
@@ -16,9 +18,11 @@ public abstract class SidecarHost : IAsyncDisposable
     private IpcListener? _listener;
     private FramedTransport? _transport;
 
-    /// <summary>Initializes the host and registers built-in handlers.</summary>
-    protected SidecarHost()
+    /// <summary>Initializes the host, structured logging, and built-in handlers.</summary>
+    /// <param name="name">Identifies the sidecar (e.g. "csharp") for its log file.</param>
+    protected SidecarHost(string name)
     {
+        SidecarLog.Initialize(name);
         _router.Register("ping", HandlePingAsync);
         _router.Register("shutdown", HandleShutdownAsync);
     }
@@ -40,9 +44,7 @@ public abstract class SidecarHost : IAsyncDisposable
             var listenerResult = IpcConnection.CreateListener(socketPath);
             if (listenerResult.IsError)
             {
-                await Console
-                    .Error.WriteLineAsync($"Listener failed: {!listenerResult}")
-                    .ConfigureAwait(false);
+                Log.Error("Sidecar listener failed: {Error}", !listenerResult);
                 return;
             }
 
@@ -54,9 +56,7 @@ public abstract class SidecarHost : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            await Console
-                .Error.WriteLineAsync($"Sidecar error: {ex.Message}")
-                .ConfigureAwait(false);
+            Log.Error(ex, "Sidecar terminated with an unexpected error");
         }
     }
 
@@ -76,6 +76,7 @@ public abstract class SidecarHost : IAsyncDisposable
         }
 
         _shutdownCts.Dispose();
+        SidecarLog.Shutdown();
         GC.SuppressFinalize(this);
     }
 
@@ -108,9 +109,7 @@ public abstract class SidecarHost : IAsyncDisposable
             }
             catch (Exception ex)
             {
-                await Console
-                    .Error.WriteLineAsync($"Message error: {ex.Message}")
-                    .ConfigureAwait(false);
+                Log.Error(ex, "Sidecar message loop error");
             }
         }
     }

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpCodeFixes.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpCodeFixes.fs
@@ -10,6 +10,7 @@ open System.Threading
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.Text
+open Serilog
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -346,7 +347,7 @@ let getCodeActions
                 | FSharpCheckFileAnswer.Aborted ->
                     return []
         with ex ->
-            eprintfn $"[F# CodeFixes] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# CodeFixes] failed")
             return []
     }
 

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpFeatures.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpFeatures.fs
@@ -7,6 +7,7 @@ open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
+open Serilog
 
 // ── Formatting via Fantomas (SEQUESTERED) ───────────────────────
 // This code is not wired into the LSP server. SharpLsp does not provide
@@ -33,7 +34,7 @@ let formatDocument (filePath: string) =
                           EndCharacter = lastChar
                           NewText = result |} |]
         with ex ->
-            eprintfn $"[F# Format] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# Format] failed")
             return [||]
     }
 
@@ -58,7 +59,7 @@ let formatRange (filePath: string) (startLine: int) (startChar: int) (endLine: i
                           EndCharacter = if endLine < lines.Length then lines[endLine].Length else 0
                           NewText = result |} |]
         with ex ->
-            eprintfn $"[F# FormatRange] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# FormatRange] failed")
             return [||]
     }
 
@@ -73,7 +74,7 @@ let formatPreview (filePath: string) =
             let formatted = formatResult.Code
             return Some {| Original = source; Formatted = formatted |}
         with ex ->
-            eprintfn $"[F# FormatPreview] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# FormatPreview] failed")
             return None
     }
 
@@ -160,7 +161,7 @@ let getSemanticTokens
                 | FSharpCheckFileAnswer.Aborted ->
                     return [||]
         with ex ->
-            eprintfn $"[F# SemanticTokens] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# SemanticTokens] failed")
             return [||]
     }
 
@@ -188,7 +189,7 @@ let getSemanticTokensRange
                 | FSharpCheckFileAnswer.Aborted ->
                     return [||]
         with ex ->
-            eprintfn $"[F# SemanticTokensRange] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# SemanticTokensRange] failed")
             return [||]
     }
 
@@ -309,6 +310,6 @@ let getInlayHints
                 | FSharpCheckFileAnswer.Aborted ->
                     return []
         with ex ->
-            eprintfn $"[F# InlayHints] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# InlayHints] failed")
             return []
     }

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpFileOrder.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpFileOrder.fs
@@ -7,6 +7,7 @@ open System.IO
 open System.Xml.Linq
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Text
+open Serilog
 
 /// A detected file ordering issue.
 type FileOrderIssue =
@@ -34,7 +35,7 @@ let getCompileOrder (fsprojPath: string) : string array =
                 Path.GetFullPath(Path.Combine(projDir, string attr.Value))))
         |> Seq.toArray
     with ex ->
-        eprintfn $"[F# FileOrder] Failed to parse .fsproj: {ex.Message}"
+        Log.Debug(ex, "[F# FileOrder] failed to parse .fsproj")
         [||]
 
 /// Build a map of symbol name → defining file path from check results.
@@ -143,7 +144,7 @@ let analyzeFileOrder
                             | _ -> ()
                     return issues |> List.rev
         with ex ->
-            eprintfn $"[F# FileOrder] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# FileOrder] failed")
             return []
     }
 
@@ -185,5 +186,5 @@ let generateReorderEdit
         else
             None
     with ex ->
-        eprintfn $"[F# FileOrder] Reorder edit failed: {ex.Message}"
+        Log.Debug(ex, "[F# FileOrder] reorder edit failed")
         None

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpLinting.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpLinting.fs
@@ -3,6 +3,7 @@ module SharpLsp.Sidecar.FSharp.FSharpLinting
 
 open System.IO
 open FSharpLint.Application
+open Serilog
 
 /// A lint diagnostic matching the sidecar wire format.
 type LintDiagnostic =
@@ -38,10 +39,10 @@ let lintFile (filePath: string) : LintDiagnostic list =
                       Severity = "Warning"
                       Code = w.RuleIdentifier })
             | LintResult.Failure failure ->
-                eprintfn $"[FSharpLint] Failure: {failure.Description}"
+                Log.Debug("[FSharpLint] failure: {Description}", failure.Description)
                 []
     with ex ->
-        eprintfn $"[FSharpLint] Exception: {ex.Message}"
+        Log.Debug(ex, "[FSharpLint] failed")
         []
 
 /// Run FSharpLint on all F# source files in a project directory.
@@ -56,5 +57,5 @@ let lintProject (projectDir: string) : Map<string, LintDiagnostic list> =
         |> Array.filter (fun (_, diags) -> not diags.IsEmpty)
         |> Map.ofArray
     with ex ->
-        eprintfn $"[FSharpLint] Project lint failed: {ex.Message}"
+        Log.Debug(ex, "[FSharpLint] project lint failed")
         Map.empty

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpReferences.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpReferences.fs
@@ -3,6 +3,7 @@ module SharpLsp.Sidecar.FSharp.FSharpReferences
 
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Symbols
+open Serilog
 
 /// Result type for document highlights: location + read/write kind.
 type HighlightLocation =
@@ -55,7 +56,7 @@ let getReferences
                                 else Some(toDefinitionLocation r))
                         |> Array.toList
         with ex ->
-            eprintfn $"[F# References] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# References] failed")
             return []
     }
 
@@ -93,6 +94,6 @@ let getDocumentHighlights
                                       Kind = kind })
                         |> Array.toList
         with ex ->
-            eprintfn $"[F# DocumentHighlight] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# DocumentHighlight] failed")
             return []
     }

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpSidecar.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpSidecar.fs
@@ -200,7 +200,7 @@ module private Helpers =
             })
 
 type FSharpSidecar() =
-    inherit SidecarHost()
+    inherit SidecarHost("fsharp")
 
     let workspace = FSharpWorkspace.create ()
     let codeFixState = FSharpCodeFixes.createState ()

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpWorkspace.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpWorkspace.fs
@@ -11,6 +11,7 @@ open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Text
 open FSharp.Compiler.Tokenization
+open Serilog
 open SharpLsp.Sidecar.Common.Solutions
 open SharpLsp.Sidecar.FSharp.Hover
 
@@ -95,7 +96,7 @@ let private loadFirstProject (state: FSharpWorkspaceState) (fsprojFiles: string 
         try
             let fsprojPath = Array.head fsprojFiles
             if fsprojFiles.Length > 1 then
-                eprintfn $"F# workspace found {fsprojFiles.Length} projects; loading {fsprojPath}"
+                Log.Debug("F# workspace found {Count} projects; loading {Path}", fsprojFiles.Length, fsprojPath)
             let sourceFiles = parseFsprojSourceFiles fsprojPath
             // Build compiler options with framework refs from the runtime dir.
             // The runtime dir contains both managed and native DLLs (e.g.
@@ -132,7 +133,7 @@ let private loadFirstProject (state: FSharpWorkspaceState) (fsprojFiles: string 
             state.ProjectOptions <- Some options
             state.IsLoaded <- true
             let fileList = String.Join(", ", sourceFiles |> Array.map Path.GetFileName)
-            eprintfn $"F# workspace loaded from {fsprojPath} with files: [{fileList}]"
+            Log.Debug("F# workspace loaded from {Path} with files: [{Files}]", fsprojPath, fileList)
             Ok()
         with ex ->
             Error ex.Message
@@ -148,16 +149,16 @@ let loadProjectWithCancellation
             let! discovered = discoverFsprojFiles path ct
             match discovered with
             | Error msg ->
-                eprintfn $"{msg}"
+                Log.Debug("F# workspace diagnostic: {Message}", msg)
                 return Error msg
             | Ok fsprojFiles ->
                 match loadFirstProject state fsprojFiles with
                 | Ok () -> return Ok()
                 | Error msg ->
-                    eprintfn $"F# workspace load failed: {msg}"
+                    Log.Debug("F# workspace load failed: {Message}", msg)
                     return Error msg
         with ex ->
-            eprintfn $"F# workspace load failed: {ex.Message}"
+            Log.Debug(ex, "F# workspace load failed")
             return Error ex.Message
     }
 
@@ -228,10 +229,10 @@ let getHover
                         parseResults.Diagnostics
                         |> Array.map (fun d -> $"{d.Severity}: {d.Message}")
                         |> String.concat "; "
-                    eprintfn $"[F# Hover] Check aborted; parse diagnostics: {diags}"
+                    Log.Debug("[F# Hover] check aborted; parse diagnostics: {Diagnostics}", diags)
                     return None
         with ex ->
-            eprintfn $"[F# Hover] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# Hover] failed")
             return None
     }
 
@@ -316,7 +317,7 @@ let getDefinition
             | None ->
                 return None
         with ex ->
-            eprintfn $"[F# Definition] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# Definition] failed")
             return None
     }
 
@@ -397,7 +398,7 @@ let getTypeDefinition
                 return extractTypeDefinition checkResults source line character
             | None -> return None
         with ex ->
-            eprintfn $"[F# TypeDefinition] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# TypeDefinition] failed")
             return None
     }
 
@@ -458,7 +459,7 @@ let getDeclaration
                 return extractDeclaration checkResults source line character
             | None -> return None
         with ex ->
-            eprintfn $"[F# Declaration] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# Declaration] failed")
             return None
     }
 
@@ -496,6 +497,6 @@ let getImplementations
                 return extractImplementations checkResults source line character
             | None -> return []
         with ex ->
-            eprintfn $"[F# Implementation] Exception: {ex.Message}"
+            Log.Debug(ex, "[F# Implementation] failed")
             return []
     }

--- a/sidecars/SharpLsp.Sidecar.FSharp/Program.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/Program.fs
@@ -1,5 +1,7 @@
 open System
 open System.Reflection
+open Serilog
+open SharpLsp.Sidecar.Common.Logging
 open SharpLsp.Sidecar.FSharp
 
 [<EntryPoint>]
@@ -29,7 +31,7 @@ let main (args: string[]) =
         }
         |> fun t -> t.GetAwaiter().GetResult()
     with ex ->
-        eprintfn $"F# sidecar failed: {ex.Message}"
+        Log.Error(ex, "F# sidecar terminated unexpectedly")
         Environment.Exit(1)
 
     0

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod vfs;
 mod workspace_symbols;
 
 use std::collections::HashMap;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::Arc;
@@ -111,12 +112,16 @@ fn main() -> ExitCode {
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
 
+    // Only emit ANSI colors when stderr is an interactive terminal. Editors
+    // (e.g. VS Code) capture stderr into a plain Output panel where escape
+    // codes would render as garbage. See issue #78 / [DIST-CLEAN-OUTPUT].
+    let stderr_is_terminal = std::io::stderr().is_terminal();
     tracing_subscriber::registry()
         .with(env_filter)
         .with(
             tracing_subscriber::fmt::layer()
                 .with_writer(std::io::stderr)
-                .with_ansi(true),
+                .with_ansi(stderr_is_terminal),
         )
         .with(
             tracing_subscriber::fmt::layer()

--- a/tests/e2e_modules/logging.rs
+++ b/tests/e2e_modules/logging.rs
@@ -1,0 +1,34 @@
+//! E2E tests for clean, editor-friendly host logging — Implements [DIST-CLEAN-OUTPUT].
+//!
+//! Editors (e.g. VS Code) capture the server's stderr into a user-facing Output
+//! panel. The captured stream is a plain pipe, not a TTY, so any ANSI color
+//! escape sequences leak through verbatim and render as garbage. The host must
+//! therefore emit plain (un-colored) text whenever stderr is not a terminal.
+
+use super::*;
+
+/// The host's stderr must not contain ANSI escape (ESC, `0x1b`) codes when
+/// stderr is captured as a pipe. Regression guard for issue #78: the stderr
+/// `tracing` layer was hard-coded to `.with_ansi(true)`, flooding the editor's
+/// Output panel with `\x1b[2m … \x1b[0m` garbage.
+#[test]
+fn test_server_stderr_has_no_ansi_escape_codes() {
+    let mut client = LspClient::start_capture_stderr();
+    let _ = client.initialize();
+    client.shutdown_and_exit();
+    client.wait_with_timeout();
+
+    let stderr = client.read_stderr_to_string();
+
+    // The startup banner ("SharpLsp LSP starting") is logged at INFO, so a
+    // non-TTY run still produces several stderr lines to inspect.
+    assert!(
+        !stderr.is_empty(),
+        "expected the host to log startup output to stderr, got nothing"
+    );
+    assert!(
+        !stderr.contains('\u{1b}'),
+        "host stderr must not contain ANSI escape (ESC) codes when captured by \
+         an editor Output panel, but it did:\n{stderr:?}"
+    );
+}

--- a/tests/e2e_modules/mod.rs
+++ b/tests/e2e_modules/mod.rs
@@ -48,6 +48,7 @@ pub mod full_stack_semantic;
 pub mod hover;
 pub mod inlay_hints_tests;
 pub mod lifecycle;
+pub mod logging;
 pub mod lsp_features;
 pub mod profiler;
 pub mod profiler_edge_cases;
@@ -71,7 +72,7 @@ pub use nav_helpers::*;
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
@@ -93,6 +94,7 @@ pub struct LspClient {
     pub child: Child,
     pub stdin: Option<ChildStdin>,
     pub reader: BufReader<ChildStdout>,
+    pub stderr: Option<ChildStderr>,
 }
 
 impl LspClient {
@@ -104,6 +106,12 @@ impl LspClient {
     /// Spawn with stderr visible (for full-stack tests that need sidecar logs).
     pub fn start_verbose() -> Self {
         Self::spawn(Stdio::inherit())
+    }
+
+    /// Spawn with stderr captured to a pipe so a test can inspect the host's
+    /// log output (e.g. to assert it contains no ANSI escape codes).
+    pub fn start_capture_stderr() -> Self {
+        Self::spawn(Stdio::piped())
     }
 
     pub fn spawn(stderr: Stdio) -> Self {
@@ -119,12 +127,25 @@ impl LspClient {
             .expect(&failure);
         let stdin = child.stdin.take().expect("no stdin");
         let stdout = child.stdout.take().expect("no stdout");
+        let stderr = child.stderr.take();
         let reader = BufReader::new(stdout);
         Self {
             child,
             stdin: Some(stdin),
             reader,
+            stderr,
         }
+    }
+
+    /// Drain the captured stderr pipe to a string. Only meaningful when the
+    /// client was created via [`LspClient::start_capture_stderr`] and the
+    /// process has exited (call after `wait_with_timeout`).
+    pub fn read_stderr_to_string(&mut self) -> String {
+        let mut buf = String::new();
+        if let Some(mut stderr) = self.stderr.take() {
+            let _ = stderr.read_to_string(&mut buf);
+        }
+        buf
     }
 
     /// Send a JSON-RPC message with proper Content-Length framing.


### PR DESCRIPTION
## TLDR
Stop the VS Code **SharpLsp** Output panel from being flooded with ANSI escape garbage and raw per-request sidecar diagnostics by gating host ANSI on TTY, stripping ANSI in the extension, and routing all C#/F# sidecar diagnostics through structured Serilog logging.

## Details

**Rust host — `src/main.rs`**
- Gate the stderr `tracing` ANSI layer on `std::io::IsTerminal` (`.with_ansi(stderr_is_terminal)`): color in an interactive terminal, plain text when stderr is captured by an editor's Output panel (where escape codes render as garbage).

**VS Code extension — `editors/vscode/`**
- New `output-filter.ts`: `stripAnsi` (a regex-free CSI/OSC character scanner) + `createAnsiStrippingChannel`, wired into the language client's `outputChannel` in `client.ts` so any leaked escape codes are stripped before reaching the panel.

**C# + F# sidecars — structured logging (replaces raw `Console.Error` / `eprintfn`)**
- New `SidecarLog.cs` (Common): process-wide Serilog logger writing to a per-sidecar rolling file under the system temp dir (`sharplsp-logs/sidecar-<name>.log`); idempotent init + flush; `CollapseRepeatedLines` folds a `ReflectionTypeLoadException`'s dozens of identical "Could not load file or assembly" loader lines into one annotated line.
- Migrated every diagnostic write to Serilog at level-appropriate severities — per-request `[Router]` traces now log at Debug (file only), not stderr: `MessageRouter`, `SidecarHost`, `WorkspaceManager` (incl. hover + a de-duplicated workspace-load-failure summary), `CodeActionResolver`, `MetadataNavigator`, `DefinitionResolver`, `Program.cs`, and the F# sidecar (`FSharpWorkspace`, `FSharpFeatures`, `FSharpFileOrder`, `FSharpLinting`, `FSharpReferences`, `FSharpCodeFixes`, `Program.fs`).
- `SidecarHost` now takes a sidecar name and initializes/flushes the logger. Legitimate stdout/CLI writes are preserved: the `READY:` IPC handshake, `--version`, and the usage message.
- New deps on the Common project: `Serilog` + `Serilog.Sinks.File`.

**Docs**
- New `[DIST-CLEAN-OUTPUT]` section in `DISTRIBUTION-SPEC.md` documenting the clean-output contract, cross-referenced from the implementing files.

_Note: #78 also called for the C# Roslyn/SDK-mismatch portability fix; that landed independently in #77 (`MSBuildInstanceSelector`). This branch is rebased on #77 and contains only the logging/output-cleanliness work._

## How Do The Automated Tests Prove It Works?

- **Rust** — `tests/e2e_modules/logging.rs::test_server_stderr_has_no_ansi_escape_codes` spawns the server with stderr captured as a pipe and asserts the output contains no ESC (`\x1b`) bytes. It fails against the old `.with_ansi(true)` and passes after the `IsTerminal` gate. Full e2e suite: **562/562 pass**, coverage 91.68% (in gate).
- **VS Code** — `editors/vscode/src/test/suite/unit-ansi.test.ts` (8 tests) verify `stripAnsi` removes SGR/OSC sequences (including the exact issue #78 `\x1b[2m…\x1b[0m` repro) and that `createAnsiStrippingChannel` forwards stripped text to the inner channel. All 8 pass in the Electron test host.
- **C# sidecar** — `MessageRouterTests.HandleAsync_routes_request_tracing_through_structured_logging` asserts the `[Router]` per-request trace is emitted through Serilog (captured via an in-memory sink) rather than `Console.Error`; plus request/response correlation and the duplicate-register guard. `SidecarLogTests.CollapseRepeatedLines_collapses_a_type_load_flood_to_one_line` feeds 70 identical loader lines and asserts they collapse to a single annotated line. `make _test-dotnet`: **Common 43 / CSharp 313 / FSharp 180 pass**; coverage 89.0 / 81.2 / 81.2% (above thresholds).

_Known unrelated: the pre-existing `Diagnostics / Problems Panel` VS Code suite fails locally because the `test-fixtures/workspace` project is not NuGet-restored (a reference-less compilation → phantom errors); `dotnet restore` of the fixture makes all 6 pass. This is independent of this PR — the diagnostics/restore paths are untouched here._

Fixes #78
