### PR TITLE
build: add .gitattributes enforcing LF (fix Windows release VSIX builds)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,40 @@
+# Line-ending policy.
+#
+# Every text file is stored as LF in the repository AND checked out as LF on
+# every platform. This is required because `.editorconfig` sets
+# `end_of_line = lf` and the .NET build enforces it via the Roslyn IDE0055
+# analyzer (`-warnaserror`). Without this, Windows CI runners (whose Git has
+# `core.autocrlf=true` by default) check out source as CRLF, and the Windows
+# `Build VSIX` jobs fail with `IDE0055: Fix formatting` even though the files
+# are clean LF in the repo. `eol=lf` here overrides `core.autocrlf`.
+* text=auto eol=lf
+
+# Windows batch scripts must stay CRLF to run correctly (e.g. Gradle wrapper).
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary assets — never normalize or diff as text.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.icns binary
+*.webp binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.7z binary
+*.wasm binary
+*.dll binary
+*.exe binary
+*.so binary
+*.dylib binary
+*.nupkg binary
+*.vsix binary
+*.snk binary
+*.ttf binary
+*.otf binary
+*.woff binary
+*.woff2 binary


### PR DESCRIPTION
## TLDR
Adds a `.gitattributes` that enforces LF for all text files so Windows CI no longer checks out C# sources as CRLF, which broke the `Build VSIX (win32-*)` release jobs.

## Details
The repo had no `.gitattributes`. GitHub's Windows runners default to `core.autocrlf=true`, so they checked out sources as CRLF. The .NET build enforces `.editorconfig`'s `end_of_line = lf` via the Roslyn **IDE0055** analyzer with `-warnaserror`, so the Windows VSIX jobs failed with `IDE0055: Fix formatting` on `WorkspaceManager.cs:508-510` even though the files are clean LF in the repo (macOS/Linux builds passed). This is what failed the **v0.6.0 release** (`Build VSIX (win32-x64)` and `(win32-arm64)`).

- `* text=auto eol=lf` — store LF, check out LF on every platform (overrides `core.autocrlf`).
- `*.bat`/`*.cmd` kept as CRLF (e.g. the Gradle wrapper).
- Known binary extensions marked `binary` so they are never normalized/diffed.

No source files needed renormalization (`git add --renormalize .` touched nothing but `.gitattributes` — everything was already LF).

## How Do The Automated Tests Prove It Works?
The same commit is tagged `v0.6.0`; its re-triggered Release run rebuilds all five VSIX platforms including `win32-x64`/`win32-arm64`, which previously failed at the `_build-dotnet` IDE0055 step and now pass with LF checkout. Full PR CI (Lint / Test Rust / Test .NET / Test VS Code / CodeQL) also runs on this branch.