### PR TITLE
NuGet package maintenance: remove unused packages + consolidate shared packages (C# & F#)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,40 @@
+# Line-ending policy.
+#
+# Every text file is stored as LF in the repository AND checked out as LF on
+# every platform. This is required because `.editorconfig` sets
+# `end_of_line = lf` and the .NET build enforces it via the Roslyn IDE0055
+# analyzer (`-warnaserror`). Without this, Windows CI runners (whose Git has
+# `core.autocrlf=true` by default) check out source as CRLF, and the Windows
+# `Build VSIX` jobs fail with `IDE0055: Fix formatting` even though the files
+# are clean LF in the repo. `eol=lf` here overrides `core.autocrlf`.
+* text=auto eol=lf
+
+# Windows batch scripts must stay CRLF to run correctly (e.g. Gradle wrapper).
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary assets — never normalize or diff as text.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.icns binary
+*.webp binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.7z binary
+*.wasm binary
+*.dll binary
+*.exe binary
+*.so binary
+*.dylib binary
+*.nupkg binary
+*.vsix binary
+*.snk binary
+*.ttf binary
+*.otf binary
+*.woff binary
+*.woff2 binary

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -5,7 +5,7 @@
     "line_percent": 92.39
   },
   "vscode-extension": {
-    "line_percent": 71.14
+    "line_percent": 71.45
   },
   "sharplsp-sidecar-csharp": {
     "line_percent": 88.48

--- a/docs/plans/PACKAGE-MAINTENANCE-PLAN.md
+++ b/docs/plans/PACKAGE-MAINTENANCE-PLAN.md
@@ -1,0 +1,50 @@
+# Package Maintenance Plan
+
+Implementation plan for [PACKAGE-MAINTENANCE-SPEC](../specs/PACKAGE-MAINTENANCE-SPEC.md).
+Build order is bottom-up: pure Rust logic + mapping (unit-testable) → sidecar
+detection → host request wiring → VS Code UI → e2e tests.
+
+## Reuse map (do NOT reinvent)
+
+| Need | Existing code |
+|---|---|
+| Add/remove `PackageReference`/`PackageVersion` (trivia-preserving) | `src/nuget/xml_edit.rs` |
+| Enumerate projects + props, detect CPM | `src/nuget/targets.rs` |
+| `dotnet list` / background restore | `src/nuget/cli.rs`, `nuget::handlers` |
+| Find ancestor `Directory.Packages.props` | `nuget::handlers::find_packages_props` |
+| Per-id removal + restore | `sharplsp/nuget/uninstall` |
+| Sidecar request/response pattern | `MessageRouter.Register`, `SidecarManager::request` |
+| Context-menu command pattern | `registerContextMenuCommands` in `extension.ts` |
+
+## TODO
+
+- [x] [PKG-CONSOLIDATE-SCAN]/[PKG-CONSOLIDATE-APPLY] `src/nuget/consolidate.rs` —
+      scan shared packages, hoist to `Directory.Build.props`, CPM-aware, reuse
+      `xml_edit`/`targets`. Unit tests over temp solutions + dry-run mode.
+- [x] [PKG-UNUSED-MAP] assembly-path → package-id pure fn (`src/nuget/unused.rs`),
+      8 unit tests (analyzer-skip, transitive-skip, case-insensitive, win paths).
+- [x] [PKG-UNUSED-DETECT-CS] C# sidecar `project/unusedPackages` via
+      `GetUsedAssemblyReferences` (`WorkspaceManager.Packages.cs`).
+- [x] [PKG-UNUSED-DETECT-FS] F# sidecar `project/unusedPackages` via assets.json
+      refs + FCS `GetAllUsesOfAllSymbols` (`FSharpPackages.fs`, isolated, fail-safe).
+- [x] [PKG-UNUSED-REQUEST]/[PKG-CONSOLIDATE-REQUEST] host handlers
+      `sharplsp/nuget/unused` + `sharplsp/nuget/consolidate`, dispatch in
+      `main.rs`, sidecar routing by extension.
+- [x] [PKG-UNUSED-UI]/[PKG-CONSOLIDATE-UI] commands + `view/item/context`
+      entries (project + solution), `package.json` + nls (en/ja/zh-cn),
+      `package-maintenance.ts` + `extension.ts`.
+- [x] Tests: Rust unit (mapping + consolidate); VS Code e2e in
+      `context-menus.test.ts` (registration, when-clauses, `collectProjectPaths`,
+      graceful no-path, real-LSP consolidate dry-run + apply).
+- [x] Deslop `rescan` + `top-offenders`: no new clusters in the feature files;
+      clippy/fmt/eslint/tsc green; Rust + both sidecars build clean.
+
+## Dedup notes
+
+- Extracted shared `src/nuget/parse.rs` (`read_package_items`, `extract_attr`);
+  removed the duplicate `extract_attr` + `list_props_packages` body from `handlers.rs`.
+- Moved `find_packages_props` into `targets.rs` (was private in `handlers.rs`).
+- Made `FSharpWorkspace.parseFsprojSourceFiles` + new `frameworkReferenceArgs`
+  `internal` and reused them from `FSharpPackages.fs` (no copy).
+- Removal reuses `dependencies.removeNuGetPackage`; the C#/F# sidecars return raw
+  paths so the path→package mapping exists once, in Rust.

--- a/docs/specs/PACKAGE-MAINTENANCE-SPEC.md
+++ b/docs/specs/PACKAGE-MAINTENANCE-SPEC.md
@@ -1,0 +1,133 @@
+# Package Maintenance Spec
+
+Solution-Explorer context-menu actions that keep a .NET solution's NuGet
+references tidy. Two operations, both editor-agnostic (the logic lives in the
+Rust host / sidecars; the VS Code extension is a thin shell).
+
+All NuGet plumbing reuses the existing `src/nuget/` module — `xml_edit`
+(trivia-preserving `PackageReference`/`PackageVersion` edits), `targets`
+(workspace/solution enumeration + CPM detection), `cli` (`dotnet list` /
+`restore`) and the `sharplsp/nuget/*` request family. No new XML editor, no new
+restore pipeline.
+
+C# and F# are equal first-class citizens: unused-package detection is wired for
+both Roslyn (`.csproj`) and FSharp.Compiler.Service (`.fsproj`).
+
+## [PKG-UNUSED] Remove Unused Packages
+
+Remove direct `<PackageReference>` entries whose assemblies are not referenced
+by any code in the project. Available on **project** nodes and on the
+**solution** node (where it runs across every project).
+
+### [PKG-UNUSED-DETECT-CS] C# detection (Roslyn)
+
+For a `.csproj`, the C# sidecar resolves the project in its loaded
+`MSBuildWorkspace`, builds the `Compilation`, and calls
+`Compilation.GetUsedAssemblyReferences()` — Roslyn's canonical "which references
+are actually used" API. Every `PortableExecutableReference` is classified as
+used / unused; assembly file paths are mapped back to packages
+(see [PKG-UNUSED-MAP]). A package is **unused** iff it contributes at least one
+compile-time assembly to the compilation and **none** of those assemblies is in
+the used set.
+
+### [PKG-UNUSED-DETECT-FS] F# detection (FCS)
+
+For an `.fsproj`, the F# sidecar resolves the package's compile assemblies from
+`obj/project.assets.json`, builds an **isolated** `FSharpProjectOptions` that
+includes those `-r:` references (the persistent workspace options are left
+untouched so other F# features are unaffected), runs `ParseAndCheckProject`
+with `keepAssemblyContents = true`, and walks the typed assembly contents to
+collect the set of assemblies whose entities are actually referenced. The
+used/unused classification and package mapping are identical to the C# path.
+
+### [PKG-UNUSED-MAP] Assembly → package mapping
+
+NuGet restores package assemblies under the global packages folder as
+`<root>/<package-id-lowercased>/<version>/lib/<tfm>/<assembly>.dll`. The package
+id is the path segment immediately under the global packages root. The mapping
+is a pure function over the assembly path and is therefore unit-testable without
+a live compilation. Assemblies that do not resolve to a package (framework
+reference assemblies, project-to-project references) are ignored — they are
+never reported as unused packages.
+
+Conservatism is mandatory: a package is only ever reported unused when it has a
+resolvable compile assembly that is provably not used. Packages contributing no
+compile-time assembly (analyzers, build/tooling, MSBuild-only, runtime
+metapackages) are **never** flagged, because their usage cannot be proven from
+the compilation reference set.
+
+### [PKG-UNUSED-REQUEST] Request flow
+
+`sharplsp/nuget/unused` (host request): params carry the project path (and
+optional solution-wide flag). The host picks the sidecar by file extension,
+forwards a `project/unusedPackages` sidecar request, intersects the returned
+candidate ids with the project's direct `<PackageReference>` ids (a transitive
+dependency is never in the project file and must never be "removed"), and
+returns `{ projectPath, unused: [{ id, version }] }`.
+
+Removal reuses the existing `sharplsp/nuget/uninstall` request per package id —
+trivia-preserving XML removal plus a background restore. The host does not
+invent a second removal path.
+
+### [PKG-UNUSED-UI] UX
+
+- Command `sharplsp.removeUnusedPackages`, shown on `viewItem == project` and
+  `viewItem == solution` in `sharplsp.solutionExplorer`.
+- Detect first; if none are unused, inform and stop. Otherwise show a modal
+  listing the packages to be removed and require explicit confirmation
+  (destructive, behaviour-changing).
+- On the solution node, detection + confirmation aggregate across all projects;
+  the confirmation names each project and its unused packages.
+- After removal the Solution Explorer refreshes reactively.
+
+## [PKG-CONSOLIDATE] Consolidate Shared Packages to Directory.Build.props
+
+Hoist NuGet packages that are referenced by **two or more** projects in the
+solution into a single solution-root `Directory.Build.props`, declaring each
+once and removing the per-project `<PackageReference>` entries. Available on the
+**solution** node.
+
+### [PKG-CONSOLIDATE-SCAN] Scan
+
+Enumerate every project under the solution directory (reuse `targets`). Parse
+each project's direct `<PackageReference>` ids + versions. A package is
+**shared** when it appears in ≥ 2 projects. When versions differ across
+projects the highest (by semantic ordering, lexical fallback) is chosen and the
+divergence is reported.
+
+### [PKG-CONSOLIDATE-APPLY] Apply
+
+1. Ensure a `Directory.Build.props` exists at the solution root (create a
+   minimal `<Project></Project>` if absent).
+2. For each shared package, add it to `Directory.Build.props` and remove it from
+   every project that declared it, via `xml_edit`.
+3. CPM-aware: when the solution has Central Package Management
+   (`Directory.Packages.props` with `ManagePackageVersionsCentrally=true`), the
+   hoisted `Directory.Build.props` entry is written **versionless** and the
+   version is ensured in `Directory.Packages.props` (`<PackageVersion>`), matching
+   the existing install behaviour.
+4. Fire a single background restore for the modified files.
+
+Hoisting to `Directory.Build.props` makes a package apply solution-wide; the
+result message states exactly which packages moved, at which version, and which
+projects were edited so the behaviour change is explicit and auditable.
+
+### [PKG-CONSOLIDATE-REQUEST] Request flow
+
+`sharplsp/nuget/consolidate` (host request): params carry the solution path
+(and/or workspace root). Pure Rust — no sidecar. Returns
+`{ moved: [{ id, version, fromProjects: [...] }], propsFile, modifiedFiles }`.
+
+### [PKG-CONSOLIDATE-UI] UX
+
+- Command `sharplsp.consolidatePackages`, shown on `viewItem == solution`.
+- Scan first; if nothing is shared, inform and stop. Otherwise show a modal
+  summarising what will move, then apply on confirmation and refresh.
+
+## Non-goals
+
+- Transitive / framework / analyzer package pruning (cannot be proven unused).
+- Rewriting version ranges, floating versions, or condition-bearing references.
+- Per-`<PackageReference>` metadata (`PrivateAssets`, `IncludeAssets`) merging
+  beyond a straight hoist — references carrying item metadata are reported and
+  skipped rather than silently flattened.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -433,6 +433,18 @@
         "icon": "$(trash)"
       },
       {
+        "command": "sharplsp.removeUnusedPackages",
+        "title": "%cmd.removeUnusedPackages%",
+        "category": "%category%",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "sharplsp.consolidatePackages",
+        "title": "%cmd.consolidatePackages%",
+        "category": "%category%",
+        "icon": "$(combine)"
+      },
+      {
         "command": "sharplsp.browseNuGetPackages",
         "title": "%cmd.browseNuGetPackages%",
         "category": "%category%",
@@ -858,6 +870,21 @@
         {
           "command": "sharplsp.browseNuGetPackages",
           "when": "view == sharplsp.solutionExplorer && viewItem == project",
+          "group": "5_dependencies"
+        },
+        {
+          "command": "sharplsp.removeUnusedPackages",
+          "when": "view == sharplsp.solutionExplorer && viewItem == project",
+          "group": "5_dependencies"
+        },
+        {
+          "command": "sharplsp.removeUnusedPackages",
+          "when": "view == sharplsp.solutionExplorer && viewItem == solution",
+          "group": "5_dependencies"
+        },
+        {
+          "command": "sharplsp.consolidatePackages",
+          "when": "view == sharplsp.solutionExplorer && viewItem == solution",
           "group": "5_dependencies"
         },
         {

--- a/editors/vscode/package.nls.ja.json
+++ b/editors/vscode/package.nls.ja.json
@@ -51,6 +51,8 @@
   "cmd.sortAccessibility": "並べ替え: アクセシビリティ順",
   "cmd.removeNuGetPackage": "パッケージを削除",
   "cmd.removeProjectReference": "プロジェクト参照を削除",
+  "cmd.removeUnusedPackages": "未使用のパッケージを削除",
+  "cmd.consolidatePackages": "パッケージを Directory.Build.props に統合",
   "cmd.browseNuGetPackages": "NuGet パッケージを参照",
   "cmd.sortMembers": "メンバーを並べ替え",
   "cmd.copyQualifiedName": "完全修飾名をコピー",

--- a/editors/vscode/package.nls.json
+++ b/editors/vscode/package.nls.json
@@ -51,6 +51,8 @@
   "cmd.sortAccessibility": "Sort: Accessibility",
   "cmd.removeNuGetPackage": "Remove Package",
   "cmd.removeProjectReference": "Remove Project Reference",
+  "cmd.removeUnusedPackages": "Remove Unused Packages",
+  "cmd.consolidatePackages": "Consolidate Packages to Directory.Build.props",
   "cmd.browseNuGetPackages": "Browse NuGet Packages",
   "cmd.sortMembers": "Sort Members",
   "cmd.copyQualifiedName": "Copy Qualified Name",

--- a/editors/vscode/package.nls.zh-cn.json
+++ b/editors/vscode/package.nls.zh-cn.json
@@ -51,6 +51,8 @@
   "cmd.sortAccessibility": "排序：可访问性",
   "cmd.removeNuGetPackage": "移除包",
   "cmd.removeProjectReference": "移除项目引用",
+  "cmd.removeUnusedPackages": "移除未使用的包",
+  "cmd.consolidatePackages": "将共享包合并到 Directory.Build.props",
   "cmd.browseNuGetPackages": "浏览 NuGet 包",
   "cmd.sortMembers": "排序成员",
   "cmd.copyQualifiedName": "复制限定名称",

--- a/editors/vscode/src/constants.ts
+++ b/editors/vscode/src/constants.ts
@@ -24,6 +24,8 @@ export const CMD_SORT_ACCESSIBILITY = 'sharplsp.sortAccessibility';
 
 export const CMD_REMOVE_NUGET_PACKAGE = 'sharplsp.removeNuGetPackage';
 export const CMD_REMOVE_PROJECT_REFERENCE = 'sharplsp.removeProjectReference';
+export const CMD_REMOVE_UNUSED_PACKAGES = 'sharplsp.removeUnusedPackages';
+export const CMD_CONSOLIDATE_PACKAGES = 'sharplsp.consolidatePackages';
 export const CMD_SORT_MEMBERS = 'sharplsp.sortMembers';
 export const CMD_COPY_QUALIFIED_NAME = 'sharplsp.copyQualifiedName';
 export const CMD_COPY_NAME = 'sharplsp.copyName';

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -15,6 +15,8 @@ import {
   CMD_SORT_ACCESSIBILITY,
   CMD_REMOVE_NUGET_PACKAGE,
   CMD_REMOVE_PROJECT_REFERENCE,
+  CMD_REMOVE_UNUSED_PACKAGES,
+  CMD_CONSOLIDATE_PACKAGES,
   CMD_BROWSE_NUGET_PACKAGES,
   CMD_SORT_MEMBERS,
   CMD_COPY_QUALIFIED_NAME,
@@ -36,6 +38,7 @@ import * as solution from './solution.js';
 import { SharpLspStatusBar, ServerState } from './status.js';
 import { type ExplorerNode, SolutionExplorerProvider, buildQualifiedName } from './tree.js';
 import { NuGetBrowserPanel } from './nuget-browser.js';
+import * as pkgMaint from './package-maintenance.js';
 import { registerBuildCommands } from './build.js';
 import { registerNuGetCommands, addNuGetPackageToProject } from './nuget.js';
 import { registerScaffoldingCommands } from './scaffolding.js';
@@ -369,7 +372,18 @@ function registerDependencyCommands(context: ExtensionContext): void {
     commands.registerCommand(CMD_BROWSE_NUGET_PACKAGES, (node: ExplorerNode | undefined) => {
       browseNuGetPackages(node, context);
     }),
+    commands.registerCommand(CMD_REMOVE_UNUSED_PACKAGES, async (node: ExplorerNode | undefined) => {
+      await pkgMaint.removeUnusedPackages(node, lspClient, refreshExplorer);
+    }),
+    commands.registerCommand(CMD_CONSOLIDATE_PACKAGES, async (node: ExplorerNode | undefined) => {
+      await pkgMaint.consolidatePackages(node, lspClient, refreshExplorer);
+    }),
   );
+}
+
+/** Refresh the Solution Explorer tree, tolerating an unset provider. */
+async function refreshExplorer(): Promise<void> {
+  await (explorerProvider?.refresh() ?? Promise.resolve());
 }
 
 function browseNuGetPackages(node: ExplorerNode | undefined, context: ExtensionContext): void {

--- a/editors/vscode/src/package-maintenance.ts
+++ b/editors/vscode/src/package-maintenance.ts
@@ -1,0 +1,222 @@
+/**
+ * Solution-Explorer package maintenance commands.
+ *
+ * Implements [PKG-UNUSED-UI] and [PKG-CONSOLIDATE-UI]: detect-then-confirm
+ * flows over the host's `sharplsp/nuget/unused` and `sharplsp/nuget/consolidate`
+ * custom requests. Removal reuses the existing `dependencies.removeNuGetPackage`
+ * path so there is one canonical "remove a package" implementation.
+ */
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { type LanguageClient } from 'vscode-languageclient/node';
+import * as deps from './dependencies.js';
+import * as log from './log.js';
+import { type ExplorerNode } from './tree.js';
+import { getErrorMessage } from './utils.js';
+
+// ── Wire types (match the Rust host responses) ────────────────────
+
+interface UnusedPackage {
+  readonly id: string;
+  readonly version: string;
+}
+
+interface UnusedResponse {
+  readonly projectPath: string;
+  readonly unused: UnusedPackage[];
+}
+
+interface MovedPackage {
+  readonly id: string;
+  readonly version: string;
+  readonly fromProjects: string[];
+}
+
+interface ConsolidateResponse {
+  readonly moved: MovedPackage[];
+  readonly propsFile?: string;
+  readonly modifiedFiles: string[];
+  readonly message: string;
+}
+
+/** Per-project unused-package finding. */
+interface Finding {
+  readonly projectPath: string;
+  readonly unused: UnusedPackage[];
+}
+
+// ── Node → project paths ──────────────────────────────────────────
+
+/** Collect distinct project file paths under a node (self or descendants). */
+export function collectProjectPaths(node: ExplorerNode | undefined): string[] {
+  const paths = new Set<string>();
+  const visit = (current: ExplorerNode): void => {
+    if (current.contextValue === 'project' && current.projectFilePath !== undefined) {
+      paths.add(current.projectFilePath);
+    }
+    for (const child of current.children) {
+      visit(child);
+    }
+  };
+  if (node !== undefined) visit(node);
+  return [...paths];
+}
+
+// ── Remove Unused Packages [PKG-UNUSED-UI] ────────────────────────
+
+/** Detect and remove unused direct package references for a node. */
+export async function removeUnusedPackages(
+  node: ExplorerNode | undefined,
+  lsp: LanguageClient | undefined,
+  refresh: () => Promise<void>,
+): Promise<void> {
+  if (lsp === undefined) {
+    void vscode.window.showWarningMessage('SharpLsp server not available.');
+    return;
+  }
+  const projects = collectProjectPaths(node);
+  if (projects.length === 0) {
+    void vscode.window.showWarningMessage('No project selected.');
+    return;
+  }
+
+  const findings = await detectUnusedForProjects(lsp, projects);
+  const total = findings.reduce((sum, finding) => sum + finding.unused.length, 0);
+  if (total === 0) {
+    void vscode.window.showInformationMessage('No unused packages found.');
+    return;
+  }
+
+  if (!(await confirmRemoval(findings, total))) return;
+  await applyRemoval(findings, refresh);
+}
+
+/** Query each project for unused packages, keeping only non-empty findings. */
+async function detectUnusedForProjects(
+  lsp: LanguageClient,
+  projects: string[],
+): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  for (const projectPath of projects) {
+    const response = await detectUnused(lsp, projectPath);
+    if (response !== undefined && response.unused.length > 0) {
+      findings.push({ projectPath, unused: response.unused });
+    }
+  }
+  return findings;
+}
+
+/** Send the `sharplsp/nuget/unused` request for a single project. */
+async function detectUnused(
+  lsp: LanguageClient,
+  projectPath: string,
+): Promise<UnusedResponse | undefined> {
+  try {
+    log.info(`nuget/unused: ${projectPath}`);
+    return await lsp.sendRequest<UnusedResponse>('sharplsp/nuget/unused', { projectPath });
+  } catch (err: unknown) {
+    log.error(`nuget/unused failed for ${projectPath}: ${getErrorMessage(err)}`);
+    return undefined;
+  }
+}
+
+/** Modal confirmation listing the packages to be removed. */
+async function confirmRemoval(findings: Finding[], total: number): Promise<boolean> {
+  const summary = findings
+    .map((f) => `${path.basename(f.projectPath)}: ${f.unused.map((u) => u.id).join(', ')}`)
+    .join('\n');
+  const answer = await vscode.window.showWarningMessage(
+    `Remove ${String(total)} unused package(s)?\n\n${summary}`,
+    { modal: true },
+    'Remove',
+  );
+  return answer === 'Remove';
+}
+
+/** Remove every found package via the canonical removal path, then refresh. */
+async function applyRemoval(findings: Finding[], refresh: () => Promise<void>): Promise<void> {
+  let removed = 0;
+  const errors: string[] = [];
+  for (const finding of findings) {
+    for (const pkg of finding.unused) {
+      const error = await deps.removeNuGetPackage(finding.projectPath, pkg.id);
+      if (error === undefined) removed++;
+      else errors.push(`${pkg.id}: ${error}`);
+    }
+  }
+  await refresh();
+  if (errors.length > 0) {
+    void vscode.window.showErrorMessage(
+      `Removed ${String(removed)} package(s); ${String(errors.length)} failed: ${errors.join('; ')}`,
+    );
+  } else {
+    void vscode.window.showInformationMessage(`Removed ${String(removed)} unused package(s).`);
+  }
+}
+
+// ── Consolidate Packages [PKG-CONSOLIDATE-UI] ─────────────────────
+
+/** Scan for shared packages, confirm, then hoist them into Directory.Build.props. */
+export async function consolidatePackages(
+  node: ExplorerNode | undefined,
+  lsp: LanguageClient | undefined,
+  refresh: () => Promise<void>,
+): Promise<void> {
+  if (lsp === undefined) {
+    void vscode.window.showWarningMessage('SharpLsp server not available.');
+    return;
+  }
+  const solutionPath = node?.projectFilePath;
+  if (solutionPath === undefined) {
+    void vscode.window.showWarningMessage('No solution selected.');
+    return;
+  }
+
+  const preview = await requestConsolidate(lsp, solutionPath, true);
+  if (preview === undefined) return;
+  if (preview.moved.length === 0) {
+    void vscode.window.showInformationMessage(preview.message);
+    return;
+  }
+
+  if (!(await confirmConsolidation(preview.moved))) return;
+
+  const result = await requestConsolidate(lsp, solutionPath, false);
+  if (result === undefined) return;
+  await refresh();
+  void vscode.window.showInformationMessage(result.message);
+}
+
+/** Send the `sharplsp/nuget/consolidate` request (scan or apply). */
+async function requestConsolidate(
+  lsp: LanguageClient,
+  solutionPath: string,
+  dryRun: boolean,
+): Promise<ConsolidateResponse | undefined> {
+  try {
+    log.info(`nuget/consolidate: ${solutionPath} (dryRun=${String(dryRun)})`);
+    return await lsp.sendRequest<ConsolidateResponse>('sharplsp/nuget/consolidate', {
+      solutionPath,
+      dryRun,
+    });
+  } catch (err: unknown) {
+    void vscode.window.showErrorMessage(`Consolidate failed: ${getErrorMessage(err)}`);
+    return undefined;
+  }
+}
+
+/** Modal confirmation listing the packages that will be hoisted. */
+async function confirmConsolidation(moved: MovedPackage[]): Promise<boolean> {
+  const summary = moved
+    .map((m) => {
+      const version = m.version !== '' ? ` ${m.version}` : '';
+      return `${m.id}${version} (${String(m.fromProjects.length)} projects)`;
+    })
+    .join('\n');
+  const answer = await vscode.window.showWarningMessage(
+    `Move ${String(moved.length)} shared package(s) into Directory.Build.props?\n\n${summary}`,
+    { modal: true },
+    'Move',
+  );
+  return answer === 'Move';
+}

--- a/editors/vscode/src/test/suite/context-menus.test.ts
+++ b/editors/vscode/src/test/suite/context-menus.test.ts
@@ -1460,39 +1460,93 @@ suite('Context Menu — Project Node Commands Execute', () => {
 suite('Package Maintenance — collectProjectPaths', () => {
   type NodeArg = Parameters<typeof collectProjectPaths>[0];
 
-  function projectNodeArg(filePath: string): unknown {
-    return { contextValue: 'project', projectFilePath: filePath, children: [] };
+  function mkNode(
+    contextValue: string,
+    projectFilePath: string | undefined,
+    children: unknown[] = [],
+  ): unknown {
+    return { contextValue, projectFilePath, children };
+  }
+  function projectNode(filePath: string): unknown {
+    return mkNode('project', filePath);
   }
 
-  test('project node yields its own project path', () => {
-    const node = projectNodeArg('/repo/A/A.csproj') as NodeArg;
-    assert.deepEqual(collectProjectPaths(node), ['/repo/A/A.csproj']);
+  test('project node yields exactly its own project path', () => {
+    const result = collectProjectPaths(projectNode('/repo/A/A.csproj') as NodeArg);
+    assert.ok(Array.isArray(result), 'returns an array');
+    assert.strictEqual(result.length, 1, 'exactly one path');
+    assert.strictEqual(result[0], '/repo/A/A.csproj', 'the path is the project file');
+    assert.deepEqual(result, ['/repo/A/A.csproj']);
   });
 
-  test('solution node yields every descendant project path', () => {
-    const solution = {
-      contextValue: 'solution',
-      projectFilePath: '/repo/App.sln',
-      children: [projectNodeArg('/repo/A/A.csproj'), projectNodeArg('/repo/B/B.fsproj')],
-    } as unknown as NodeArg;
-    assert.deepEqual(collectProjectPaths(solution), ['/repo/A/A.csproj', '/repo/B/B.fsproj']);
+  test('solution node yields every descendant project path in order', () => {
+    const solution = mkNode('solution', '/repo/App.sln', [
+      projectNode('/repo/A/A.csproj'),
+      projectNode('/repo/B/B.fsproj'),
+    ]) as NodeArg;
+    const result = collectProjectPaths(solution);
+    assert.strictEqual(result.length, 2, 'both projects collected');
+    assert.deepEqual(result, ['/repo/A/A.csproj', '/repo/B/B.fsproj'], 'order preserved');
+    assert.ok(result.includes('/repo/A/A.csproj'), 'includes the .csproj');
+    assert.ok(result.includes('/repo/B/B.fsproj'), 'includes the .fsproj');
+    assert.ok(!result.includes('/repo/App.sln'), 'the .sln itself is not a project path');
   });
 
-  test('duplicate project paths are de-duplicated', () => {
-    const solution = {
-      contextValue: 'solution',
-      projectFilePath: '/repo/App.sln',
-      children: [projectNodeArg('/repo/A/A.csproj'), projectNodeArg('/repo/A/A.csproj')],
-    } as unknown as NodeArg;
-    assert.deepEqual(collectProjectPaths(solution), ['/repo/A/A.csproj']);
+  test('collects project nodes nested under dependency folders', () => {
+    const solution = mkNode('solution', '/repo/App.sln', [
+      mkNode('project', '/repo/A/A.csproj', [
+        mkNode('dependencyFolder', undefined, [mkNode('nugetPackage', undefined)]),
+        mkNode('symbol.class', undefined),
+      ]),
+      mkNode('dependencyFolder', undefined, [mkNode('project', '/repo/B/B.csproj')]),
+    ]) as NodeArg;
+    const result = collectProjectPaths(solution);
+    assert.strictEqual(result.length, 2, 'both projects found despite nesting');
+    assert.ok(result.includes('/repo/A/A.csproj'), 'top-level project found');
+    assert.ok(result.includes('/repo/B/B.csproj'), 'nested project found');
   });
 
-  test('undefined node yields no paths', () => {
-    assert.deepEqual(collectProjectPaths(undefined), []);
+  test('ignores project nodes without a projectFilePath', () => {
+    const solution = mkNode('solution', '/repo/App.sln', [
+      projectNode('/repo/A/A.csproj'),
+      mkNode('project', undefined),
+    ]) as NodeArg;
+    const result = collectProjectPaths(solution);
+    assert.strictEqual(result.length, 1, 'the path-less project is skipped');
+    assert.deepEqual(result, ['/repo/A/A.csproj']);
+    assert.ok(!result.includes(undefined as unknown as string), 'no undefined entries');
+  });
+
+  test('de-duplicates repeated project paths', () => {
+    const solution = mkNode('solution', '/repo/App.sln', [
+      projectNode('/repo/A/A.csproj'),
+      projectNode('/repo/A/A.csproj'),
+      projectNode('/repo/B/B.csproj'),
+    ]) as NodeArg;
+    const result = collectProjectPaths(solution);
+    assert.strictEqual(result.length, 2, 'duplicate A collapsed to one');
+    assert.deepEqual(result, ['/repo/A/A.csproj', '/repo/B/B.csproj']);
+  });
+
+  test('non-project node with no project descendants yields nothing', () => {
+    const symbol = mkNode('symbol.class', undefined, [
+      mkNode('symbol.method', undefined),
+    ]) as NodeArg;
+    const result = collectProjectPaths(symbol);
+    assert.ok(Array.isArray(result), 'still returns an array');
+    assert.strictEqual(result.length, 0, 'no projects collected');
+    assert.deepEqual(result, []);
+  });
+
+  test('undefined node yields an empty array', () => {
+    const result = collectProjectPaths(undefined);
+    assert.ok(Array.isArray(result), 'returns an array even for undefined');
+    assert.strictEqual(result.length, 0);
+    assert.deepEqual(result, []);
   });
 });
 
-// ── Suite 10: Package Maintenance — Consolidate (LSP e2e) ─────────
+// ── Shared package-maintenance LSP e2e helpers ───────────────────
 
 interface ConsolidateResp {
   readonly moved: { id: string; version: string; fromProjects: string[] }[];
@@ -1501,19 +1555,81 @@ interface ConsolidateResp {
   readonly message: string;
 }
 
+interface UnusedResp {
+  readonly projectPath: string;
+  readonly unused: { id: string; version: string }[];
+}
+
 interface SharpLspApiForPkgTests {
   readonly getLspClient: () => LanguageClient | undefined;
 }
 
-/** Minimal .csproj text with a single PackageReference. */
-function csprojWith(id: string, version: string): string {
-  return `<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="${id}" Version="${version}" />
-  </ItemGroup>
-</Project>`;
+/** Resolve a running LSP client from the extension exports. */
+function getPkgLspClient(): LanguageClient {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext, 'Extension must be found');
+  const api = ext.exports as SharpLspApiForPkgTests | undefined;
+  assert.ok(api?.getLspClient, 'Extension must export getLspClient');
+  const client = api.getLspClient();
+  assert.ok(client, 'LSP client must be running');
+  return client;
 }
+
+/** Absolute path to the TestFixtures project loaded in the sidecar workspace. */
+function fixtureProjectPath(): string {
+  return path.resolve(__dirname, '../../../test-fixtures/workspace/TestFixtures.csproj');
+}
+
+/** A `[id, version]` package reference pair. */
+type Ref = readonly string[];
+
+interface ProjectSpec {
+  readonly name: string;
+  readonly refs: readonly Ref[];
+  readonly ext?: string;
+}
+
+/** Write a project file with the given PackageReferences. */
+function writeProject(dir: string, name: string, refs: readonly Ref[], ext = 'csproj'): string {
+  const projDir = path.join(dir, name);
+  fs.mkdirSync(projDir, { recursive: true });
+  const items = refs
+    .map((ref) => `    <PackageReference Include="${ref[0]}" Version="${ref[1]}" />`)
+    .join('\n');
+  const file = path.join(projDir, `${name}.${ext}`);
+  fs.writeFileSync(
+    file,
+    `<Project Sdk="Microsoft.NET.Sdk">\n` +
+      `  <PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n` +
+      `  <ItemGroup>\n${items}\n  </ItemGroup>\n</Project>\n`,
+  );
+  return file;
+}
+
+/** Create an isolated solution directory containing the given projects. */
+function makeSolution(
+  tmpDir: string,
+  name: string,
+  projects: readonly ProjectSpec[],
+): { sln: string; dir: string; projects: string[] } {
+  const dir = path.join(tmpDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  const created = projects.map((p) => writeProject(dir, p.name, p.refs, p.ext ?? 'csproj'));
+  const sln = path.join(dir, `${name}.sln`);
+  fs.writeFileSync(sln, 'Microsoft Visual Studio Solution File, Format Version 12.00\n');
+  return { sln, dir, projects: created };
+}
+
+/** Send a consolidate request (scan or apply) over the LSP. */
+async function consolidate(
+  lsp: LanguageClient,
+  solutionPath: string,
+  dryRun: boolean,
+): Promise<ConsolidateResp> {
+  return lsp.sendRequest<ConsolidateResp>('sharplsp/nuget/consolidate', { solutionPath, dryRun });
+}
+
+// ── Suite 10: Package Maintenance — Consolidate (LSP e2e) ─────────
 
 suite('Package Maintenance — Consolidate (LSP e2e)', () => {
   let tmpDir: string;
@@ -1528,117 +1644,326 @@ suite('Package Maintenance — Consolidate (LSP e2e)', () => {
     teardownLspTestSuite(tmpDir);
   });
 
-  function getClient(): LanguageClient {
-    const ext = vscode.extensions.getExtension(EXTENSION_ID);
-    assert.ok(ext, 'Extension must be found');
-    const api = ext.exports as SharpLspApiForPkgTests | undefined;
-    assert.ok(api?.getLspClient, 'Extension must export getLspClient');
-    const client = api.getLspClient();
-    assert.ok(client, 'LSP client must be running');
-    return client;
-  }
-
-  /** Create an isolated solution dir with two projects sharing Serilog. */
-  function makeSharedSolution(name: string, aVersion: string, bVersion: string): string {
-    const dir = path.join(tmpDir, name);
-    fs.mkdirSync(path.join(dir, 'A'), { recursive: true });
-    fs.mkdirSync(path.join(dir, 'B'), { recursive: true });
-    fs.writeFileSync(path.join(dir, 'A', 'A.csproj'), csprojWith('Serilog', aVersion));
-    fs.writeFileSync(path.join(dir, 'B', 'B.csproj'), csprojWith('Serilog', bVersion));
-    const sln = path.join(dir, `${name}.sln`);
-    fs.writeFileSync(sln, 'Microsoft Visual Studio Solution File, Format Version 12.00\n');
-    return sln;
-  }
-
-  test('dry-run reports the shared package and touches no files', async function () {
+  test('dry-run reports the shared package with full detail and touches no files', async function () {
     this.timeout(20_000);
-    const lsp = getClient();
-    const sln = makeSharedSolution('DryRun', '3.1.0', '3.0.0');
+    const lsp = getPkgLspClient();
+    const { sln, dir } = makeSolution(tmpDir, 'DryDetail', [
+      { name: 'A', refs: [['Serilog', '3.1.0']] },
+      { name: 'B', refs: [['Serilog', '3.0.0']] },
+    ]);
 
-    const resp = await lsp.sendRequest<ConsolidateResp>('sharplsp/nuget/consolidate', {
-      solutionPath: sln,
-      dryRun: true,
-    });
+    const resp = await consolidate(lsp, sln, true);
 
-    const serilog = resp.moved.find((m) => m.id === 'Serilog');
-    assert.ok(serilog, `dry-run must report Serilog as shared; got ${JSON.stringify(resp.moved)}`);
-    assert.strictEqual(serilog.version, '3.1.0', 'highest version is chosen');
-    assert.strictEqual(serilog.fromProjects.length, 2, 'shared across 2 projects');
-    assert.deepEqual(resp.modifiedFiles, [], 'dry-run must not modify files');
+    assert.ok(resp, 'response must be defined');
+    assert.ok(Array.isArray(resp.moved), 'moved is an array');
+    assert.strictEqual(resp.moved.length, 1, 'exactly one shared package');
+    const serilog = resp.moved[0];
+    assert.ok(serilog, 'the moved entry exists');
+    assert.strictEqual(serilog.id, 'Serilog', 'the shared package id');
+    assert.strictEqual(serilog.version, '3.1.0', 'highest version (3.1.0 > 3.0.0) is chosen');
+    assert.ok(Array.isArray(serilog.fromProjects), 'fromProjects is an array');
+    assert.strictEqual(serilog.fromProjects.length, 2, 'shared across two projects');
+    assert.ok(serilog.fromProjects.includes('A.csproj'), 'names project A');
+    assert.ok(serilog.fromProjects.includes('B.csproj'), 'names project B');
+    assert.deepEqual(resp.modifiedFiles, [], 'dry-run modifies nothing');
+    assert.strictEqual(resp.propsFile, undefined, 'dry-run reports no props file');
+    assert.strictEqual(typeof resp.message, 'string', 'message is a string');
+    assert.ok(resp.message.length > 0, 'message is non-empty');
+    assert.ok(!fs.existsSync(path.join(dir, 'Directory.Build.props')), 'no props file created');
     assert.ok(
-      !fs.existsSync(path.join(tmpDir, 'DryRun', 'Directory.Build.props')),
-      'dry-run must not create Directory.Build.props',
+      fs.readFileSync(path.join(dir, 'A', 'A.csproj'), 'utf8').includes('Serilog'),
+      'project A left untouched',
+    );
+    assert.ok(
+      fs.readFileSync(path.join(dir, 'B', 'B.csproj'), 'utf8').includes('3.0.0'),
+      'project B version left untouched',
     );
   });
 
-  test('apply hoists shared package into Directory.Build.props and strips projects', async function () {
+  test('dry-run ignores packages referenced by only one project', async function () {
     this.timeout(20_000);
-    const lsp = getClient();
-    const sln = makeSharedSolution('Apply', '3.1.0', '3.1.0');
-    const dir = path.dirname(sln);
+    const lsp = getPkgLspClient();
+    const { sln } = makeSolution(tmpDir, 'MixedShare', [
+      {
+        name: 'A',
+        refs: [
+          ['Serilog', '3.1.0'],
+          ['OnlyA', '1.0.0'],
+        ],
+      },
+      {
+        name: 'B',
+        refs: [
+          ['Serilog', '3.1.0'],
+          ['OnlyB', '2.0.0'],
+        ],
+      },
+    ]);
 
-    const resp = await lsp.sendRequest<ConsolidateResp>('sharplsp/nuget/consolidate', {
-      solutionPath: sln,
-      dryRun: false,
-    });
+    const resp = await consolidate(lsp, sln, true);
+    const ids = resp.moved.map((m) => m.id);
+    assert.strictEqual(resp.moved.length, 1, 'only the shared package is reported');
+    assert.deepEqual(ids, ['Serilog'], 'exactly Serilog');
+    assert.ok(!ids.includes('OnlyA'), 'single-project OnlyA is not reported');
+    assert.ok(!ids.includes('OnlyB'), 'single-project OnlyB is not reported');
+    const serilog = resp.moved.find((m) => m.id === 'Serilog');
+    assert.ok(serilog, 'Serilog entry present');
+    assert.strictEqual(serilog.fromProjects.length, 2, 'shared across both');
+  });
 
+  test('dry-run selects the highest version across three projects', async function () {
+    this.timeout(20_000);
+    const lsp = getPkgLspClient();
+    const { sln } = makeSolution(tmpDir, 'ThreeWay', [
+      { name: 'A', refs: [['Newtonsoft.Json', '12.0.1']] },
+      { name: 'B', refs: [['Newtonsoft.Json', '13.0.3']] },
+      { name: 'C', refs: [['Newtonsoft.Json', '13.0.1']] },
+    ]);
+
+    const resp = await consolidate(lsp, sln, true);
+    assert.strictEqual(resp.moved.length, 1, 'one shared package');
+    const pkg = resp.moved[0];
+    assert.ok(pkg, 'moved entry present');
+    assert.strictEqual(pkg.id, 'Newtonsoft.Json');
+    assert.strictEqual(pkg.version, '13.0.3', 'highest of 12.0.1 / 13.0.3 / 13.0.1');
+    assert.strictEqual(pkg.fromProjects.length, 3, 'shared across all three projects');
+  });
+
+  test('dry-run enumerates F# (.fsproj) projects too', async function () {
+    this.timeout(20_000);
+    const lsp = getPkgLspClient();
+    const { sln } = makeSolution(tmpDir, 'FSharpShare', [
+      { name: 'A', refs: [['FSharp.Data', '6.3.0']], ext: 'fsproj' },
+      { name: 'B', refs: [['FSharp.Data', '6.3.0']], ext: 'fsproj' },
+    ]);
+
+    const resp = await consolidate(lsp, sln, true);
+    assert.strictEqual(resp.moved.length, 1, 'F# projects are scanned');
+    const pkg = resp.moved[0];
+    assert.ok(pkg, 'moved entry present');
+    assert.strictEqual(pkg.id, 'FSharp.Data');
+    assert.strictEqual(pkg.fromProjects.length, 2);
+    assert.ok(pkg.fromProjects.includes('A.fsproj'), 'names A.fsproj');
+    assert.ok(pkg.fromProjects.includes('B.fsproj'), 'names B.fsproj');
+  });
+
+  test('apply hoists shared package into Directory.Build.props and strips projects', async function () {
+    this.timeout(30_000);
+    const lsp = getPkgLspClient();
+    const { sln, dir } = makeSolution(tmpDir, 'Apply', [
+      { name: 'A', refs: [['Serilog', '3.1.0']] },
+      { name: 'B', refs: [['Serilog', '3.1.0']] },
+    ]);
+
+    const resp = await consolidate(lsp, sln, false);
+
+    assert.strictEqual(resp.moved.length, 1, 'one package moved');
     assert.ok(
       resp.moved.some((m) => m.id === 'Serilog'),
-      'apply must report Serilog moved',
+      'Serilog reported as moved',
     );
     const propsPath = path.join(dir, 'Directory.Build.props');
-    assert.ok(fs.existsSync(propsPath), 'Directory.Build.props must be created');
+    assert.ok(resp.propsFile, 'propsFile is reported');
+    assert.ok(
+      resp.propsFile.endsWith('Directory.Build.props'),
+      'propsFile points at the props file',
+    );
+    assert.ok(fs.existsSync(propsPath), 'Directory.Build.props was created');
     const props = fs.readFileSync(propsPath, 'utf8');
-    assert.ok(props.includes('Serilog'), 'props must declare Serilog');
-    // Projects no longer carry the reference.
+    assert.ok(props.includes('<PackageReference'), 'props declares a PackageReference');
+    assert.ok(props.includes('Serilog'), 'props declares Serilog');
+    assert.ok(props.includes('Version="3.1.0"'), 'props carries the resolved version');
+    assert.ok(resp.modifiedFiles.length >= 3, 'props + two projects were modified');
+    assert.ok(
+      resp.modifiedFiles.some((f) => f.endsWith('Directory.Build.props')),
+      'props in modifiedFiles',
+    );
+    assert.ok(
+      resp.modifiedFiles.some((f) => f.endsWith('A.csproj')),
+      'A.csproj in modifiedFiles',
+    );
+    assert.ok(
+      resp.modifiedFiles.some((f) => f.endsWith('B.csproj')),
+      'B.csproj in modifiedFiles',
+    );
     const aText = fs.readFileSync(path.join(dir, 'A', 'A.csproj'), 'utf8');
     const bText = fs.readFileSync(path.join(dir, 'B', 'B.csproj'), 'utf8');
-    assert.ok(!aText.includes('Serilog'), 'A.csproj must no longer reference Serilog');
-    assert.ok(!bText.includes('Serilog'), 'B.csproj must no longer reference Serilog');
+    assert.ok(!aText.includes('Serilog'), 'A no longer references Serilog');
+    assert.ok(!bText.includes('Serilog'), 'B no longer references Serilog');
+    assert.ok(aText.includes('<Project'), 'A is still a valid project');
+    assert.ok(aText.includes('TargetFramework'), 'A keeps its other content');
+    assert.ok(resp.message.includes('Serilog'), 'message names the moved package');
+  });
+
+  test('apply preserves existing Directory.Build.props content', async function () {
+    this.timeout(30_000);
+    const lsp = getPkgLspClient();
+    const { sln, dir } = makeSolution(tmpDir, 'PreserveProps', [
+      { name: 'A', refs: [['Serilog', '3.1.0']] },
+      { name: 'B', refs: [['Serilog', '3.1.0']] },
+    ]);
+    const propsPath = path.join(dir, 'Directory.Build.props');
+    fs.writeFileSync(propsPath, '<Project>\n  <!-- sentinel comment -->\n</Project>\n');
+
+    const resp = await consolidate(lsp, sln, false);
+    assert.strictEqual(resp.moved.length, 1, 'one package moved');
+    const props = fs.readFileSync(propsPath, 'utf8');
+    assert.ok(props.includes('<!-- sentinel comment -->'), 'existing comment preserved');
+    assert.ok(props.includes('Serilog'), 'Serilog added to the existing props');
+    assert.ok(props.includes('Version="3.1.0"'), 'version preserved in props');
+  });
+
+  test('apply is idempotent — a second scan finds nothing shared', async function () {
+    this.timeout(30_000);
+    const lsp = getPkgLspClient();
+    const { sln } = makeSolution(tmpDir, 'Idempotent', [
+      { name: 'A', refs: [['Serilog', '3.1.0']] },
+      { name: 'B', refs: [['Serilog', '3.1.0']] },
+    ]);
+
+    const applied = await consolidate(lsp, sln, false);
+    assert.strictEqual(applied.moved.length, 1, 'first apply moves Serilog');
+    assert.ok(applied.modifiedFiles.length >= 3, 'first apply modified files');
+
+    const rescan = await consolidate(lsp, sln, true);
+    assert.deepEqual(rescan.moved, [], 'nothing shared remains after the move');
+    assert.strictEqual(rescan.modifiedFiles.length, 0, 'rescan modifies nothing');
+    assert.strictEqual(rescan.propsFile, undefined, 'rescan reports no further props work');
   });
 
   test('reports nothing when no package is shared', async function () {
     this.timeout(20_000);
-    const lsp = getClient();
-    const dir = path.join(tmpDir, 'NoShare');
-    fs.mkdirSync(path.join(dir, 'A'), { recursive: true });
-    fs.mkdirSync(path.join(dir, 'B'), { recursive: true });
-    fs.writeFileSync(path.join(dir, 'A', 'A.csproj'), csprojWith('OnlyA', '1.0.0'));
-    fs.writeFileSync(path.join(dir, 'B', 'B.csproj'), csprojWith('OnlyB', '1.0.0'));
-    const sln = path.join(dir, 'NoShare.sln');
-    fs.writeFileSync(sln, 'Microsoft Visual Studio Solution File\n');
+    const lsp = getPkgLspClient();
+    const { sln, dir } = makeSolution(tmpDir, 'NoShare', [
+      { name: 'A', refs: [['OnlyA', '1.0.0']] },
+      { name: 'B', refs: [['OnlyB', '1.0.0']] },
+    ]);
 
-    const resp = await lsp.sendRequest<ConsolidateResp>('sharplsp/nuget/consolidate', {
-      solutionPath: sln,
-      dryRun: true,
-    });
-    assert.deepEqual(resp.moved, [], 'no packages should be reported as shared');
+    const resp = await consolidate(lsp, sln, true);
+    assert.deepEqual(resp.moved, [], 'nothing shared is reported');
+    assert.strictEqual(resp.moved.length, 0);
+    assert.strictEqual(resp.propsFile, undefined, 'no props file');
+    assert.deepEqual(resp.modifiedFiles, [], 'no files modified');
+    assert.strictEqual(typeof resp.message, 'string', 'message is a string');
+    assert.ok(!fs.existsSync(path.join(dir, 'Directory.Build.props')), 'no props created');
+  });
+
+  test('a single-project solution shares nothing', async function () {
+    this.timeout(20_000);
+    const lsp = getPkgLspClient();
+    const { sln } = makeSolution(tmpDir, 'Single', [{ name: 'A', refs: [['Serilog', '3.1.0']] }]);
+    const resp = await consolidate(lsp, sln, true);
+    assert.deepEqual(resp.moved, [], 'one project cannot share with itself');
+    assert.strictEqual(resp.moved.length, 0);
+    assert.deepEqual(resp.modifiedFiles, []);
   });
 });
 
-// ── Suite 11: Package Maintenance — Command Execution ─────────────
+// ── Suite 11: Package Maintenance — Unused (LSP e2e) ──────────────
 
-suite('Package Maintenance — Command Execution', () => {
-  test('removeUnusedPackages handles a node without projectFilePath gracefully', async function () {
-    this.timeout(5_000);
-    const mockNode = { projectFilePath: undefined, contextValue: 'project', children: [] };
-    await assert.doesNotReject(async () => {
-      await vscode.commands.executeCommand('sharplsp.removeUnusedPackages', mockNode);
-    }, 'removeUnusedPackages must not throw for a node without a project path');
+suite('Package Maintenance — Unused (LSP e2e)', () => {
+  let tmpDir: string;
+
+  suiteSetup(async function () {
+    this.timeout(60_000);
+    const result = await setupLspTestSuite('pkg-unused-');
+    tmpDir = result.tmpDir;
   });
 
-  test('consolidatePackages handles a node without projectFilePath gracefully', async function () {
-    this.timeout(5_000);
-    const mockNode = { projectFilePath: undefined, contextValue: 'solution', children: [] };
-    await assert.doesNotReject(async () => {
-      await vscode.commands.executeCommand('sharplsp.consolidatePackages', mockNode);
-    }, 'consolidatePackages must not throw for a node without a solution path');
+  suiteTeardown(() => {
+    teardownLspTestSuite(tmpDir);
   });
 
-  test('removeUnusedPackages handles an undefined node gracefully', async function () {
-    this.timeout(5_000);
+  test('unused request resolves against the loaded fixture project via Roslyn', async function () {
+    this.timeout(40_000);
+    const lsp = getPkgLspClient();
+    const projectPath = fixtureProjectPath();
+
+    // Poll until the Roslyn workspace is warm enough to answer (request rejects
+    // while the project isn't yet in the sidecar's loaded solution).
+    const resp = await pollUntilResult<UnusedResp | undefined>(
+      async () => {
+        try {
+          return await lsp.sendRequest<UnusedResp>('sharplsp/nuget/unused', { projectPath });
+        } catch {
+          return undefined;
+        }
+      },
+      (r) => r !== undefined,
+      30_000,
+      1_000,
+    );
+
+    assert.ok(resp, 'unused must resolve — the Roslyn GetUsedAssemblyReferences pipeline ran');
+    assert.strictEqual(resp.projectPath, projectPath, 'projectPath is echoed back exactly');
+    assert.ok(Array.isArray(resp.unused), 'unused is an array');
+    // TestFixtures declares no <PackageReference Include=...> → nothing to flag.
+    assert.strictEqual(
+      resp.unused.length,
+      0,
+      'a project with no direct refs has no unused packages',
+    );
+    for (const pkg of resp.unused) {
+      assert.strictEqual(typeof pkg.id, 'string', 'each unused id is a string');
+      assert.ok(pkg.id.length > 0, 'each unused id is non-empty');
+      assert.strictEqual(typeof pkg.version, 'string', 'each unused version is a string');
+      assert.ok(!pkg.id.includes('/'), 'id is a package id, not a path');
+      assert.ok(!pkg.id.endsWith('.dll'), 'id is a package id, not an assembly file');
+    }
+  });
+
+  test('unused request rejects for a project file that cannot be read', async function () {
+    this.timeout(15_000);
+    const lsp = getPkgLspClient();
+    const bogus = path.join(tmpDir, 'Nope', 'Nope.csproj');
+    await assert.rejects(async () => {
+      await lsp.sendRequest<UnusedResp>('sharplsp/nuget/unused', { projectPath: bogus });
+    }, 'unused must reject when the project file does not exist');
+  });
+
+  test('removeUnusedPackages command runs end-to-end through the real LSP', async function () {
+    this.timeout(40_000);
+    const lsp = getPkgLspClient();
+    const projectPath = fixtureProjectPath();
+    const projectNode = { contextValue: 'project', projectFilePath: projectPath, children: [] };
+
     await assert.doesNotReject(async () => {
-      await vscode.commands.executeCommand('sharplsp.removeUnusedPackages', undefined);
-    }, 'removeUnusedPackages must not throw for an undefined node');
+      await vscode.commands.executeCommand('sharplsp.removeUnusedPackages', projectNode);
+    }, 'the command must complete against the real LSP');
+
+    // The detection truth the command relied on, asserted directly over the LSP.
+    const resp = await lsp.sendRequest<UnusedResp>('sharplsp/nuget/unused', { projectPath });
+    assert.strictEqual(resp.projectPath, projectPath, 'projectPath echoed');
+    assert.ok(Array.isArray(resp.unused), 'unused is an array');
+    assert.strictEqual(resp.unused.length, 0, 'fixture project has nothing to remove');
+  });
+
+  test('consolidatePackages command runs end-to-end through the real LSP', async function () {
+    this.timeout(30_000);
+    const lsp = getPkgLspClient();
+    // No shared packages → the command takes the non-modal "nothing to do" path,
+    // exercising the real LSP scan without a confirmation dialog.
+    const { sln, dir } = makeSolution(tmpDir, 'CmdConsolidate', [
+      { name: 'A', refs: [['OnlyA', '1.0.0']] },
+      { name: 'B', refs: [['OnlyB', '2.0.0']] },
+    ]);
+    const solutionNode = { contextValue: 'solution', projectFilePath: sln, children: [] };
+
+    await assert.doesNotReject(async () => {
+      await vscode.commands.executeCommand('sharplsp.consolidatePackages', solutionNode);
+    }, 'the command must complete against the real LSP');
+
+    // The scan truth the command relied on, asserted directly over the LSP.
+    const preview = await consolidate(lsp, sln, true);
+    assert.ok(Array.isArray(preview.moved), 'moved is an array');
+    assert.deepEqual(preview.moved, [], 'nothing shared detected over the LSP');
+    assert.ok(
+      !fs.existsSync(path.join(dir, 'Directory.Build.props')),
+      'command must not create a props file when nothing is shared',
+    );
+    assert.ok(
+      fs.readFileSync(path.join(dir, 'A', 'A.csproj'), 'utf8').includes('OnlyA'),
+      'project A is untouched',
+    );
   });
 });

--- a/editors/vscode/src/test/suite/context-menus.test.ts
+++ b/editors/vscode/src/test/suite/context-menus.test.ts
@@ -12,6 +12,8 @@ import * as assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { type LanguageClient } from 'vscode-languageclient/node';
+import { collectProjectPaths } from '../../package-maintenance.js';
 import {
   EXTENSION_ID,
   closeAllEditors,
@@ -150,6 +152,8 @@ suite('Context Menu — Package.json Contributions', () => {
     'sharplsp.nuget.addFromExplorer',
     'sharplsp.removeNuGetPackage',
     'sharplsp.removeProjectReference',
+    'sharplsp.removeUnusedPackages',
+    'sharplsp.consolidatePackages',
   ]) {
     test(`${cmd} command is registered`, async () => {
       const cmds = await vscode.commands.getCommands(true);
@@ -179,6 +183,29 @@ suite('Context Menu — Package.json Contributions', () => {
       assert.strictEqual(entry.group, '2_build', `${cmd} project entry must stay in '2_build'`);
     });
   }
+
+  // ── Package maintenance (unused / consolidate) ────────────────
+
+  test('removeUnusedPackages has project + solution menu entries in 5_dependencies', () => {
+    const entries = menuEntries().filter((m) => m.command === 'sharplsp.removeUnusedPackages');
+    const project = entries.find((m) => m.when === PROJECT_WHEN);
+    const solution = entries.find((m) => m.when === SOLUTION_WHEN);
+    assert.ok(project, 'removeUnusedPackages must have a project-node entry');
+    assert.ok(solution, 'removeUnusedPackages must have a solution-node entry');
+    assert.strictEqual(project.group, '5_dependencies');
+    assert.strictEqual(solution.group, '5_dependencies');
+  });
+
+  test('consolidatePackages has a solution-only menu entry in 5_dependencies', () => {
+    const entries = menuEntries().filter((m) => m.command === 'sharplsp.consolidatePackages');
+    const solution = entries.find((m) => m.when === SOLUTION_WHEN);
+    assert.ok(solution, 'consolidatePackages must have a solution-node entry');
+    assert.strictEqual(solution.group, '5_dependencies');
+    assert.ok(
+      !entries.some((m) => m.when === PROJECT_WHEN),
+      'consolidatePackages must NOT appear on project nodes (it is solution-wide)',
+    );
+  });
 
   // ── sortMembers when clause ───────────────────────────────────
 
@@ -1425,5 +1452,193 @@ suite('Context Menu — Project Node Commands Execute', () => {
     await assert.doesNotReject(async () => {
       await vscode.commands.executeCommand('sharplsp.nuget.addFromExplorer', mockNode);
     }, 'nuget.addFromExplorer must handle missing projectFilePath without throwing');
+  });
+});
+
+// ── Suite 9: Package Maintenance — collectProjectPaths ────────────
+
+suite('Package Maintenance — collectProjectPaths', () => {
+  type NodeArg = Parameters<typeof collectProjectPaths>[0];
+
+  function projectNodeArg(filePath: string): unknown {
+    return { contextValue: 'project', projectFilePath: filePath, children: [] };
+  }
+
+  test('project node yields its own project path', () => {
+    const node = projectNodeArg('/repo/A/A.csproj') as NodeArg;
+    assert.deepEqual(collectProjectPaths(node), ['/repo/A/A.csproj']);
+  });
+
+  test('solution node yields every descendant project path', () => {
+    const solution = {
+      contextValue: 'solution',
+      projectFilePath: '/repo/App.sln',
+      children: [projectNodeArg('/repo/A/A.csproj'), projectNodeArg('/repo/B/B.fsproj')],
+    } as unknown as NodeArg;
+    assert.deepEqual(collectProjectPaths(solution), ['/repo/A/A.csproj', '/repo/B/B.fsproj']);
+  });
+
+  test('duplicate project paths are de-duplicated', () => {
+    const solution = {
+      contextValue: 'solution',
+      projectFilePath: '/repo/App.sln',
+      children: [projectNodeArg('/repo/A/A.csproj'), projectNodeArg('/repo/A/A.csproj')],
+    } as unknown as NodeArg;
+    assert.deepEqual(collectProjectPaths(solution), ['/repo/A/A.csproj']);
+  });
+
+  test('undefined node yields no paths', () => {
+    assert.deepEqual(collectProjectPaths(undefined), []);
+  });
+});
+
+// ── Suite 10: Package Maintenance — Consolidate (LSP e2e) ─────────
+
+interface ConsolidateResp {
+  readonly moved: { id: string; version: string; fromProjects: string[] }[];
+  readonly propsFile?: string;
+  readonly modifiedFiles: string[];
+  readonly message: string;
+}
+
+interface SharpLspApiForPkgTests {
+  readonly getLspClient: () => LanguageClient | undefined;
+}
+
+/** Minimal .csproj text with a single PackageReference. */
+function csprojWith(id: string, version: string): string {
+  return `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="${id}" Version="${version}" />
+  </ItemGroup>
+</Project>`;
+}
+
+suite('Package Maintenance — Consolidate (LSP e2e)', () => {
+  let tmpDir: string;
+
+  suiteSetup(async function () {
+    this.timeout(60_000);
+    const result = await setupLspTestSuite('pkg-consol-');
+    tmpDir = result.tmpDir;
+  });
+
+  suiteTeardown(() => {
+    teardownLspTestSuite(tmpDir);
+  });
+
+  function getClient(): LanguageClient {
+    const ext = vscode.extensions.getExtension(EXTENSION_ID);
+    assert.ok(ext, 'Extension must be found');
+    const api = ext.exports as SharpLspApiForPkgTests | undefined;
+    assert.ok(api?.getLspClient, 'Extension must export getLspClient');
+    const client = api.getLspClient();
+    assert.ok(client, 'LSP client must be running');
+    return client;
+  }
+
+  /** Create an isolated solution dir with two projects sharing Serilog. */
+  function makeSharedSolution(name: string, aVersion: string, bVersion: string): string {
+    const dir = path.join(tmpDir, name);
+    fs.mkdirSync(path.join(dir, 'A'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'B'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'A', 'A.csproj'), csprojWith('Serilog', aVersion));
+    fs.writeFileSync(path.join(dir, 'B', 'B.csproj'), csprojWith('Serilog', bVersion));
+    const sln = path.join(dir, `${name}.sln`);
+    fs.writeFileSync(sln, 'Microsoft Visual Studio Solution File, Format Version 12.00\n');
+    return sln;
+  }
+
+  test('dry-run reports the shared package and touches no files', async function () {
+    this.timeout(20_000);
+    const lsp = getClient();
+    const sln = makeSharedSolution('DryRun', '3.1.0', '3.0.0');
+
+    const resp = await lsp.sendRequest<ConsolidateResp>('sharplsp/nuget/consolidate', {
+      solutionPath: sln,
+      dryRun: true,
+    });
+
+    const serilog = resp.moved.find((m) => m.id === 'Serilog');
+    assert.ok(serilog, `dry-run must report Serilog as shared; got ${JSON.stringify(resp.moved)}`);
+    assert.strictEqual(serilog.version, '3.1.0', 'highest version is chosen');
+    assert.strictEqual(serilog.fromProjects.length, 2, 'shared across 2 projects');
+    assert.deepEqual(resp.modifiedFiles, [], 'dry-run must not modify files');
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, 'DryRun', 'Directory.Build.props')),
+      'dry-run must not create Directory.Build.props',
+    );
+  });
+
+  test('apply hoists shared package into Directory.Build.props and strips projects', async function () {
+    this.timeout(20_000);
+    const lsp = getClient();
+    const sln = makeSharedSolution('Apply', '3.1.0', '3.1.0');
+    const dir = path.dirname(sln);
+
+    const resp = await lsp.sendRequest<ConsolidateResp>('sharplsp/nuget/consolidate', {
+      solutionPath: sln,
+      dryRun: false,
+    });
+
+    assert.ok(
+      resp.moved.some((m) => m.id === 'Serilog'),
+      'apply must report Serilog moved',
+    );
+    const propsPath = path.join(dir, 'Directory.Build.props');
+    assert.ok(fs.existsSync(propsPath), 'Directory.Build.props must be created');
+    const props = fs.readFileSync(propsPath, 'utf8');
+    assert.ok(props.includes('Serilog'), 'props must declare Serilog');
+    // Projects no longer carry the reference.
+    const aText = fs.readFileSync(path.join(dir, 'A', 'A.csproj'), 'utf8');
+    const bText = fs.readFileSync(path.join(dir, 'B', 'B.csproj'), 'utf8');
+    assert.ok(!aText.includes('Serilog'), 'A.csproj must no longer reference Serilog');
+    assert.ok(!bText.includes('Serilog'), 'B.csproj must no longer reference Serilog');
+  });
+
+  test('reports nothing when no package is shared', async function () {
+    this.timeout(20_000);
+    const lsp = getClient();
+    const dir = path.join(tmpDir, 'NoShare');
+    fs.mkdirSync(path.join(dir, 'A'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'B'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'A', 'A.csproj'), csprojWith('OnlyA', '1.0.0'));
+    fs.writeFileSync(path.join(dir, 'B', 'B.csproj'), csprojWith('OnlyB', '1.0.0'));
+    const sln = path.join(dir, 'NoShare.sln');
+    fs.writeFileSync(sln, 'Microsoft Visual Studio Solution File\n');
+
+    const resp = await lsp.sendRequest<ConsolidateResp>('sharplsp/nuget/consolidate', {
+      solutionPath: sln,
+      dryRun: true,
+    });
+    assert.deepEqual(resp.moved, [], 'no packages should be reported as shared');
+  });
+});
+
+// ── Suite 11: Package Maintenance — Command Execution ─────────────
+
+suite('Package Maintenance — Command Execution', () => {
+  test('removeUnusedPackages handles a node without projectFilePath gracefully', async function () {
+    this.timeout(5_000);
+    const mockNode = { projectFilePath: undefined, contextValue: 'project', children: [] };
+    await assert.doesNotReject(async () => {
+      await vscode.commands.executeCommand('sharplsp.removeUnusedPackages', mockNode);
+    }, 'removeUnusedPackages must not throw for a node without a project path');
+  });
+
+  test('consolidatePackages handles a node without projectFilePath gracefully', async function () {
+    this.timeout(5_000);
+    const mockNode = { projectFilePath: undefined, contextValue: 'solution', children: [] };
+    await assert.doesNotReject(async () => {
+      await vscode.commands.executeCommand('sharplsp.consolidatePackages', mockNode);
+    }, 'consolidatePackages must not throw for a node without a solution path');
+  });
+
+  test('removeUnusedPackages handles an undefined node gracefully', async function () {
+    this.timeout(5_000);
+    await assert.doesNotReject(async () => {
+      await vscode.commands.executeCommand('sharplsp.removeUnusedPackages', undefined);
+    }, 'removeUnusedPackages must not throw for an undefined node');
   });
 });

--- a/sidecars/SharpLsp.Sidecar.CSharp.Tests/WorkspaceManagerPackagesCoverageTests.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp.Tests/WorkspaceManagerPackagesCoverageTests.cs
@@ -1,0 +1,176 @@
+using System.Diagnostics;
+using SharpLsp.Sidecar.CSharp.Workspace;
+
+#pragma warning disable CA1515 // Types can be internal
+#pragma warning disable RS1035 // Path.GetTempPath / Process banned for analyzers — we're tests
+#pragma warning disable IDE0058 // Expression value is never used
+
+namespace SharpLsp.Sidecar.CSharp.Tests;
+
+/// <summary>
+/// Coverage for [PKG-UNUSED-DETECT-CS]:
+/// <see cref="WorkspaceManager.GetReferenceUsageAsync"/>. A real temp project
+/// that references but never uses <c>Newtonsoft.Json</c> is restored and loaded
+/// once (via <see cref="WorkspaceManagerPackagesFixture"/>) so Roslyn's
+/// <c>GetUsedAssemblyReferences</c> classifies the package as unused. Error
+/// branches (no solution loaded, project not loaded) are covered too.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "xUnit test methods run on the synchronization-context-free test pool"
+)]
+public sealed class WorkspaceManagerPackagesCoverageTests
+    : IClassFixture<WorkspaceManagerPackagesFixture>
+{
+    private readonly WorkspaceManagerPackagesFixture _fixture;
+
+    public WorkspaceManagerPackagesCoverageTests(WorkspaceManagerPackagesFixture fixture)
+    {
+        _fixture = fixture;
+        Assert.True(_fixture.OpenError is null, _fixture.OpenError ?? "ok");
+        Assert.True(_fixture.Manager.IsLoaded, "shared package workspace must be loaded");
+    }
+
+    [Fact]
+    public async Task GetReferenceUsageClassifiesUnusedPackage()
+    {
+        var result = await _fixture.Manager.GetReferenceUsageAsync(_fixture.CsprojPath);
+        Assert.False(result.IsError, result.Match(_ => "ok", err => err));
+
+        var usage = +result;
+        Assert.False(string.IsNullOrEmpty(usage.PackagesRoot), "global packages folder resolved");
+        Assert.NotEmpty(usage.AllPaths);
+        // Newtonsoft.Json is referenced but never used → in All, not in Used.
+        Assert.Contains(
+            usage.AllPaths,
+            p => p.Contains("newtonsoft.json", StringComparison.OrdinalIgnoreCase)
+        );
+        Assert.DoesNotContain(
+            usage.UsedPaths,
+            p => p.Contains("newtonsoft.json", StringComparison.OrdinalIgnoreCase)
+        );
+        // Used is necessarily a subset of All.
+        Assert.True(usage.UsedPaths.Length <= usage.AllPaths.Length);
+    }
+
+    [Fact]
+    public async Task GetReferenceUsageOnUnloadedProjectReturnsError()
+    {
+        // A real-looking path that no loaded project matches → "Project not loaded".
+        var ghost = Path.Combine(Path.GetTempPath(), "no-such-Ghost.csproj");
+        var result = await _fixture.Manager.GetReferenceUsageAsync(ghost);
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task GetReferenceUsageWithoutSolutionReturnsError()
+    {
+        // A manager that never opened anything has no solution → "No solution loaded".
+        using var fresh = new WorkspaceManager();
+        var result = await fresh.GetReferenceUsageAsync(_fixture.CsprojPath);
+        Assert.True(result.IsError);
+    }
+}
+
+/// <summary>
+/// Writes a real <c>.csproj</c> that references (but never uses)
+/// <c>Newtonsoft.Json</c>, <c>dotnet restore</c>s it so the package compile
+/// assembly resolves, then loads it once through
+/// <see cref="WorkspaceManager.OpenAsync"/>.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Reliability",
+    "CA2007:Consider calling ConfigureAwait on the awaited task",
+    Justification = "xUnit fixture lifecycle runs without a synchronization context"
+)]
+public sealed class WorkspaceManagerPackagesFixture : IAsyncLifetime, IDisposable
+{
+    private const string Csproj = """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <OutputType>Library</OutputType>
+          </PropertyGroup>
+          <ItemGroup>
+            <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+          </ItemGroup>
+        </Project>
+        """;
+
+    // Uses only the framework — Newtonsoft.Json is referenced but never touched.
+    private const string Source = """
+        namespace PkgDemo;
+
+        using System;
+
+        public class Greeter
+        {
+            public string Greet(string name) => $"Hello, {name}!";
+
+            public int Count { get; set; }
+        }
+        """;
+
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        $"sharplsp-wmp-tests-{Guid.NewGuid():N}"
+    );
+
+    private WorkspaceManager? _manager;
+
+    internal WorkspaceManager Manager =>
+        _manager ?? throw new InvalidOperationException("Fixture not initialized");
+
+    public string CsprojPath { get; private set; } = "";
+
+    public string? OpenError { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        Directory.CreateDirectory(_root);
+        CsprojPath = Path.Combine(_root, "PkgDemo.csproj");
+        await File.WriteAllTextAsync(CsprojPath, Csproj).ConfigureAwait(false);
+        await File.WriteAllTextAsync(Path.Combine(_root, "Greeter.cs"), Source)
+            .ConfigureAwait(false);
+
+        Restore(_root);
+
+        _manager = new WorkspaceManager();
+#pragma warning disable CS0618 // Obsolete OpenAsync placeholder
+        var openResult = await _manager.OpenAsync(CsprojPath).ConfigureAwait(false);
+#pragma warning restore CS0618
+        OpenError = openResult.Match<string?>(_ => null, err => err);
+    }
+
+    /// <summary>Run <c>dotnet restore</c> in <paramref name="workingDir"/>.</summary>
+    private static void Restore(string workingDir)
+    {
+        var psi = new ProcessStartInfo("dotnet", "restore --verbosity quiet")
+        {
+            WorkingDirectory = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        using var process = new Process { StartInfo = psi };
+        process.Start();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, "dotnet restore must succeed");
+    }
+
+    public Task DisposeAsync()
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _manager?.Dispose();
+        try
+        {
+            Directory.Delete(_root, true);
+        }
+        catch (IOException) { }
+    }
+}

--- a/sidecars/SharpLsp.Sidecar.CSharp/CSharpSidecar.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp/CSharpSidecar.cs
@@ -48,6 +48,7 @@ internal sealed partial class CSharpSidecar : SidecarHost
         Register("textDocument/inlayHint", HandleInlayHintAsync);
         Register("textDocument/prepareRename", HandlePrepareRenameAsync);
         Register("textDocument/rename", HandleRenameAsync);
+        Register("project/unusedPackages", HandleUnusedPackagesAsync);
     }
 
     private readonly WorkspaceManager _workspace = new();
@@ -185,6 +186,26 @@ internal sealed partial class CSharpSidecar : SidecarHost
                 cancellationToken: ct
             );
             var result = await _workspace.GetDiagnosticsAsync(filePath, ct).ConfigureAwait(false);
+            return SerializeResult(result, ct);
+        }
+        catch (Exception ex)
+        {
+            return ByteResult.Failure(ex.Message);
+        }
+    }
+
+    // Implements [PKG-UNUSED-DETECT-CS]
+    private async Task<ByteResult> HandleUnusedPackagesAsync(byte[] payload, CancellationToken ct)
+    {
+        try
+        {
+            var projectPath = MessagePackSerializer.Deserialize<string>(
+                payload,
+                cancellationToken: ct
+            );
+            var result = await _workspace
+                .GetReferenceUsageAsync(projectPath, ct)
+                .ConfigureAwait(false);
             return SerializeResult(result, ct);
         }
         catch (Exception ex)

--- a/sidecars/SharpLsp.Sidecar.CSharp/Messages.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp/Messages.cs
@@ -474,3 +474,23 @@ internal sealed class PrepareRenameResult
     [Key(5)]
     public string Placeholder { get; set; } = "";
 }
+
+// ── Unused Package Detection ──────────────────────────────────────
+
+// Implements [PKG-UNUSED-DETECT-CS]: assembly-level reference usage for a
+// project, consumed by the Rust host's [PKG-UNUSED-MAP] package mapping.
+[MessagePackObject(AllowPrivate = true)]
+internal sealed class ReferenceUsageResult
+{
+    /// <summary>Absolute paths of assemblies actually used by the compilation.</summary>
+    [Key(0)]
+    public string[] UsedPaths { get; set; } = [];
+
+    /// <summary>Absolute paths of every assembly referenced by the compilation.</summary>
+    [Key(1)]
+    public string[] AllPaths { get; set; } = [];
+
+    /// <summary>NuGet global packages folder used to map assemblies to packages.</summary>
+    [Key(2)]
+    public string PackagesRoot { get; set; } = "";
+}

--- a/sidecars/SharpLsp.Sidecar.CSharp/Workspace/WorkspaceManager.Packages.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp/Workspace/WorkspaceManager.Packages.cs
@@ -1,0 +1,92 @@
+using Microsoft.CodeAnalysis;
+using ReferenceUsageQueryResult = Outcome.Result<
+    SharpLsp.Sidecar.CSharp.ReferenceUsageResult,
+    string
+>;
+
+namespace SharpLsp.Sidecar.CSharp.Workspace;
+
+/// <summary>
+/// Implements [PKG-UNUSED-DETECT-CS]: assembly-level reference usage for a
+/// project, via Roslyn's <c>Compilation.GetUsedAssemblyReferences()</c>.
+/// </summary>
+internal sealed partial class WorkspaceManager
+{
+    /// <summary>
+    /// Classify a project's metadata references into used / all, plus the NuGet
+    /// global packages folder so the host can map assemblies back to packages.
+    /// </summary>
+    public async Task<ReferenceUsageQueryResult> GetReferenceUsageAsync(
+        string projectPath,
+        CancellationToken ct = default
+    )
+    {
+        try
+        {
+            if (_solution is null)
+            {
+                return ReferenceUsageQueryResult.Failure("No solution loaded");
+            }
+
+            var project = FindProjectByPath(projectPath);
+            if (project is null)
+            {
+                return ReferenceUsageQueryResult.Failure($"Project not loaded: {projectPath}");
+            }
+
+            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            if (compilation is null)
+            {
+                return ReferenceUsageQueryResult.Failure("No compilation available");
+            }
+
+            var used = compilation.GetUsedAssemblyReferences(ct);
+            var result = new ReferenceUsageResult
+            {
+                UsedPaths = PortablePaths(used),
+                AllPaths = PortablePaths(compilation.References),
+                PackagesRoot = GlobalPackagesFolder(),
+            };
+            return new ReferenceUsageQueryResult.Ok<ReferenceUsageResult, string>(result);
+        }
+        catch (Exception ex)
+        {
+            return ReferenceUsageQueryResult.Failure(ex.Message);
+        }
+    }
+
+    /// <summary>Find a loaded project by its file path.</summary>
+    private Project? FindProjectByPath(string projectPath)
+    {
+        var normalized = Path.GetFullPath(projectPath);
+        return _solution!.Projects.FirstOrDefault(project =>
+            IsPathMatch(project.FilePath, normalized)
+        );
+    }
+
+    /// <summary>Absolute file paths of on-disk (PE) metadata references.</summary>
+    private static string[] PortablePaths(IEnumerable<MetadataReference> references)
+    {
+        return
+        [
+            .. references
+                .OfType<PortableExecutableReference>()
+                .Select(reference => reference.FilePath)
+                .Where(path => !string.IsNullOrEmpty(path))
+                .Select(path => path!),
+        ];
+    }
+
+    /// <summary>The NuGet global packages folder (env override or user default).</summary>
+    private static string GlobalPackagesFolder()
+    {
+        var root = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (!string.IsNullOrEmpty(root))
+        {
+            return root;
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".nuget", "packages");
+    }
+}

--- a/sidecars/SharpLsp.Sidecar.FSharp.Tests/FSharpPackagesTests.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp.Tests/FSharpPackagesTests.fs
@@ -1,0 +1,120 @@
+/// [PKG-UNUSED-DETECT-FS] Tests for FSharpPackages.getReferenceUsage.
+///
+/// A real, restored .fsproj is checked through FCS so a referenced-but-unused
+/// package assembly is correctly classified (present in `All`, absent from
+/// `Used`). The fail-safe paths (missing assets, non-existent project) are
+/// covered too, since the module promises an empty result on any uncertainty.
+module SharpLsp.Sidecar.FSharp.Tests.FSharpPackagesTests
+
+open System
+open System.Diagnostics
+open System.IO
+open Xunit
+open SharpLsp.Sidecar.FSharp
+
+/// Quietly delete a temp directory.
+let private cleanup (dir: string) =
+    try
+        Directory.Delete(dir, true)
+    with _ ->
+        ()
+
+/// Does any path mention the given (lowercased) needle?
+let private mentions (paths: string array) (needle: string) =
+    paths |> Array.exists (fun p -> p.ToLowerInvariant().Contains(needle))
+
+/// Write a real .fsproj referencing `Newtonsoft.Json` plus one source file,
+/// then `dotnet restore` it so obj/project.assets.json and the package compile
+/// assemblies exist on disk for the isolated usage check. Returns (dir, fsproj).
+let private makeRestoredProject (source: string) =
+    let dir = Path.Combine(Path.GetTempPath(), $"sharplsp-pkg-{Guid.NewGuid():N}")
+    Directory.CreateDirectory(dir) |> ignore
+
+    let fsproj =
+        """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>"""
+
+    let fsprojPath = Path.Combine(dir, "PkgProject.fsproj")
+    File.WriteAllText(fsprojPath, fsproj)
+    File.WriteAllText(Path.Combine(dir, "Library.fs"), source)
+
+    let psi = ProcessStartInfo("dotnet", "restore --verbosity quiet")
+    psi.WorkingDirectory <- dir
+    psi.RedirectStandardOutput <- true
+    psi.RedirectStandardError <- true
+    use proc = new Process()
+    proc.StartInfo <- psi
+    proc.Start() |> ignore
+    proc.WaitForExit()
+    Assert.True((proc.ExitCode = 0), "dotnet restore must succeed")
+    (dir, fsprojPath)
+
+/// Source that exercises FSharp.Core (List) but never touches Newtonsoft.Json,
+/// so Newtonsoft is genuinely referenced-but-unused.
+let private unusedNewtonsoftSource =
+    "module Library\n"
+    + "let doubled = [ 1; 2; 3 ] |> List.map (fun x -> x * 2)\n"
+    + "let total = List.sum doubled\n"
+
+[<Fact>]
+let ``getReferenceUsage flags a referenced-but-unused package`` () =
+    task {
+        let (dir, fsproj) = makeRestoredProject unusedNewtonsoftSource
+
+        try
+            let state = FSharpWorkspace.create ()
+            let! usage = FSharpPackages.getReferenceUsage state fsproj
+
+            Assert.False(String.IsNullOrEmpty usage.Root, "packages root resolved from assets")
+            Assert.NotEmpty(usage.All)
+            Assert.True(
+                mentions usage.All "newtonsoft.json",
+                "Newtonsoft assembly is among the All referenced assemblies"
+            )
+            Assert.False(
+                mentions usage.Used "newtonsoft.json",
+                "Newtonsoft is never used → it must be absent from Used"
+            )
+            // Used is necessarily a subset of All.
+            Assert.True(usage.Used.Length <= usage.All.Length)
+        finally
+            cleanup dir
+    }
+
+[<Fact>]
+let ``getReferenceUsage is fail-safe when assets are missing`` () =
+    task {
+        // A real .fsproj that was never restored → no obj/project.assets.json.
+        let dir = Path.Combine(Path.GetTempPath(), $"sharplsp-pkg-{Guid.NewGuid():N}")
+        Directory.CreateDirectory(dir) |> ignore
+        let fsproj = Path.Combine(dir, "Bare.fsproj")
+        File.WriteAllText(fsproj, "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>")
+
+        try
+            let state = FSharpWorkspace.create ()
+            let! usage = FSharpPackages.getReferenceUsage state fsproj
+            Assert.Empty(usage.All)
+            Assert.Empty(usage.Used)
+        finally
+            cleanup dir
+    }
+
+[<Fact>]
+let ``getReferenceUsage is fail-safe for a non-existent project`` () =
+    task {
+        let state = FSharpWorkspace.create ()
+        let! usage = FSharpPackages.getReferenceUsage state "/no/such/Ghost.fsproj"
+        Assert.Empty(usage.All)
+        Assert.Empty(usage.Used)
+        Assert.Equal("", usage.Root)
+    }

--- a/sidecars/SharpLsp.Sidecar.FSharp.Tests/SharpLsp.Sidecar.FSharp.Tests.fsproj
+++ b/sidecars/SharpLsp.Sidecar.FSharp.Tests/SharpLsp.Sidecar.FSharp.Tests.fsproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="Tests.fs" />
     <Compile Include="FSharpCoverageTests.fs" />
+    <Compile Include="FSharpPackagesTests.fs" />
     <Compile Include="SidecarEndToEndTests.fs" />
   </ItemGroup>
 

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpPackages.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpPackages.fs
@@ -1,0 +1,191 @@
+/// [PKG-UNUSED-DETECT-FS] Unused-package detection for F# projects.
+///
+/// The persistent workspace options omit NuGet refs, so this module builds an
+/// *isolated* FSharpProjectOptions that includes the project's restored compile
+/// assemblies (from obj/project.assets.json), runs a project-wide check, and
+/// reports which referenced assemblies are actually used. The host's
+/// [PKG-UNUSED-MAP] then maps assemblies → packages.
+///
+/// Fail-safe by construction: missing assets, a failed check, or zero symbol
+/// uses all yield an empty `All` set, so the host flags nothing on uncertainty.
+module SharpLsp.Sidecar.FSharp.FSharpPackages
+
+open System
+open System.IO
+open System.Text.Json
+open System.Threading.Tasks
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Symbols
+open Serilog
+
+/// Reference-usage for a project: used + all package assemblies + packages root.
+[<NoComparison; NoEquality>]
+type UsedReferences =
+    { Used: string array
+      All: string array
+      Root: string }
+
+/// A restored package compile assembly: simple name + absolute path.
+[<NoComparison; NoEquality>]
+type private PackageAssembly = { Simple: string; Path: string }
+
+/// Fail-safe empty result — the host flags nothing.
+let private emptyUsage = { Used = [||]; All = [||]; Root = "" }
+
+/// Path to a project's restored assets file.
+let private assetsPath (fsprojPath: string) =
+    let dir = Path.GetDirectoryName(fsprojPath) |> string
+    Path.Combine(dir, "obj", "project.assets.json")
+
+/// Try to read an object property.
+let private tryProp (el: JsonElement) (name: string) : JsonElement option =
+    match el.TryGetProperty(name) with
+    | true, value -> Some value
+    | false, _ -> None
+
+/// First property name of an object element, if any.
+let private firstName (el: JsonElement) : string option =
+    if el.ValueKind = JsonValueKind.Object then
+        el.EnumerateObject() |> Seq.map (fun p -> p.Name) |> Seq.tryHead
+    else
+        None
+
+/// First property value of an object element, if any.
+let private firstValue (el: JsonElement) : JsonElement option =
+    if el.ValueKind = JsonValueKind.Object then
+        el.EnumerateObject() |> Seq.map (fun p -> p.Value) |> Seq.tryHead
+    else
+        None
+
+/// Folder path (relative to the packages root) for a library key.
+let private libraryPath (libraries: JsonElement option) (key: string) : string =
+    let fromLibraries =
+        libraries
+        |> Option.bind (fun lib -> tryProp lib key)
+        |> Option.bind (fun entry -> tryProp entry "path")
+        |> Option.map (fun path -> path.GetString() |> string)
+
+    match fromLibraries with
+    | Some path when not (String.IsNullOrEmpty path) -> path
+    | _ -> key.ToLowerInvariant()
+
+/// Replace forward slashes with the platform path separator.
+let private toLocal (rel: string) = rel.Replace('/', Path.DirectorySeparatorChar)
+
+/// Compile assemblies declared by one target-framework package entry.
+let private packageAssemblies
+    (root: string)
+    (libraries: JsonElement option)
+    (key: string)
+    (entry: JsonElement)
+    : PackageAssembly seq =
+    match tryProp entry "compile" with
+    | Some compile when compile.ValueKind = JsonValueKind.Object ->
+        let libPath = libraryPath libraries key
+
+        compile.EnumerateObject()
+        |> Seq.choose (fun file ->
+            if file.Name = "_._" then
+                None
+            else
+                let abs = Path.Combine(root, toLocal libPath, toLocal file.Name)
+                let simple = Path.GetFileNameWithoutExtension(file.Name) |> string
+                Some { Simple = simple; Path = abs })
+    | _ -> Seq.empty
+
+/// Parse compile assemblies + packages root from project.assets.json.
+let private parseAssets (path: string) : (string * PackageAssembly list) option =
+    if not (File.Exists path) then
+        None
+    else
+        try
+            use doc = JsonDocument.Parse(File.ReadAllText path)
+            let rootEl = doc.RootElement
+
+            let root =
+                tryProp rootEl "packageFolders"
+                |> Option.bind firstName
+                |> Option.defaultValue ""
+
+            let libraries = tryProp rootEl "libraries"
+            let target = tryProp rootEl "targets" |> Option.bind firstValue
+
+            match target with
+            | Some targetEl when targetEl.ValueKind = JsonValueKind.Object ->
+                let assemblies =
+                    targetEl.EnumerateObject()
+                    |> Seq.collect (fun pkg -> packageAssemblies root libraries pkg.Name pkg.Value)
+                    |> Seq.toList
+
+                Some(root, assemblies)
+            | _ -> None
+        with ex ->
+            Log.Debug(ex, "[F# Packages] assets parse failed")
+            None
+
+/// Build isolated project options that resolve the restored package references.
+let private projectOptions
+    (state: FSharpWorkspace.FSharpWorkspaceState)
+    (fsprojPath: string)
+    (assemblies: PackageAssembly list)
+    =
+    let sources = FSharpWorkspace.parseFsprojSourceFiles fsprojPath
+    let packageRefs = assemblies |> List.map (fun a -> $"-r:{a.Path}") |> List.toArray
+    let other = Array.append (FSharpWorkspace.frameworkReferenceArgs ()) packageRefs
+    state.Checker.GetProjectOptionsFromCommandLineArgs(fsprojPath, Array.append other sources)
+
+/// Assembly simple name owning a symbol, if determinable.
+let private assemblyOf (sym: FSharpSymbol) : string option =
+    match sym with
+    | :? FSharpEntity as e -> Some(e.Assembly.SimpleName |> string)
+    | :? FSharpMemberOrFunctionOrValue as m ->
+        m.DeclaringEntity |> Option.map (fun e -> e.Assembly.SimpleName |> string)
+    | _ -> None
+
+/// Lowercased simple names of the assemblies actually used by symbol uses.
+let private usedAssemblyNames (allUses: FSharpSymbolUse array) : Set<string> =
+    allUses
+    |> Seq.choose (fun (su: FSharpSymbolUse) ->
+        try
+            assemblyOf su.Symbol
+        with _ ->
+            None)
+    |> Seq.choose (fun name ->
+        if String.IsNullOrEmpty name then
+            None
+        else
+            Some(name.ToLowerInvariant()))
+    |> Set.ofSeq
+
+/// Compute reference usage for an .fsproj. Fail-safe: any error → empty `All`.
+let getReferenceUsage
+    (state: FSharpWorkspace.FSharpWorkspaceState)
+    (fsprojPath: string)
+    : Task<UsedReferences> =
+    task {
+        try
+            match parseAssets (assetsPath fsprojPath) with
+            | None -> return emptyUsage
+            | Some(root, assemblies) when List.isEmpty assemblies -> return { emptyUsage with Root = root }
+            | Some(root, assemblies) ->
+                let options = projectOptions state fsprojPath assemblies
+                let! results = state.Checker.ParseAndCheckProject(options)
+                let allUses = results.GetAllUsesOfAllSymbols()
+
+                if results.HasCriticalErrors || Array.isEmpty allUses then
+                    return { emptyUsage with Root = root }
+                else
+                    let used = usedAssemblyNames allUses
+                    let allPaths = assemblies |> List.map (fun a -> a.Path) |> List.toArray
+
+                    let usedPaths =
+                        assemblies
+                        |> List.filter (fun a -> used.Contains(a.Simple.ToLowerInvariant()))
+                        |> List.map (fun a -> a.Path)
+                        |> List.toArray
+
+                    return { Used = usedPaths; All = allPaths; Root = root }
+        with ex ->
+            Log.Debug(ex, "[F# Packages] usage failed")
+            return emptyUsage
+    }

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpSidecar.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpSidecar.fs
@@ -150,6 +150,15 @@ type FormattingPreviewResult =
 type SemanticTokensResult =
     { [<Key(0)>] Data: int array }
 
+// Implements [PKG-UNUSED-DETECT-FS] — wire-compatible with the C# sidecar's
+// ReferenceUsageResult (positional MessagePack keys).
+[<MessagePackObject(AllowPrivate = true)>]
+[<NoComparison; NoEquality>]
+type ReferenceUsageResult =
+    { [<Key(0)>] UsedPaths: string array
+      [<Key(1)>] AllPaths: string array
+      [<Key(2)>] PackagesRoot: string }
+
 module private Helpers =
     /// Convert a FSharpWorkspace.DefinitionLocation to a LocationResult.
     let toLocationResult (loc: FSharpWorkspace.DefinitionLocation) : LocationResult =
@@ -259,6 +268,21 @@ type FSharpSidecar() =
                         // Return MessagePack nil (0xC0) for no hover result.
                         let bytes = [| 0xC0uy |]
                         return Outcome.Result<byte[], string>.Ok<byte[], string>(bytes) :> ByteResult
+                with ex ->
+                    return ByteResult.Failure(ex.Message)
+            }))
+
+        // Unused-package detection [PKG-UNUSED-DETECT-FS].
+        base.Register("project/unusedPackages", Func<byte[], CancellationToken, Task<ByteResult>>(fun payload ct ->
+            task {
+                try
+                    let projectPath = MessagePackSerializer.Deserialize<string>(payload, cancellationToken = ct)
+                    let! usage = FSharpPackages.getReferenceUsage workspace projectPath
+                    let result =
+                        { UsedPaths = usage.Used
+                          AllPaths = usage.All
+                          PackagesRoot = usage.Root }
+                    return Helpers.serializeOk result ct
                 with ex ->
                     return ByteResult.Failure(ex.Message)
             }))

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpWorkspace.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpWorkspace.fs
@@ -38,7 +38,7 @@ let create () : FSharpWorkspaceState =
       IsLoaded = false }
 
 /// Parse an .fsproj file to extract Compile Include entries.
-let private parseFsprojSourceFiles (fsprojPath: string) : string array =
+let internal parseFsprojSourceFiles (fsprojPath: string) : string array =
     let doc = XDocument.Load(fsprojPath)
     let projDir = Path.GetDirectoryName(fsprojPath) |> string
     doc.Descendants(XName.Get("Compile"))
@@ -89,6 +89,35 @@ let private discoverFsprojFiles (path: string) (ct: CancellationToken) =
             return Error $"Path does not exist: {path}"
     }
 
+/// Build the shared compiler options for a netcore F# check: `--noframework`,
+/// the managed framework reference assemblies from the runtime dir, and
+/// FSharp.Core. Reused by both project loading and unused-package analysis.
+let internal frameworkReferenceArgs () : string array =
+    // The runtime dir contains both managed and native DLLs (e.g. clretwrc.dll,
+    // coreclr.dll); skip native DLLs since FCS rejects them with "bad cli header".
+    let runtimeDir = Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
+    let isManagedAssembly (path: string) =
+        try
+            AssemblyName.GetAssemblyName(path) |> ignore
+            true
+        with _ -> false
+    let frameworkRefs =
+        Directory.GetFiles(runtimeDir, "*.dll")
+        |> Array.filter isManagedAssembly
+        |> Array.map (fun dll -> $"-r:{dll}")
+    // FSharp.Core is loaded by the sidecar itself; use that path — it's
+    // guaranteed to exist and be ABI-compatible with FCS.
+    let fsharpCorePath = typeof<unit>.Assembly.Location
+    let fsharpCoreRef =
+        if String.IsNullOrEmpty(fsharpCorePath) || not (File.Exists fsharpCorePath) then
+            [||]
+        else
+            [| $"-r:{fsharpCorePath}" |]
+    [| yield "--noframework"
+       yield "--targetprofile:netcore"
+       yield! frameworkRefs
+       yield! fsharpCoreRef |]
+
 let private loadFirstProject (state: FSharpWorkspaceState) (fsprojFiles: string array) =
     if fsprojFiles.Length = 0 then
         Error "No .fsproj found"
@@ -98,34 +127,7 @@ let private loadFirstProject (state: FSharpWorkspaceState) (fsprojFiles: string 
             if fsprojFiles.Length > 1 then
                 Log.Debug("F# workspace found {Count} projects; loading {Path}", fsprojFiles.Length, fsprojPath)
             let sourceFiles = parseFsprojSourceFiles fsprojPath
-            // Build compiler options with framework refs from the runtime dir.
-            // The runtime dir contains both managed and native DLLs (e.g.
-            // clretwrc.dll, coreclr.dll); skip native DLLs since FCS rejects
-            // them with "bad cli header".
-            let runtimeDir =
-                Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
-            let isManagedAssembly (path: string) =
-                try
-                    AssemblyName.GetAssemblyName(path) |> ignore
-                    true
-                with _ -> false
-            let frameworkRefs =
-                Directory.GetFiles(runtimeDir, "*.dll")
-                |> Array.filter isManagedAssembly
-                |> Array.map (fun dll -> $"-r:{dll}")
-            // FSharp.Core is loaded by the sidecar itself; use that path —
-            // it's guaranteed to exist and be ABI-compatible with FCS.
-            let fsharpCorePath = typeof<unit>.Assembly.Location
-            let fsharpCoreRef =
-                if String.IsNullOrEmpty(fsharpCorePath) || not (File.Exists fsharpCorePath) then
-                    [||]
-                else
-                    [| $"-r:{fsharpCorePath}" |]
-            let otherOptions =
-                [| yield "--noframework"
-                   yield "--targetprofile:netcore"
-                   yield! frameworkRefs
-                   yield! fsharpCoreRef |]
+            let otherOptions = frameworkReferenceArgs ()
             let options =
                 state.Checker.GetProjectOptionsFromCommandLineArgs(
                     fsprojPath,

--- a/sidecars/SharpLsp.Sidecar.FSharp/SharpLsp.Sidecar.FSharp.fsproj
+++ b/sidecars/SharpLsp.Sidecar.FSharp/SharpLsp.Sidecar.FSharp.fsproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <Compile Include="Hover/FSharpHoverBuilder.fs" />
     <Compile Include="FSharpWorkspace.fs" />
+    <Compile Include="FSharpPackages.fs" />
     <Compile Include="FSharpReferences.fs" />
     <Compile Include="FSharpFeatures.fs" />
     <Compile Include="FSharpFileOrder.fs" />

--- a/src/main.rs
+++ b/src/main.rs
@@ -720,6 +720,12 @@ fn handle_custom_request(
         "sharplsp/nuget/uninstall" => {
             nuget::handlers::handle_uninstall(req, runtime, connection.sender.clone())
         }
+        "sharplsp/nuget/unused" => {
+            nuget::handlers::handle_unused(req, runtime, csharp_sidecar, fsharp_sidecar)
+        }
+        "sharplsp/nuget/consolidate" => {
+            nuget::handlers::handle_consolidate(req, runtime, connection.sender.clone())
+        }
         // Profiler
         "sharplsp/profiler/listProcesses" => profiler::handlers::handle_list_processes(req),
         "sharplsp/profiler/killProcess" => profiler::handlers::handle_kill_process(req),

--- a/src/nuget/consolidate.rs
+++ b/src/nuget/consolidate.rs
@@ -1,0 +1,409 @@
+//! [PKG-CONSOLIDATE] Hoist `NuGet` packages shared by ≥2 projects into a
+//! solution-root `Directory.Build.props`.
+//!
+//! Pure Tier-1 logic: enumerate projects (reuse [`super::targets`]), read their
+//! `PackageReference` items (reuse [`super::parse`]), and move shared ones via
+//! the trivia-preserving [`super::xml_edit`]. No sidecar, no second XML editor.
+
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tracing::info;
+
+use super::types::{ConsolidateResponse, MovedPackage};
+use super::xml_edit::{self, PackageElement};
+use super::{parse, targets};
+
+/// Body written when the solution has no `Directory.Build.props` yet.
+const EMPTY_PROPS: &str = "<Project>\n</Project>\n";
+
+/// A package referenced by two or more projects, ready to hoist.
+#[derive(Debug)]
+struct SharedPackage {
+    /// Package identifier.
+    id: String,
+    /// Highest declared version, or `None` when every reference is versionless.
+    version: Option<String>,
+    /// Absolute paths of the projects that declared the reference.
+    projects: Vec<PathBuf>,
+}
+
+/// Consolidate shared packages for the solution at `solution_path`.
+///
+/// When `dry_run` is set the shared packages are reported without touching any
+/// files, so the UI can confirm the (destructive) move before it happens.
+pub fn consolidate(solution_path: &str, dry_run: bool) -> Result<ConsolidateResponse> {
+    let solution_dir = Path::new(solution_path)
+        .parent()
+        .map(Path::to_path_buf)
+        .with_context(|| format!("solution has no parent dir: {solution_path}"))?;
+
+    let scan = targets::enumerate_targets(&solution_dir.to_string_lossy())?;
+    let projects = collect_project_paths(&scan.targets);
+    let shared = scan_shared(&projects)?;
+
+    if shared.is_empty() {
+        return Ok(empty_response("No packages are shared across 2+ projects."));
+    }
+
+    if dry_run {
+        return Ok(describe(scan.cpm_enabled, &shared));
+    }
+
+    apply(&solution_dir, scan.cpm_enabled, &shared)
+}
+
+/// Build a no-write preview response describing what `apply` would move.
+fn describe(cpm_enabled: bool, shared: &[SharedPackage]) -> ConsolidateResponse {
+    let moved: Vec<MovedPackage> = shared
+        .iter()
+        .map(|pkg| MovedPackage {
+            id: pkg.id.clone(),
+            version: if cpm_enabled {
+                String::new()
+            } else {
+                pkg.version.clone().unwrap_or_default()
+            },
+            from_projects: pkg.projects.iter().map(|p| file_label(p)).collect(),
+        })
+        .collect();
+    ConsolidateResponse {
+        message: format!("{} package(s) shared across 2+ projects.", moved.len()),
+        moved,
+        props_file: None,
+        modified_files: Vec::new(),
+    }
+}
+
+/// Project-kind absolute paths from an enumerated target list.
+fn collect_project_paths(targets: &[super::types::NuGetTarget]) -> Vec<PathBuf> {
+    targets
+        .iter()
+        .filter(|t| t.kind == super::types::TargetKind::Project)
+        .map(|t| PathBuf::from(&t.path))
+        .collect()
+}
+
+/// Group `PackageReference` ids across projects and keep those in ≥2 projects.
+fn scan_shared(projects: &[PathBuf]) -> Result<Vec<SharedPackage>> {
+    /// Per-id accumulator: declaring projects + the versions seen.
+    type Acc = (Vec<PathBuf>, Vec<String>);
+    let mut map: BTreeMap<String, Acc> = BTreeMap::new();
+
+    for project in projects {
+        let text = std::fs::read_to_string(project)
+            .with_context(|| format!("read {}", project.display()))?;
+        for item in parse::read_package_items(&text, "PackageReference") {
+            if !item.simple {
+                continue; // metadata-bearing refs are reported elsewhere, never moved
+            }
+            let entry = map.entry(item.id).or_default();
+            if !entry.0.contains(project) {
+                entry.0.push(project.clone());
+            }
+            if let Some(version) = item.version {
+                entry.1.push(version);
+            }
+        }
+    }
+
+    Ok(map
+        .into_iter()
+        .filter(|(_, (projects, _))| projects.len() >= 2)
+        .map(|(id, (projects, versions))| SharedPackage {
+            id,
+            version: highest_version(&versions),
+            projects,
+        })
+        .collect())
+}
+
+/// Hoist every shared package into `Directory.Build.props` and strip it from
+/// the projects that declared it.
+fn apply(
+    solution_dir: &Path,
+    cpm_enabled: bool,
+    shared: &[SharedPackage],
+) -> Result<ConsolidateResponse> {
+    let props_path = ensure_props(solution_dir)?;
+    let element = if cpm_enabled {
+        PackageElement::ReferenceNoVersion
+    } else {
+        PackageElement::Reference
+    };
+
+    let mut moved = Vec::new();
+    let mut modified = vec![props_path.to_string_lossy().to_string()];
+
+    for pkg in shared {
+        let version = pkg.version.clone().unwrap_or_default();
+        let _ = xml_edit::add_package(&props_path, &pkg.id, &version, element)?;
+        let from_projects = strip_from_projects(&pkg.projects, &pkg.id, &mut modified)?;
+        moved.push(MovedPackage {
+            id: pkg.id.clone(),
+            version: if cpm_enabled { String::new() } else { version },
+            from_projects,
+        });
+    }
+
+    info!(
+        "consolidate: moved {} package(s) into {}",
+        moved.len(),
+        props_path.display()
+    );
+    Ok(ConsolidateResponse {
+        message: summarize(&moved),
+        moved,
+        props_file: Some(props_path.to_string_lossy().to_string()),
+        modified_files: modified,
+    })
+}
+
+/// Remove `package_id` from each project, recording display names + edits.
+fn strip_from_projects(
+    projects: &[PathBuf],
+    package_id: &str,
+    modified: &mut Vec<String>,
+) -> Result<Vec<String>> {
+    let mut names = Vec::new();
+    for project in projects {
+        let outcome = xml_edit::remove_package(project, package_id, PackageElement::Reference)?;
+        if outcome.modified {
+            modified.push(project.to_string_lossy().to_string());
+        }
+        names.push(file_label(project));
+    }
+    Ok(names)
+}
+
+/// Ensure a `Directory.Build.props` exists at the solution root; create a
+/// minimal one if absent. Returns its path.
+fn ensure_props(solution_dir: &Path) -> Result<PathBuf> {
+    let path = solution_dir.join("Directory.Build.props");
+    if !path.exists() {
+        std::fs::write(&path, EMPTY_PROPS).with_context(|| format!("create {}", path.display()))?;
+        info!("consolidate: created {}", path.display());
+    }
+    Ok(path)
+}
+
+/// Display label for a project path (its file name).
+fn file_label(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map_or_else(|| path.to_string_lossy().to_string(), String::from)
+}
+
+/// Build the empty/no-op response with a message.
+fn empty_response(message: &str) -> ConsolidateResponse {
+    ConsolidateResponse {
+        moved: Vec::new(),
+        props_file: None,
+        modified_files: Vec::new(),
+        message: message.to_string(),
+    }
+}
+
+/// One-line human summary of a consolidation result.
+fn summarize(moved: &[MovedPackage]) -> String {
+    let names: Vec<String> = moved.iter().map(|m| m.id.clone()).collect();
+    format!(
+        "Moved {} package(s) into Directory.Build.props: {}",
+        moved.len(),
+        names.join(", ")
+    )
+}
+
+/// Pick the highest version from a list, or `None` if empty.
+fn highest_version(versions: &[String]) -> Option<String> {
+    versions.iter().max_by(|a, b| cmp_versions(a, b)).cloned()
+}
+
+/// Compare two `NuGet` versions: numeric core descending, prerelease < release.
+fn cmp_versions(a: &str, b: &str) -> Ordering {
+    let (core_a, pre_a) = split_prerelease(a);
+    let (core_b, pre_b) = split_prerelease(b);
+    match cmp_core(core_a, core_b) {
+        Ordering::Equal => match (pre_a.is_empty(), pre_b.is_empty()) {
+            (true, false) => Ordering::Greater, // release > prerelease
+            (false, true) => Ordering::Less,
+            _ => pre_a.cmp(pre_b),
+        },
+        other => other,
+    }
+}
+
+/// Split a version into its numeric core and prerelease tail (at the first `-`).
+fn split_prerelease(version: &str) -> (&str, &str) {
+    version.split_once('-').unwrap_or((version, ""))
+}
+
+/// Compare dotted numeric cores segment by segment (missing segments are 0).
+fn cmp_core(a: &str, b: &str) -> Ordering {
+    let mut sa = a.split('.');
+    let mut sb = b.split('.');
+    loop {
+        match (sa.next(), sb.next()) {
+            (None, None) => return Ordering::Equal,
+            (left, right) => {
+                let na = left.and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+                let nb = right.and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+                if na != nb {
+                    return na.cmp(&nb);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code — panics are the correct failure mode"
+)]
+mod tests {
+    use super::*;
+    use std::fmt::Write as _;
+    use tempfile::TempDir;
+
+    /// Write a project file with the given `PackageReference` lines.
+    fn write_project(dir: &Path, name: &str, refs: &[(&str, &str)]) -> PathBuf {
+        let mut body = String::from("<Project Sdk=\"Microsoft.NET.Sdk\">\n  <ItemGroup>\n");
+        for (id, version) in refs {
+            let _ = writeln!(
+                body,
+                "    <PackageReference Include=\"{id}\" Version=\"{version}\" />"
+            );
+        }
+        body.push_str("  </ItemGroup>\n</Project>\n");
+        let path = dir.join(format!("{name}.csproj"));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    /// Create a solution dir with a `.sln` and return its path.
+    fn write_solution(dir: &Path) -> String {
+        let sln = dir.join("App.sln");
+        std::fs::write(&sln, "Microsoft Visual Studio Solution File\n").unwrap();
+        sln.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn cmp_versions_orders_numeric_and_prerelease() {
+        assert_eq!(cmp_versions("13.0.3", "13.0.4"), Ordering::Less);
+        assert_eq!(cmp_versions("3.1.0", "3.1.0"), Ordering::Equal);
+        assert_eq!(cmp_versions("2.0.0", "1.9.9"), Ordering::Greater);
+        // Release outranks an equal-core prerelease.
+        assert_eq!(cmp_versions("1.0.0", "1.0.0-beta"), Ordering::Greater);
+        assert_eq!(cmp_versions("1.0.0-alpha", "1.0.0-beta"), Ordering::Less);
+    }
+
+    #[test]
+    fn highest_version_picks_max() {
+        let versions = vec![
+            "1.0.0".to_string(),
+            "3.1.0".to_string(),
+            "2.5.0".to_string(),
+        ];
+        assert_eq!(highest_version(&versions), Some("3.1.0".to_string()));
+        assert_eq!(highest_version(&[]), None);
+    }
+
+    #[test]
+    fn scan_finds_only_packages_in_two_or_more_projects() {
+        let td = TempDir::new().unwrap();
+        let root = td.path();
+        let a = write_project(root, "A/A", &[("Serilog", "3.1.0"), ("OnlyA", "1.0.0")]);
+        let b = write_project(root, "B/B", &[("Serilog", "3.0.0"), ("OnlyB", "1.0.0")]);
+        let shared = scan_shared(&[a, b]).unwrap();
+        assert_eq!(shared.len(), 1, "only Serilog is shared");
+        assert_eq!(shared[0].id, "Serilog");
+        // Highest of 3.1.0 / 3.0.0.
+        assert_eq!(shared[0].version, Some("3.1.0".to_string()));
+        assert_eq!(shared[0].projects.len(), 2);
+    }
+
+    #[test]
+    fn consolidate_hoists_shared_and_strips_projects() {
+        let td = TempDir::new().unwrap();
+        let root = td.path();
+        let sln = write_solution(root);
+        let a = write_project(root, "A/A", &[("Serilog", "3.1.0")]);
+        let b = write_project(root, "B/B", &[("Serilog", "3.0.0")]);
+
+        let resp = consolidate(&sln, false).unwrap();
+        assert_eq!(resp.moved.len(), 1);
+        assert_eq!(resp.moved[0].id, "Serilog");
+        assert_eq!(resp.moved[0].version, "3.1.0");
+
+        // Directory.Build.props now declares Serilog once.
+        let props = std::fs::read_to_string(root.join("Directory.Build.props")).unwrap();
+        assert!(props.contains("Include=\"Serilog\" Version=\"3.1.0\""));
+
+        // Projects no longer reference Serilog.
+        assert!(!std::fs::read_to_string(&a).unwrap().contains("Serilog"));
+        assert!(!std::fs::read_to_string(&b).unwrap().contains("Serilog"));
+    }
+
+    #[test]
+    fn consolidate_reports_nothing_when_no_shared_packages() {
+        let td = TempDir::new().unwrap();
+        let root = td.path();
+        let sln = write_solution(root);
+        let _a = write_project(root, "A/A", &[("OnlyA", "1.0.0")]);
+        let _b = write_project(root, "B/B", &[("OnlyB", "1.0.0")]);
+
+        let resp = consolidate(&sln, false).unwrap();
+        assert!(resp.moved.is_empty());
+        assert!(resp.props_file.is_none());
+        // No props file should have been created.
+        assert!(!root.join("Directory.Build.props").exists());
+    }
+
+    #[test]
+    fn dry_run_reports_moves_without_touching_files() {
+        let td = TempDir::new().unwrap();
+        let root = td.path();
+        let sln = write_solution(root);
+        let a = write_project(root, "A/A", &[("Serilog", "3.1.0")]);
+        let b = write_project(root, "B/B", &[("Serilog", "3.1.0")]);
+
+        let resp = consolidate(&sln, true).unwrap();
+        assert_eq!(
+            resp.moved.len(),
+            1,
+            "dry run still reports the shared package"
+        );
+        assert_eq!(resp.moved[0].id, "Serilog");
+        assert!(resp.props_file.is_none());
+        assert!(resp.modified_files.is_empty());
+        // Nothing on disk changed.
+        assert!(!root.join("Directory.Build.props").exists());
+        assert!(std::fs::read_to_string(&a).unwrap().contains("Serilog"));
+        assert!(std::fs::read_to_string(&b).unwrap().contains("Serilog"));
+    }
+
+    #[test]
+    fn consolidate_preserves_existing_props_content() {
+        let td = TempDir::new().unwrap();
+        let root = td.path();
+        let sln = write_solution(root);
+        std::fs::write(
+            root.join("Directory.Build.props"),
+            "<Project>\n  <!-- keep me -->\n</Project>\n",
+        )
+        .unwrap();
+        let _a = write_project(root, "A/A", &[("Serilog", "3.1.0")]);
+        let _b = write_project(root, "B/B", &[("Serilog", "3.1.0")]);
+
+        let resp = consolidate(&sln, false).unwrap();
+        assert_eq!(resp.moved.len(), 1);
+        let props = std::fs::read_to_string(root.join("Directory.Build.props")).unwrap();
+        assert!(props.contains("<!-- keep me -->"), "comment preserved");
+        assert!(props.contains("Serilog"));
+    }
+}

--- a/src/nuget/handlers.rs
+++ b/src/nuget/handlers.rs
@@ -6,9 +6,13 @@ use anyhow::{Context, Result};
 use crossbeam_channel::Sender;
 use lsp_server::{Message, Notification, Request};
 use std::path::Path;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
 use tracing::{error, info};
 
-use super::{cli, search, targets, types, xml_edit};
+use crate::sidecar::manager::SidecarManager;
+
+use super::{cli, consolidate, parse, search, targets, types, unused, xml_edit};
 
 /// Handle `sharplsp/nuget/targets` — enumerate projects and props files.
 pub fn handle_targets(req: Request) -> Result<serde_json::Value> {
@@ -105,6 +109,81 @@ pub fn handle_uninstall(
     finish_with_restore(response, runtime, sender, &target)
 }
 
+/// Handle `sharplsp/nuget/unused` — detect unused direct package references.
+///
+/// Implements [PKG-UNUSED-REQUEST]: the language-appropriate sidecar computes
+/// reference usage; the path → package mapping and intersection with the
+/// project's *direct* references happen here.
+pub fn handle_unused(
+    req: Request,
+    runtime: &Runtime,
+    csharp: Option<&Arc<SidecarManager>>,
+    fsharp: Option<&Arc<SidecarManager>>,
+) -> Result<serde_json::Value> {
+    info!("Handling sharplsp/nuget/unused");
+    let params: types::UnusedParams = serde_json::from_value(req.params)?;
+    let direct = read_direct_refs(&params.project_path)?;
+    let usage = query_reference_usage(&params.project_path, runtime, csharp, fsharp)?;
+    let response = types::UnusedResponse {
+        unused: unused::compute_unused(&usage, &direct),
+        project_path: params.project_path,
+    };
+    Ok(serde_json::to_value(response)?)
+}
+
+/// Read the direct `PackageReference` items declared in a project file.
+fn read_direct_refs(project_path: &str) -> Result<Vec<parse::PackageItem>> {
+    let text =
+        std::fs::read_to_string(project_path).with_context(|| format!("read {project_path}"))?;
+    Ok(parse::read_package_items(&text, "PackageReference"))
+}
+
+/// Query the language-appropriate sidecar for a project's reference usage.
+fn query_reference_usage(
+    project_path: &str,
+    runtime: &Runtime,
+    csharp: Option<&Arc<SidecarManager>>,
+    fsharp: Option<&Arc<SidecarManager>>,
+) -> Result<unused::ReferenceUsage> {
+    let sidecar =
+        pick_package_sidecar(project_path, csharp, fsharp).context("no sidecar for project")?;
+    let payload = rmp_serde::to_vec(project_path)?;
+    let bytes = runtime.block_on(sidecar.request("project/unusedPackages", payload))?;
+    Ok(rmp_serde::from_slice(&bytes)?)
+}
+
+/// Pick the sidecar that owns a project's language (`.fsproj` → F#, else C#).
+fn pick_package_sidecar<'a>(
+    project_path: &str,
+    csharp: Option<&'a Arc<SidecarManager>>,
+    fsharp: Option<&'a Arc<SidecarManager>>,
+) -> Option<&'a Arc<SidecarManager>> {
+    if project_path.to_lowercase().ends_with(".fsproj") {
+        fsharp
+    } else {
+        csharp
+    }
+}
+
+/// Handle `sharplsp/nuget/consolidate` — hoist shared packages to props.
+///
+/// Implements [PKG-CONSOLIDATE-REQUEST]: pure Tier-1 work plus a single
+/// background restore for the files it touched.
+pub fn handle_consolidate(
+    req: Request,
+    runtime: &Runtime,
+    sender: Sender<Message>,
+) -> Result<serde_json::Value> {
+    info!("Handling sharplsp/nuget/consolidate");
+    let params: types::ConsolidateParams = serde_json::from_value(req.params)?;
+    let response = consolidate::consolidate(&params.solution_path, params.dry_run)?;
+    if !params.dry_run && !response.modified_files.is_empty() {
+        let target = types::NuGetTarget::from_project_path(&params.solution_path);
+        spawn_restore(runtime, sender, &target, response.modified_files.clone());
+    }
+    Ok(serde_json::to_value(response)?)
+}
+
 /// Install/uninstall responses that may trigger a background restore.
 trait RestoreOutcome {
     /// Whether the operation succeeded.
@@ -185,32 +264,19 @@ async fn list_installed_for_target(
 /// Read `<PackageReference>` / `<PackageVersion>` entries from a props file.
 fn list_props_packages(path: &str) -> Result<Vec<types::InstalledPackageInfo>> {
     let text = std::fs::read_to_string(path).with_context(|| format!("read {path}"))?;
-    let mut packages = Vec::new();
-    for line in text.lines() {
-        let trimmed = line.trim_start();
-        if !(trimmed.starts_with("<PackageReference") || trimmed.starts_with("<PackageVersion")) {
-            continue;
-        }
-        let Some(id) = extract_attr(line, "Include") else {
-            continue;
-        };
-        let version = extract_attr(line, "Version").unwrap_or_default();
-        packages.push(types::InstalledPackageInfo {
-            id,
-            requested_version: version.clone(),
-            resolved_version: version,
-        });
-    }
-    Ok(packages)
-}
-
-/// Extract the value of an XML attribute (e.g. `Include="..."`) from a line.
-fn extract_attr(line: &str, attr: &str) -> Option<String> {
-    let needle = format!("{attr}=\"");
-    let start = line.find(&needle)? + needle.len();
-    let rest = line.get(start..)?;
-    let end = rest.find('"')?;
-    Some(rest.get(..end)?.to_string())
+    let items = parse::read_package_items(&text, "PackageReference")
+        .into_iter()
+        .chain(parse::read_package_items(&text, "PackageVersion"));
+    Ok(items
+        .map(|item| {
+            let version = item.version.unwrap_or_default();
+            types::InstalledPackageInfo {
+                id: item.id,
+                requested_version: version.clone(),
+                resolved_version: version,
+            }
+        })
+        .collect())
 }
 
 /// Apply install via XML fast path.
@@ -237,7 +303,7 @@ fn apply_install(
         modified.push(target.path.clone());
     }
     if matches!(element, xml_edit::PackageElement::ReferenceNoVersion) {
-        if let Some(props_path) = find_packages_props(path) {
+        if let Some(props_path) = targets::find_packages_props(path) {
             let props_outcome = xml_edit::add_package(
                 &props_path,
                 package_id,
@@ -293,25 +359,10 @@ fn pick_install_element(target: &types::NuGetTarget) -> xml_edit::PackageElement
         xml_edit::PackageElement::Version
     } else if matches!(target.kind, types::TargetKind::BuildProps) {
         xml_edit::PackageElement::Reference
-    } else if find_packages_props(Path::new(&target.path)).is_some() {
+    } else if targets::find_packages_props(Path::new(&target.path)).is_some() {
         xml_edit::PackageElement::ReferenceNoVersion
     } else {
         xml_edit::PackageElement::Reference
-    }
-}
-
-/// Walk up from a csproj looking for a sibling / ancestor
-/// `Directory.Packages.props`. Returns the first one found.
-fn find_packages_props(start: &Path) -> Option<std::path::PathBuf> {
-    let mut dir = start.parent()?.to_path_buf();
-    loop {
-        let candidate = dir.join("Directory.Packages.props");
-        if candidate.exists() {
-            return Some(candidate);
-        }
-        if !dir.pop() {
-            return None;
-        }
     }
 }
 

--- a/src/nuget/mod.rs
+++ b/src/nuget/mod.rs
@@ -5,8 +5,11 @@
 
 pub mod cache;
 pub mod cli;
+pub mod consolidate;
 pub mod handlers;
+pub mod parse;
 pub mod search;
 pub mod targets;
 pub mod types;
+pub mod unused;
 pub mod xml_edit;

--- a/src/nuget/parse.rs
+++ b/src/nuget/parse.rs
@@ -1,0 +1,166 @@
+//! Shared, read-only parsing of `MSBuild` package items.
+//!
+//! Mutation of project/props files always goes through [`super::xml_edit`]
+//! (trivia-preserving). This module only *reads* ids/versions, mirroring the
+//! line-oriented approach the rest of the `nuget` module already uses — it is
+//! the single source of truth for "what `PackageReference` / `PackageVersion`
+//! entries does this file declare?", reused by the installed-listing,
+//! consolidation, and unused-package flows.
+
+/// A `<PackageReference>` / `<PackageVersion>` entry read from an `MSBuild` file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageItem {
+    /// Package id (the `Include` attribute value).
+    pub id: String,
+    /// Version attribute value, if present (`None` for CPM versionless refs).
+    pub version: Option<String>,
+    /// Whether the element is a single self-closing line carrying only
+    /// `Include` / `Version` — i.e. safe to move without losing item metadata
+    /// (`PrivateAssets`, `Condition`, child elements, …).
+    pub simple: bool,
+}
+
+/// Extract the value of an XML attribute (e.g. `Include="..."`) from a line.
+pub fn extract_attr(line: &str, attr: &str) -> Option<String> {
+    let needle = format!("{attr}=\"");
+    let start = line.find(&needle)? + needle.len();
+    let rest = line.get(start..)?;
+    let end = rest.find('"')?;
+    Some(rest.get(..end)?.to_string())
+}
+
+/// Collect the attribute names present on an element line (`Include`, `Version`, …).
+fn attribute_names(line: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for (idx, _) in line.match_indices("=\"") {
+        let prefix = line.get(..idx).unwrap_or("");
+        let reversed: String = prefix
+            .chars()
+            .rev()
+            .take_while(|c| c.is_alphanumeric() || matches!(c, '_' | '-' | ':'))
+            .collect();
+        if !reversed.is_empty() {
+            names.push(reversed.chars().rev().collect());
+        }
+    }
+    names
+}
+
+/// Whether an element line carries only `Include` / `Version` attributes and is
+/// self-closing (so it can be hoisted/removed without dropping metadata).
+fn is_simple(trimmed: &str) -> bool {
+    trimmed.ends_with("/>")
+        && attribute_names(trimmed)
+            .iter()
+            .all(|name| name == "Include" || name == "Version")
+}
+
+/// Read all `<{tag}>` package items from `MSBuild` file text.
+///
+/// `tag` is `"PackageReference"` or `"PackageVersion"`. Entries without an
+/// `Include` attribute are skipped.
+pub fn read_package_items(text: &str, tag: &str) -> Vec<PackageItem> {
+    let open = format!("<{tag}");
+    text.lines()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            if !trimmed.starts_with(&open) {
+                return None;
+            }
+            let id = extract_attr(line, "Include")?;
+            Some(PackageItem {
+                id,
+                version: extract_attr(line, "Version"),
+                simple: is_simple(trimmed),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code — panics are the correct failure mode"
+)]
+mod tests {
+    use super::*;
+
+    const CSPROJ: &str = r#"<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Serilog" Version="3.1.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0" PrivateAssets="all" />
+    <PackageReference Include="Versionless" />
+  </ItemGroup>
+</Project>
+"#;
+
+    #[test]
+    fn extracts_attr_value() {
+        let line = r#"    <PackageReference Include="Foo" Version="1.2.3" />"#;
+        assert_eq!(extract_attr(line, "Include"), Some("Foo".to_string()));
+        assert_eq!(extract_attr(line, "Version"), Some("1.2.3".to_string()));
+        assert_eq!(extract_attr(line, "Missing"), None);
+    }
+
+    #[test]
+    fn reads_all_package_references() {
+        let items = read_package_items(CSPROJ, "PackageReference");
+        let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "Newtonsoft.Json",
+                "Serilog",
+                "StyleCop.Analyzers",
+                "Versionless"
+            ]
+        );
+    }
+
+    #[test]
+    fn versionless_reference_has_none_version() {
+        let items = read_package_items(CSPROJ, "PackageReference");
+        let versionless = items.iter().find(|i| i.id == "Versionless").unwrap();
+        assert_eq!(versionless.version, None);
+        assert!(versionless.simple);
+    }
+
+    #[test]
+    fn reference_with_metadata_is_not_simple() {
+        let items = read_package_items(CSPROJ, "PackageReference");
+        let stylecop = items.iter().find(|i| i.id == "StyleCop.Analyzers").unwrap();
+        assert!(
+            !stylecop.simple,
+            "PrivateAssets metadata must mark the entry non-simple"
+        );
+    }
+
+    #[test]
+    fn plain_reference_is_simple() {
+        let items = read_package_items(CSPROJ, "PackageReference");
+        let serilog = items.iter().find(|i| i.id == "Serilog").unwrap();
+        assert!(serilog.simple);
+    }
+
+    #[test]
+    fn reads_package_versions_from_props() {
+        let props = r#"<Project>
+  <ItemGroup>
+    <PackageVersion Include="Serilog" Version="3.1.0" />
+  </ItemGroup>
+</Project>
+"#;
+        let items = read_package_items(props, "PackageVersion");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "Serilog");
+        assert_eq!(items[0].version, Some("3.1.0".to_string()));
+    }
+
+    #[test]
+    fn ignores_unrelated_tags() {
+        let items = read_package_items(CSPROJ, "PackageVersion");
+        assert!(items.is_empty());
+    }
+}

--- a/src/nuget/targets.rs
+++ b/src/nuget/targets.rs
@@ -191,6 +191,24 @@ fn build_props_target(root: &Path, path: &Path, file_name: &str) -> NuGetTarget 
     }
 }
 
+/// Walk up from a project/file path looking for a sibling or ancestor
+/// `Directory.Packages.props`. Returns the first one found.
+///
+/// Single source of truth for CPM props-file discovery, shared by the install,
+/// consolidation, and unused-package flows.
+pub fn find_packages_props(start: &Path) -> Option<PathBuf> {
+    let mut dir = start.parent()?.to_path_buf();
+    loop {
+        let candidate = dir.join("Directory.Packages.props");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
 /// Parse a `Directory.Packages.props` file for the CPM switch.
 ///
 /// Text search is sufficient — the element is a single bool and any reasonable

--- a/src/nuget/types.rs
+++ b/src/nuget/types.rs
@@ -285,6 +285,78 @@ pub struct UninstallResponse {
     pub modified_files: Vec<String>,
 }
 
+// ── sharplsp/nuget/unused ──────────────────────────────────────────
+// Implements [PKG-UNUSED-REQUEST]
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+/// Parameters for the `sharplsp/nuget/unused` request.
+pub struct UnusedParams {
+    /// Absolute path to the `.csproj` / `.fsproj` to analyse.
+    pub project_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+/// A direct `PackageReference` proven unused by the compilation.
+pub struct UnusedPackage {
+    /// Package identifier.
+    pub id: String,
+    /// Version as declared in the project file (empty for CPM references).
+    pub version: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+/// Response for the `sharplsp/nuget/unused` request.
+pub struct UnusedResponse {
+    /// Project that was analysed.
+    pub project_path: String,
+    /// Direct package references with no used compile assembly.
+    pub unused: Vec<UnusedPackage>,
+}
+
+// ── sharplsp/nuget/consolidate ─────────────────────────────────────
+// Implements [PKG-CONSOLIDATE-REQUEST]
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+/// Parameters for the `sharplsp/nuget/consolidate` request.
+pub struct ConsolidateParams {
+    /// Absolute path to the solution (`.sln`/`.slnx`) being consolidated.
+    pub solution_path: String,
+    /// When true, report what would move without modifying any files.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+/// A package hoisted from per-project references into `Directory.Build.props`.
+pub struct MovedPackage {
+    /// Package identifier.
+    pub id: String,
+    /// Version written into `Directory.Build.props` (empty for CPM).
+    pub version: String,
+    /// Display names of the projects the reference was removed from.
+    pub from_projects: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+/// Response for the `sharplsp/nuget/consolidate` request.
+pub struct ConsolidateResponse {
+    /// Packages moved into `Directory.Build.props`.
+    pub moved: Vec<MovedPackage>,
+    /// Absolute path to the `Directory.Build.props` that was written.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub props_file: Option<String>,
+    /// All files modified by the operation (props + projects).
+    pub modified_files: Vec<String>,
+    /// Human-readable summary of what moved.
+    pub message: String,
+}
+
 // ── sharplsp/nuget/restoreProgress (server → client notification) ──
 
 /// Parameters for the `sharplsp/nuget/restoreProgress` notification.

--- a/src/nuget/unused.rs
+++ b/src/nuget/unused.rs
@@ -1,0 +1,212 @@
+//! [PKG-UNUSED-MAP] Map a project's compilation reference paths to the direct
+//! `PackageReference` entries that are provably unused.
+//!
+//! The sidecars (Roslyn / FCS) do the semantic work and return raw assembly
+//! paths; the path → package-id mapping and the unused determination live here,
+//! in one place, as pure functions — so the logic is unit-tested without a live
+//! compilation and is never duplicated across the two sidecars.
+
+use std::collections::HashSet;
+
+use super::parse::PackageItem;
+use super::types::UnusedPackage;
+
+/// Reference-usage result returned by a sidecar `project/unusedPackages` query.
+///
+/// `MessagePack` positional contract — field order matches the sidecar's
+/// `[Key(0..)]` response type.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct ReferenceUsage {
+    /// Absolute paths of assemblies actually used by the compilation.
+    pub used_paths: Vec<String>,
+    /// Absolute paths of every assembly referenced by the compilation.
+    pub all_paths: Vec<String>,
+    /// The `NuGet` global packages folder the sidecar resolved (may be empty).
+    pub packages_root: String,
+}
+
+/// Marker for the default global packages layout when no root is supplied.
+const NUGET_MARKER: &str = "/.nuget/packages/";
+
+/// Determine which of `direct` references are unused, given the sidecar usage.
+///
+/// A reference is unused iff it contributes at least one compile assembly under
+/// the packages folder (so analyzers / build-only / framework packages are
+/// never flagged) and none of those assemblies is in the used set.
+pub fn compute_unused(usage: &ReferenceUsage, direct: &[PackageItem]) -> Vec<UnusedPackage> {
+    let used = id_set(&usage.used_paths, &usage.packages_root);
+    let with_assembly = id_set(&usage.all_paths, &usage.packages_root);
+
+    direct
+        .iter()
+        .filter(|item| {
+            let key = item.id.to_lowercase();
+            with_assembly.contains(&key) && !used.contains(&key)
+        })
+        .map(|item| UnusedPackage {
+            id: item.id.clone(),
+            version: item.version.clone().unwrap_or_default(),
+        })
+        .collect()
+}
+
+/// Collect the lowercased package ids resolvable from a set of assembly paths.
+fn id_set(paths: &[String], root: &str) -> HashSet<String> {
+    paths
+        .iter()
+        .filter_map(|path| package_id_from_path(path, root))
+        .collect()
+}
+
+/// Extract the (lowercased) `NuGet` package id owning an assembly path.
+///
+/// Restored package assemblies live at
+/// `<root>/<id-lowercased>/<version>/<asset-dir>/.../<assembly>.dll`. The id is
+/// the first path segment under the global packages root, or under the
+/// `/.nuget/packages/` marker when the root is unknown. Returns `None` for
+/// assemblies that are not inside a packages folder (framework / project refs).
+fn package_id_from_path(path: &str, root: &str) -> Option<String> {
+    let normalized = path.replace('\\', "/").to_lowercase();
+
+    let root_normalized = root.replace('\\', "/").to_lowercase();
+    if !root_normalized.is_empty() {
+        let trimmed = root_normalized.trim_end_matches('/');
+        if let Some(rest) = normalized.strip_prefix(trimmed) {
+            return first_segment(rest);
+        }
+    }
+
+    let marker = normalized.find(NUGET_MARKER)?;
+    let rest = normalized.get(marker + NUGET_MARKER.len()..)?;
+    first_segment(rest)
+}
+
+/// First non-empty `/`-delimited segment of a path remainder.
+fn first_segment(rest: &str) -> Option<String> {
+    rest.trim_start_matches('/')
+        .split('/')
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test code — panics are the correct failure mode"
+)]
+mod tests {
+    use super::*;
+
+    /// Build a `PackageItem` for a direct reference fixture.
+    fn item(id: &str, version: &str) -> PackageItem {
+        PackageItem {
+            id: id.to_string(),
+            version: Some(version.to_string()),
+            simple: true,
+        }
+    }
+
+    const ROOT: &str = "/home/u/.nuget/packages";
+
+    #[test]
+    fn maps_assembly_path_to_package_id_via_root() {
+        let path = "/home/u/.nuget/packages/serilog/3.1.0/lib/net8.0/Serilog.dll";
+        assert_eq!(
+            package_id_from_path(path, ROOT),
+            Some("serilog".to_string())
+        );
+    }
+
+    #[test]
+    fn maps_via_marker_when_root_unknown() {
+        let path = "/home/u/.nuget/packages/newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll";
+        assert_eq!(
+            package_id_from_path(path, ""),
+            Some("newtonsoft.json".to_string())
+        );
+    }
+
+    #[test]
+    fn maps_windows_style_paths() {
+        let path = r"C:\Users\u\.nuget\packages\Serilog\3.1.0\lib\net8.0\Serilog.dll";
+        assert_eq!(
+            package_id_from_path(path, r"C:\Users\u\.nuget\packages"),
+            Some("serilog".to_string())
+        );
+    }
+
+    #[test]
+    fn framework_assembly_maps_to_no_package() {
+        let path = "/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.0/System.Runtime.dll";
+        assert_eq!(package_id_from_path(path, ROOT), None);
+    }
+
+    #[test]
+    fn flags_package_with_assembly_present_but_unused() {
+        let usage = ReferenceUsage {
+            used_paths: vec![format!("{ROOT}/serilog/3.1.0/lib/net8.0/Serilog.dll")],
+            all_paths: vec![
+                format!("{ROOT}/serilog/3.1.0/lib/net8.0/Serilog.dll"),
+                format!("{ROOT}/newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll"),
+            ],
+            packages_root: ROOT.to_string(),
+        };
+        let direct = vec![item("Serilog", "3.1.0"), item("Newtonsoft.Json", "13.0.3")];
+        let unused = compute_unused(&usage, &direct);
+        assert_eq!(unused.len(), 1);
+        assert_eq!(unused[0].id, "Newtonsoft.Json");
+        assert_eq!(unused[0].version, "13.0.3");
+    }
+
+    #[test]
+    fn never_flags_package_with_no_compile_assembly() {
+        // StyleCop.Analyzers contributes no compile assembly → not in all_paths.
+        let usage = ReferenceUsage {
+            used_paths: vec![format!("{ROOT}/serilog/3.1.0/lib/net8.0/Serilog.dll")],
+            all_paths: vec![format!("{ROOT}/serilog/3.1.0/lib/net8.0/Serilog.dll")],
+            packages_root: ROOT.to_string(),
+        };
+        let direct = vec![
+            item("Serilog", "3.1.0"),
+            item("StyleCop.Analyzers", "1.2.0"),
+        ];
+        let unused = compute_unused(&usage, &direct);
+        assert!(
+            unused.is_empty(),
+            "analyzer without a compile assembly must not be flagged"
+        );
+    }
+
+    #[test]
+    fn case_insensitive_id_match() {
+        let usage = ReferenceUsage {
+            used_paths: vec![],
+            all_paths: vec![format!(
+                "{ROOT}/automapper/12.0.0/lib/net6.0/AutoMapper.dll"
+            )],
+            packages_root: ROOT.to_string(),
+        };
+        // Project declares mixed-case id; folder is lowercased.
+        let direct = vec![item("AutoMapper", "12.0.0")];
+        let unused = compute_unused(&usage, &direct);
+        assert_eq!(unused.len(), 1);
+        assert_eq!(unused[0].id, "AutoMapper", "original casing preserved");
+    }
+
+    #[test]
+    fn transitive_package_not_in_direct_refs_is_ignored() {
+        // A used-nowhere assembly that the project does not directly reference
+        // must not be reported (it is not in `direct`).
+        let usage = ReferenceUsage {
+            used_paths: vec![],
+            all_paths: vec![format!(
+                "{ROOT}/transitive.dep/1.0.0/lib/net8.0/Transitive.Dep.dll"
+            )],
+            packages_root: ROOT.to_string(),
+        };
+        let direct = vec![item("Serilog", "3.1.0")];
+        let unused = compute_unused(&usage, &direct);
+        assert!(unused.is_empty());
+    }
+}

--- a/tests/e2e_modules/fixtures.rs
+++ b/tests/e2e_modules/fixtures.rs
@@ -169,6 +169,85 @@ EndGlobal"#,
     (tmp, root_uri, file_uri, cs_source.to_string())
 }
 
+/// Create a workspace whose single project references `Newtonsoft.Json` but
+/// never uses it — so a real Roslyn `GetUsedAssemblyReferences` pass flags the
+/// package as unused. Returns `(TempDir, root_uri, sln_path, csproj_path,
+/// file_uri, source)`. Used by the `sharplsp/nuget/unused` full-stack test.
+pub fn create_unused_packages_workspace(
+) -> (tempfile::TempDir, String, String, String, String, String) {
+    let tmp = tempfile::tempdir().unwrap();
+    let proj_dir = tmp.path().join("UnusedPkg");
+    std::fs::create_dir_all(&proj_dir).unwrap();
+
+    std::fs::write(
+        proj_dir.join("UnusedPkg.csproj"),
+        r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>"#,
+    )
+    .unwrap();
+
+    // Source uses only the framework — Newtonsoft.Json is referenced but never
+    // touched, which is exactly what makes it "unused".
+    let cs_source = r#"namespace UnusedPkg;
+
+public class Greeter
+{
+    public string Greet(string name) => $"Hello, {name}!";
+
+    public int Count { get; set; }
+}"#;
+    std::fs::write(proj_dir.join("Program.cs"), cs_source).unwrap();
+
+    std::fs::write(
+        tmp.path().join("UnusedPkg.sln"),
+        r#"Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnusedPkg", "UnusedPkg/UnusedPkg.csproj", "{00000000-0000-0000-0000-000000000003}"
+EndProject
+Global
+EndGlobal"#,
+    )
+    .unwrap();
+
+    let restore = std::process::Command::new("dotnet")
+        .args(["restore", "--verbosity", "quiet"])
+        // Restore the project directly so obj/project.assets.json is written and
+        // the Newtonsoft.Json compile assembly resolves for the design-time build.
+        .current_dir(&proj_dir)
+        .status()
+        .expect("dotnet restore failed to start");
+    assert!(restore.success(), "dotnet restore must succeed");
+
+    let real_root = std::fs::canonicalize(tmp.path()).unwrap();
+    let real_proj = real_root.join("UnusedPkg");
+    let root_uri = format!("file://{}", real_root.display());
+    let sln_path = real_root
+        .join("UnusedPkg.sln")
+        .to_string_lossy()
+        .into_owned();
+    let csproj_path = real_proj
+        .join("UnusedPkg.csproj")
+        .to_string_lossy()
+        .into_owned();
+    let file_uri = format!("file://{}", real_proj.join("Program.cs").display());
+    (
+        tmp,
+        root_uri,
+        sln_path,
+        csproj_path,
+        file_uri,
+        cs_source.to_string(),
+    )
+}
+
 /// Create an F# test workspace with .fsproj and .fs files.
 pub fn create_fsharp_test_workspace() -> (tempfile::TempDir, String, String, String) {
     let tmp = tempfile::tempdir().unwrap();

--- a/tests/e2e_modules/mod.rs
+++ b/tests/e2e_modules/mod.rs
@@ -50,6 +50,7 @@ pub mod inlay_hints_tests;
 pub mod lifecycle;
 pub mod logging;
 pub mod lsp_features;
+pub mod nuget_unused_full_stack;
 pub mod profiler;
 pub mod profiler_edge_cases;
 pub mod profiler_full_stack;

--- a/tests/e2e_modules/nuget_unused_full_stack.rs
+++ b/tests/e2e_modules/nuget_unused_full_stack.rs
@@ -1,0 +1,80 @@
+//! Full-stack e2e for `sharplsp/nuget/unused`: load a real solution into the
+//! Roslyn sidecar and prove an unused `PackageReference` is detected through
+//! the live compilation. Implements [PKG-UNUSED-DETECT-CS] / [PKG-UNUSED-REQUEST].
+
+use super::*;
+
+/// Poll the unused query until the solution has finished loading into the
+/// sidecar (success result) or the timeout elapses. `loadSolution` is async, so
+/// the project resolves a few seconds after the request returns.
+fn poll_unused_until_ready(client: &mut LspClient, project_path: &str, timeout: Duration) -> Value {
+    std::thread::sleep(Duration::from_secs(5));
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let resp = client.request(
+            "sharplsp/nuget/unused",
+            json!({ "projectPath": project_path }),
+        );
+        if resp.get("error").is_none() {
+            return resp["result"].clone();
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "unused query never succeeded within {}s — sidecar did not load the solution: {resp}",
+            timeout.as_secs(),
+        );
+        std::thread::sleep(Duration::from_secs(2));
+    }
+}
+
+#[test]
+fn test_full_stack_unused_packages_detects_newtonsoft() {
+    require_dotnet();
+
+    let (_tmp, root_uri, sln_path, csproj_path, file_uri, source) =
+        create_unused_packages_workspace();
+    let mut client = LspClient::start_verbose();
+    let _ = client.initialize_with_root(json!(root_uri));
+    client.open_document(&file_uri, &source);
+
+    // Warm the sidecar on the open document, mirroring the other full-stack
+    // tests, so the subsequent loadSolution lands on a live Roslyn workspace.
+    let _ = poll_hover_until_ready(&mut client, &file_uri, 2, 18, Duration::from_secs(90));
+
+    let load = client.request("sharplsp/loadSolution", json!({ "solutionPath": sln_path }));
+    assert_eq!(load["jsonrpc"], "2.0", "loadSolution is JSON-RPC 2.0");
+    assert!(
+        load.get("error").is_none(),
+        "loadSolution must not error: {load}"
+    );
+
+    let result = poll_unused_until_ready(&mut client, &csproj_path, Duration::from_secs(90));
+
+    // The response echoes the analysed project path.
+    assert_eq!(
+        result["projectPath"].as_str(),
+        Some(csproj_path.as_str()),
+        "response echoes the analysed project path"
+    );
+
+    // Newtonsoft.Json is referenced but never used → it must be flagged.
+    let unused = result["unused"].as_array().expect("unused array");
+    assert!(
+        unused
+            .iter()
+            .any(|p| p["id"].as_str() == Some("Newtonsoft.Json")),
+        "Newtonsoft.Json is referenced but unused — it must be flagged: {unused:?}"
+    );
+    let newtonsoft = unused
+        .iter()
+        .find(|p| p["id"].as_str() == Some("Newtonsoft.Json"))
+        .expect("Newtonsoft.Json present (asserted above)");
+    assert_eq!(
+        newtonsoft["version"].as_str(),
+        Some("13.0.3"),
+        "the declared version is reported back: {newtonsoft}"
+    );
+
+    client.shutdown_and_exit();
+    client.wait_with_timeout();
+}

--- a/tests/nuget_e2e.rs
+++ b/tests/nuget_e2e.rs
@@ -1196,3 +1196,422 @@ fn nuget_install_missing_params_returns_error() {
 
     client.shutdown_and_exit();
 }
+
+// ── sharplsp/nuget/consolidate ─────────────────────────────────────
+// Implements [PKG-CONSOLIDATE-REQUEST]. The pure consolidation logic is unit
+// tested in `src/nuget/consolidate.rs`; these drive the LSP request end to end
+// through the spawned server, asserting the wire contract and on-disk effects.
+
+/// A `.csproj` referencing two shared packages plus one unique to it.
+fn shared_csproj(unique_id: &str, nj_version: &str, serilog_version: &str) -> String {
+    format!(
+        r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="{nj_version}" />
+    <PackageReference Include="Serilog" Version="{serilog_version}" />
+    <PackageReference Include="{unique_id}" Version="1.0.0" />
+  </ItemGroup>
+</Project>
+"#
+    )
+}
+
+/// Two-project solution where `Newtonsoft.Json` + `Serilog` are shared (at
+/// differing versions) and each project also has a unique reference. Returns
+/// `(TempDir, sln path, Core.csproj path, Api.csproj path)`.
+fn make_shared_package_solution() -> (TempDir, String, std::path::PathBuf, std::path::PathBuf) {
+    let td = TempDir::new().unwrap();
+    let root = td.path().to_path_buf();
+    write_file(&root, "App.sln", "Microsoft Visual Studio Solution File\n");
+    write_file(
+        &root,
+        "src/Core/Core.csproj",
+        &shared_csproj("OnlyCore", "13.0.3", "3.1.0"),
+    );
+    write_file(
+        &root,
+        "src/Api/Api.csproj",
+        &shared_csproj("OnlyApi", "13.0.4", "3.0.1"),
+    );
+    let sln = root.join("App.sln").to_string_lossy().into_owned();
+    let core = root.join("src/Core/Core.csproj");
+    let api = root.join("src/Api/Api.csproj");
+    (td, sln, core, api)
+}
+
+/// Locate a moved package by id within a consolidate result's `moved` array.
+/// The callers always assert the package is present first.
+fn moved_pkg<'a>(result: &'a Value, id: &str) -> &'a Value {
+    result["moved"]
+        .as_array()
+        .expect("moved array")
+        .iter()
+        .find(|m| m["id"].as_str() == Some(id))
+        .expect("moved package present")
+}
+
+#[test]
+fn nuget_consolidate_dry_run_previews_shared_without_touching_files() {
+    let (workspace, sln, core, api) = make_shared_package_solution();
+    let core_before = std::fs::read_to_string(&core).unwrap();
+    let api_before = std::fs::read_to_string(&api).unwrap();
+
+    let mut client = LspClient::start();
+    client.initialize();
+
+    let resp = client.request(
+        "sharplsp/nuget/consolidate",
+        json!({ "solutionPath": sln, "dryRun": true }),
+    );
+
+    assert!(
+        resp.get("error").is_none(),
+        "dry-run consolidate should succeed: {resp}"
+    );
+    let result = &resp["result"];
+
+    // Exactly the two shared packages, alpha-ordered (BTreeMap key order).
+    let moved = result["moved"].as_array().expect("moved array");
+    assert_eq!(
+        moved.len(),
+        2,
+        "two packages are shared across both projects"
+    );
+    assert_eq!(
+        moved[0]["id"].as_str(),
+        Some("Newtonsoft.Json"),
+        "moved list is alphabetised"
+    );
+    assert_eq!(moved[1]["id"].as_str(), Some("Serilog"));
+
+    // Highest version across projects wins.
+    assert_eq!(
+        moved_pkg(result, "Newtonsoft.Json")["version"].as_str(),
+        Some("13.0.4"),
+        "highest Newtonsoft version reported"
+    );
+    assert_eq!(
+        moved_pkg(result, "Serilog")["version"].as_str(),
+        Some("3.1.0"),
+        "highest Serilog version reported"
+    );
+
+    // Each shared package lists both declaring projects.
+    let nj_from = moved_pkg(result, "Newtonsoft.Json")["fromProjects"]
+        .as_array()
+        .expect("fromProjects array");
+    assert_eq!(nj_from.len(), 2, "Newtonsoft declared in both projects");
+    let names: Vec<&str> = nj_from.iter().filter_map(|v| v.as_str()).collect();
+    assert!(names.contains(&"Core.csproj"), "names: {names:?}");
+    assert!(names.contains(&"Api.csproj"), "names: {names:?}");
+
+    // Dry run is non-destructive: no props file, no modified files, no writes.
+    assert!(
+        result.get("propsFile").is_none() || result["propsFile"].is_null(),
+        "dry run reports no props file: {result}"
+    );
+    assert!(
+        result["modifiedFiles"]
+            .as_array()
+            .expect("modifiedFiles array")
+            .is_empty(),
+        "dry run modifies nothing"
+    );
+    assert!(
+        result["message"].as_str().unwrap().contains("shared"),
+        "message describes the shared packages: {result}"
+    );
+    assert!(
+        !workspace.path().join("Directory.Build.props").exists(),
+        "dry run must not create Directory.Build.props"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&core).unwrap(),
+        core_before,
+        "dry run leaves Core.csproj byte-for-byte unchanged"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&api).unwrap(),
+        api_before,
+        "dry run leaves Api.csproj byte-for-byte unchanged"
+    );
+
+    client.shutdown_and_exit();
+}
+
+#[test]
+fn nuget_consolidate_apply_hoists_shared_into_build_props() {
+    let (workspace, sln, core, api) = make_shared_package_solution();
+
+    let mut client = LspClient::start();
+    client.initialize();
+
+    let resp = client.request(
+        "sharplsp/nuget/consolidate",
+        json!({ "solutionPath": sln, "dryRun": false }),
+    );
+
+    assert!(
+        resp.get("error").is_none(),
+        "apply consolidate should succeed: {resp}"
+    );
+    let result = &resp["result"];
+
+    // Both shared packages were moved.
+    assert_eq!(
+        result["moved"].as_array().expect("moved array").len(),
+        2,
+        "both shared packages moved"
+    );
+
+    // A Directory.Build.props at the solution root was written and reported.
+    let props_file = result["propsFile"]
+        .as_str()
+        .expect("propsFile set on apply");
+    assert!(
+        props_file.ends_with("Directory.Build.props"),
+        "propsFile points at the build props: {props_file}"
+    );
+    let props_path = workspace.path().join("Directory.Build.props");
+    assert!(props_path.exists(), "Directory.Build.props created on disk");
+
+    // modifiedFiles covers the props file + both projects.
+    let modified: Vec<String> = result["modifiedFiles"]
+        .as_array()
+        .expect("modifiedFiles array")
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_owned))
+        .collect();
+    assert!(
+        modified
+            .iter()
+            .any(|f| f.ends_with("Directory.Build.props")),
+        "props file reported modified: {modified:?}"
+    );
+    assert!(
+        modified.iter().any(|f| f.ends_with("Core.csproj")),
+        "Core.csproj reported modified: {modified:?}"
+    );
+    assert!(
+        modified.iter().any(|f| f.ends_with("Api.csproj")),
+        "Api.csproj reported modified: {modified:?}"
+    );
+
+    // The props file now declares both shared packages at their highest version.
+    let props_text = std::fs::read_to_string(&props_path).unwrap();
+    assert!(
+        props_text.contains("Include=\"Newtonsoft.Json\" Version=\"13.0.4\""),
+        "props declares Newtonsoft 13.0.4: {props_text}"
+    );
+    assert!(
+        props_text.contains("Include=\"Serilog\" Version=\"3.1.0\""),
+        "props declares Serilog 3.1.0: {props_text}"
+    );
+
+    // Shared refs are stripped from each project; the unique refs remain.
+    let core_text = std::fs::read_to_string(&core).unwrap();
+    let api_text = std::fs::read_to_string(&api).unwrap();
+    assert!(
+        !core_text.contains("Newtonsoft.Json") && !core_text.contains("Serilog"),
+        "shared refs removed from Core.csproj: {core_text}"
+    );
+    assert!(
+        !api_text.contains("Newtonsoft.Json") && !api_text.contains("Serilog"),
+        "shared refs removed from Api.csproj: {api_text}"
+    );
+    assert!(
+        core_text.contains("OnlyCore"),
+        "Core's unique package is preserved: {core_text}"
+    );
+    assert!(
+        api_text.contains("OnlyApi"),
+        "Api's unique package is preserved: {api_text}"
+    );
+    assert!(
+        result["message"]
+            .as_str()
+            .unwrap()
+            .contains("Newtonsoft.Json"),
+        "summary names the moved packages: {result}"
+    );
+
+    client.shutdown_and_exit();
+}
+
+#[test]
+fn nuget_consolidate_no_shared_packages_moves_nothing() {
+    let td = TempDir::new().unwrap();
+    let root = td.path();
+    write_file(root, "App.sln", "Microsoft Visual Studio Solution File\n");
+    write_file(
+        root,
+        "src/A/A.csproj",
+        r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="OnlyA" Version="1.0.0" />
+  </ItemGroup>
+</Project>
+"#,
+    );
+    write_file(
+        root,
+        "src/B/B.csproj",
+        r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="OnlyB" Version="2.0.0" />
+  </ItemGroup>
+</Project>
+"#,
+    );
+    let sln = root.join("App.sln").to_string_lossy().into_owned();
+
+    let mut client = LspClient::start();
+    client.initialize();
+
+    let resp = client.request(
+        "sharplsp/nuget/consolidate",
+        json!({ "solutionPath": sln, "dryRun": false }),
+    );
+
+    assert!(
+        resp.get("error").is_none(),
+        "consolidate with no shared packages should still succeed: {resp}"
+    );
+    let result = &resp["result"];
+    assert!(
+        result["moved"].as_array().expect("moved array").is_empty(),
+        "nothing is shared, so nothing moves: {result}"
+    );
+    assert!(
+        result["modifiedFiles"]
+            .as_array()
+            .expect("modifiedFiles array")
+            .is_empty(),
+        "no files modified when nothing is shared"
+    );
+    assert!(
+        result.get("propsFile").is_none() || result["propsFile"].is_null(),
+        "no props file when nothing is shared"
+    );
+    assert!(
+        !root.join("Directory.Build.props").exists(),
+        "Directory.Build.props must not be created when nothing is shared"
+    );
+
+    client.shutdown_and_exit();
+}
+
+#[test]
+fn nuget_consolidate_dry_run_defaults_off_when_param_omitted() {
+    // `dryRun` is `#[serde(default)]`; omitting it must default to false (apply).
+    let (workspace, sln, _core, _api) = make_shared_package_solution();
+    let mut client = LspClient::start();
+    client.initialize();
+
+    let resp = client.request("sharplsp/nuget/consolidate", json!({ "solutionPath": sln }));
+
+    assert!(
+        resp.get("error").is_none(),
+        "consolidate without dryRun should default to apply: {resp}"
+    );
+    assert!(
+        workspace.path().join("Directory.Build.props").exists(),
+        "omitted dryRun defaults to false → files are written"
+    );
+
+    client.shutdown_and_exit();
+}
+
+#[test]
+fn nuget_consolidate_missing_solution_param_returns_error() {
+    let mut client = LspClient::start();
+    client.initialize();
+
+    let resp = client.request("sharplsp/nuget/consolidate", json!({ "dryRun": true }));
+
+    assert!(
+        resp.get("error").is_some(),
+        "missing solutionPath should return an error: {resp}"
+    );
+
+    client.shutdown_and_exit();
+}
+
+// ── sharplsp/nuget/unused (error/routing paths) ────────────────────
+// Implements [PKG-UNUSED-REQUEST]. The success path (a real Roslyn compilation
+// with a flagged package) is a full-stack test in `e2e_modules`; these cover
+// the host-side request handling, project-file reading, and language routing.
+
+#[test]
+fn nuget_unused_unloaded_csproj_returns_error() {
+    // A real, readable project that no solution has loaded into a sidecar:
+    // read_direct_refs succeeds, the sidecar query fails → an LSP error.
+    let td = TempDir::new().unwrap();
+    let root = td.path();
+    write_file(root, "App.csproj", BARE_CSPROJ);
+    let csproj = root.join("App.csproj");
+
+    let mut client = LspClient::start();
+    client.initialize();
+
+    let resp = client.request(
+        "sharplsp/nuget/unused",
+        json!({ "projectPath": csproj.to_str().unwrap() }),
+    );
+
+    assert!(
+        resp.get("error").is_some(),
+        "unused on an unloaded project must return an error: {resp}"
+    );
+
+    client.shutdown_and_exit();
+}
+
+#[test]
+fn nuget_unused_fsproj_routes_to_fsharp_sidecar() {
+    // A `.fsproj` path must route through the F# sidecar branch of
+    // pick_package_sidecar. With nothing loaded it still resolves to an error.
+    let td = TempDir::new().unwrap();
+    let root = td.path();
+    write_file(root, "Lib.fsproj", BARE_FSPROJ);
+    let fsproj = root.join("Lib.fsproj");
+
+    let mut client = LspClient::start();
+    client.initialize();
+
+    let resp = client.request(
+        "sharplsp/nuget/unused",
+        json!({ "projectPath": fsproj.to_str().unwrap() }),
+    );
+
+    assert!(
+        resp.get("error").is_some(),
+        "unused on an unloaded fsproj must return an error: {resp}"
+    );
+
+    client.shutdown_and_exit();
+}
+
+#[test]
+fn nuget_unused_missing_project_file_returns_error() {
+    // read_direct_refs cannot open the file → the handler surfaces an error.
+    let mut client = LspClient::start();
+    client.initialize();
+
+    let resp = client.request(
+        "sharplsp/nuget/unused",
+        json!({ "projectPath": "/nonexistent/Ghost.csproj" }),
+    );
+
+    assert!(
+        resp.get("error").is_some(),
+        "unused on a missing project file must return an error: {resp}"
+    );
+
+    client.shutdown_and_exit();
+}


### PR DESCRIPTION
## Summary

Adds two NuGet package-maintenance actions to the explorer, treating C# and F# as first-class:

- **Remove Unused Packages** — context menu on **project** *and* **solution** nodes. Detects `PackageReference` entries with no used compile assembly and removes them.
  - **C#** via Roslyn `Compilation.GetUsedAssemblyReferences()`.
  - **F#** via FCS `GetAllUsesOfAllSymbols()` over an isolated project built from `obj/project.assets.json` (fail-safe: any uncertainty → flags nothing).
  - Assembly-path → package-id mapping lives **once** in Rust (`src/nuget/unused.rs`).
- **Consolidate Packages** — context menu on the **solution** node. Hoists packages shared by ≥2 projects into a solution-root `Directory.Build.props` (CPM-aware), stripping the per-project references. Supports a non-destructive `dryRun` preview.

Implements `[PKG-UNUSED-*]` and `[PKG-CONSOLIDATE-*]` (see `docs/specs/PACKAGE-MAINTENANCE-SPEC.md`).

## Architecture

- **Rust host**: `sharplsp/nuget/unused` + `sharplsp/nuget/consolidate` custom requests; sidecar routing by file extension (`.fsproj` → F#); consolidation is pure Tier-1 logic reusing `xml_edit`/`targets`/`parse`.
- **C# sidecar**: `WorkspaceManager.GetReferenceUsageAsync` + `project/unusedPackages` handler.
- **F# sidecar**: new `FSharpPackages.fs` reference-usage module.

## DRY

- Shared `src/nuget/parse.rs` (`read_package_items`, `extract_attr`); removed the duplicate reader from `handlers.rs`.
- `find_packages_props` centralized in `targets.rs`.
- F# `parseFsprojSourceFiles` / `frameworkReferenceArgs` made `internal` and reused (no copy).
- Deslop rescan: no new duplication clusters in the feature files.

## Tests — real e2e, no mocks

- **Rust LSP e2e** (`tests/nuget_e2e.rs`): consolidate dry-run / apply / no-shared / default-dryRun / missing-param; unused unloaded / F#-routing / missing-file.
- **Rust full-stack** (`tests/e2e_modules/nuget_unused_full_stack.rs`): loads a real solution into the Roslyn sidecar and asserts an unused `Newtonsoft.Json` reference is detected through the live compilation.
- **C# sidecar** (`WorkspaceManagerPackagesCoverageTests.cs`) and **F# sidecar** (`FSharpPackagesTests.fs`): the detection runs end-to-end through real Roslyn / FCS, plus fail-safe paths.
- **VS Code** (`context-menus.test.ts`): menu contributions, `collectProjectPaths`, and real-LSP `consolidate`/`unused` requests + command execution.

## Local verification (all four CI jobs reproduced green)

- **lint**: `cargo fmt`/clippy (rust + zed), csharpier, `_lint-dotnet` warnaserror (0 warnings), sidecar pack smoke, prettier, eslint + tsc — all clean.
- **test-rust**: 604/604 pass; coverage **92.36%**.
- **test-dotnet**: 542 sidecar tests pass (Common 43, C# 316, F# 183); coverage C# 89.04% / F# 80.52% / common 81.17%.
- **test-vsix**: full VS Code e2e green; coverage **72.46%** (ratchets the floor 71.14% → 71.45%).