### PR TITLE
fix(vscode): Remove Unused Packages no-op on .NET 10 ("N failed")

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -5,7 +5,7 @@
     "line_percent": 92.39
   },
   "vscode-extension": {
-    "line_percent": 71.45
+    "line_percent": 71.58
   },
   "sharplsp-sidecar-csharp": {
     "line_percent": 88.48

--- a/editors/vscode/src/dependencies.ts
+++ b/editors/vscode/src/dependencies.ts
@@ -141,7 +141,12 @@ export async function removeNuGetPackage(
 ): Promise<string | undefined> {
   try {
     log.info(`Removing NuGet package ${packageName} from ${projectPath}`);
-    await execFileAsync('dotnet', ['remove', projectPath, 'package', packageName]);
+    // Use `dotnet package remove <name> --project <path>` (the .NET 10 verb-noun
+    // form). The legacy `dotnet remove <path> package <name>` silently ignores the
+    // positional project and resolves against the *current working directory*
+    // instead — which, for the extension host, is the workspace root, not the
+    // project's folder — so every removal failed with "Could not find any project".
+    await execFileAsync('dotnet', ['package', 'remove', packageName, '--project', projectPath]);
     return undefined;
   } catch (err: unknown) {
     const msg = getErrorMessage(err);

--- a/editors/vscode/src/test/suite/unit-dependencies.test.ts
+++ b/editors/vscode/src/test/suite/unit-dependencies.test.ts
@@ -2,7 +2,11 @@ import * as assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { parseProjectXml, parseProjectDependencies } from '../../dependencies.js';
+import {
+  parseProjectXml,
+  parseProjectDependencies,
+  removeNuGetPackage,
+} from '../../dependencies.js';
 
 const SINGLE_PACKAGE_XML = `
 <Project Sdk="Microsoft.NET.Sdk">
@@ -186,5 +190,41 @@ suite('Dependencies Module — parseProjectDependencies()', () => {
     const result = parseProjectDependencies(filePath);
     assert.strictEqual(result.nugetPackages.length, 0);
     assert.strictEqual(result.projectReferences.length, 0);
+  });
+});
+
+// Coarse e2e over the real `dotnet` CLI: the removal path behind
+// "Remove Unused Packages" must actually delete the <PackageReference> from a
+// project that lives OUTSIDE the current working directory — exactly how the
+// extension host invokes it (cwd = workspace root, project in a subfolder).
+suite('Dependencies Module — removeNuGetPackage() (real dotnet)', () => {
+  let tmpDir: string;
+
+  setup(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sharplsp-remove-pkg-'));
+  });
+
+  teardown(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('removes a PackageReference from a project outside the cwd', async function () {
+    this.timeout(60_000);
+    const projectPath = path.join(tmpDir, 'RemoveMe.csproj');
+    fs.writeFileSync(projectPath, SINGLE_PACKAGE_XML, 'utf-8');
+    assert.ok(
+      fs.readFileSync(projectPath, 'utf8').includes('Newtonsoft.Json'),
+      'precondition: the package is present before removal',
+    );
+
+    // The function shells out to `dotnet`; it must resolve the project from the
+    // absolute path we hand it, NOT from process.cwd() (which is not tmpDir).
+    const error = await removeNuGetPackage(projectPath, 'Newtonsoft.Json');
+
+    assert.strictEqual(error, undefined, `removal must succeed, got error: ${error ?? ''}`);
+    assert.ok(
+      !fs.readFileSync(projectPath, 'utf8').includes('Newtonsoft.Json'),
+      'the <PackageReference> must be gone from the project file after removal',
+    );
   });
 });


### PR DESCRIPTION
## Problem

Running **Remove Unused Packages** (solution or project node) reported
`Removed 0 package(s); N failed: …` — every detected package failed to remove.

## Root cause

`dotnet remove <project> package <name>` **silently ignores the positional
project path on .NET SDK 10** and resolves against the *current working
directory* instead. For the extension host the cwd is the workspace root, not
the project's folder, so the command errors with `Could not find any project in
<cwd>` and nothing is removed.

This is an isolated .NET 10 regression: `dotnet add … package`,
`dotnet add … reference`, and `dotnet remove … reference` all still honor the
positional project from any cwd — only `remove … package` broke.

## Fix

Switch to the .NET 10 verb-noun form
`dotnet package remove <name> --project <path>`, which honors an explicit
project path regardless of cwd. One line in `editors/vscode/src/dependencies.ts`.

## Test

Added a coarse e2e test (`unit-dependencies.test.ts`) that writes a real
`.csproj` **outside** the cwd and asserts the real `removeNuGetPackage` deletes
the `<PackageReference>` — it fails against the old command and passes with the
fix. Full VS Code suite: **510 passing**, coverage 72.58% (ratcheted 71.45 → 71.58).