### PR TITLE
fix(fsharp): hover honors the live editor buffer (didChange overlay)

### DIFF
--- a/docs/specs/HOVER-SPEC.md
+++ b/docs/specs/HOVER-SPEC.md
@@ -143,6 +143,19 @@ F# hover follows the same Markdown structure as C#:
 | Discriminated union cases | Show case fields with types |
 | Record fields | Show field type and containing record |
 
+### 5.4 Live-Buffer Resolution `[FS-DIDCHANGE-OVERLAY]`
+
+Hover MUST resolve against the editor's **in-memory buffer**, not the on-disk
+file. The Rust host forwards `textDocument/didOpen`/`didChange` to the document's
+own sidecar (F# → F# sidecar, C# → C# sidecar); routing by language is mandatory,
+since a misrouted edit leaves the owning sidecar resolving positions against stale
+text. The F# sidecar keeps an in-memory overlay keyed by absolute file path and
+every per-file analysis (hover, completion, signature help, …) reads source via
+that overlay, falling back to disk only when no open buffer exists. This restores
+F# to parity with C#, whose Roslyn workspace is already updated in place on
+`didChange`. Without this, F# hover misaligns the moment the buffer diverges from
+disk (i.e. as soon as the user types) and returns the wrong symbol or `null`.
+
 ## 6. Caching Strategy
 
 Hover results are cached via the [salsa](https://salsa-rs.github.io/salsa/) incremental computation database in the Rust host.

--- a/sidecars/SharpLsp.Sidecar.FSharp.Tests/FSharpExtraCoverageTests.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp.Tests/FSharpExtraCoverageTests.fs
@@ -38,6 +38,7 @@ type SidecarErrorBranchTests(fixture: SidecarFixture) =
     [<InlineData("workspace/open")>]
     [<InlineData("solution/read")>]
     [<InlineData("textDocument/hover")>]
+    [<InlineData("textDocument/didChange")>]
     [<InlineData("project/unusedPackages")>]
     [<InlineData("textDocument/definition")>]
     [<InlineData("textDocument/typeDefinition")>]
@@ -325,6 +326,39 @@ let ``inlay hints surface on the loaded file`` () =
         let ws, src = loaded.Value
         let! hints = FSharpFeatures.getInlayHints ws src 0 100
         Assert.NotEmpty(hints)
+    }
+
+/// Hover resolves against the in-memory `didChange` overlay rather than the
+/// on-disk file: an unsaved binding that exists ONLY in the editor buffer must
+/// be hoverable. Regression for "F# hover is broken after typing". Uses an
+/// isolated workspace so the overlay never leaks into the shared `loaded`.
+/// [FS-DIDCHANGE-OVERLAY]
+[<Fact>]
+let ``getHover reads the didChange overlay instead of on-disk source`` () =
+    task {
+        let dir = createTestProject ()
+        try
+            let ws = FSharpWorkspace.create ()
+            let! _ = FSharpWorkspace.loadProject ws dir
+            let src = Path.Combine(dir, "Library.fs")
+            // Edited buffer: append a binding present only in memory, never on disk.
+            let edited =
+                File.ReadAllText(src)
+                + "\n/// Present only in the editor buffer, never on disk.\n"
+                + "let overlayOnlyBinding (a: int) (b: int) : int = a - b\n"
+            FSharpWorkspace.applyDidChange ws src edited
+
+            let lines = edited.Replace("\r\n", "\n").Split('\n')
+            let lineIdx =
+                lines |> Array.findIndex (fun l -> l.Contains "let overlayOnlyBinding")
+            let col = lines[lineIdx].IndexOf("overlayOnlyBinding") + 2
+
+            let! h = FSharpWorkspace.getHover ws src lineIdx col
+            Assert.True(h.IsSome, "hover must resolve the overlay-only binding")
+            let markdown, _, _, _, _ = h.Value
+            Assert.Contains("overlayOnlyBinding", markdown)
+        finally
+            try Directory.Delete(dir, true) with _ -> ()
     }
 
 // ── Program entry point: --version path ──────────────────────────

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpSidecar.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpSidecar.fs
@@ -82,6 +82,19 @@ type FSharpSidecar() =
                     return ByteResult.Failure(ex.Message)
             }))
 
+        // Records the editor's in-memory buffer so per-file analyses (hover,
+        // completion, …) reflect unsaved edits instead of stale on-disk text.
+        // Mirrors the C# sidecar's didChange overlay. [FS-DIDCHANGE-OVERLAY]
+        base.Register("textDocument/didChange", Func<byte[], CancellationToken, Task<ByteResult>>(fun payload ct ->
+            task {
+                try
+                    let request = MessagePackSerializer.Deserialize<DidChangeRequest>(payload, cancellationToken = ct)
+                    FSharpWorkspace.applyDidChange workspace request.FilePath request.NewText
+                    return Helpers.serializeOk "ok" ct
+                with ex ->
+                    return ByteResult.Failure(ex.Message)
+            }))
+
         // Unused-package detection [PKG-UNUSED-DETECT-FS].
         base.Register("project/unusedPackages", Func<byte[], CancellationToken, Task<ByteResult>>(fun payload ct ->
             task {

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpWire.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpWire.fs
@@ -16,6 +16,15 @@ type PositionRequest =
       [<Key(1)>] Line: int
       [<Key(2)>] Character: int }
 
+/// `textDocument/didChange` payload: the full replacement text of a document.
+/// Layout mirrors the Rust host's `SidecarDidChangeReq` and the C# sidecar's
+/// `DidChangeRequest`. [FS-DIDCHANGE-OVERLAY]
+[<MessagePackObject(AllowPrivate = true)>]
+[<NoComparison; NoEquality>]
+type DidChangeRequest =
+    { [<Key(0)>] FilePath: string
+      [<Key(1)>] NewText: string }
+
 [<MessagePackObject(AllowPrivate = true)>]
 [<NoComparison; NoEquality>]
 type HoverResult =

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpWorkspace.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpWorkspace.fs
@@ -2,6 +2,7 @@
 module SharpLsp.Sidecar.FSharp.FSharpWorkspace
 
 open System
+open System.Collections.Concurrent
 open System.IO
 open System.Reflection
 open System.Threading
@@ -28,14 +29,35 @@ type DefinitionLocation =
 type FSharpWorkspaceState =
     { Checker: FSharpChecker
       mutable ProjectOptions: FSharpProjectOptions option
-      mutable IsLoaded: bool }
+      mutable IsLoaded: bool
+      /// In-memory document buffers keyed by absolute file path, kept current by
+      /// LSP `textDocument/didChange`. Per-file analyses read from here so hover,
+      /// completion, etc. reflect unsaved edits instead of stale on-disk text.
+      /// [FS-DIDCHANGE-OVERLAY]
+      Overlays: ConcurrentDictionary<string, string> }
 
 /// Create a new workspace with an FSharpChecker.
 let create () : FSharpWorkspaceState =
     let checker = FSharpChecker.Create(keepAssemblyContents = true)
     { Checker = checker
       ProjectOptions = None
-      IsLoaded = false }
+      IsLoaded = false
+      Overlays = ConcurrentDictionary<string, string>() }
+
+/// Record the editor's in-memory buffer for a file (LSP didChange/didOpen).
+/// Per-file FCS analyses then resolve positions against the live buffer rather
+/// than the on-disk file, restoring parity with the C# sidecar. The Rust host
+/// sends the same absolute path it sends on position requests, so the keys
+/// align. [FS-DIDCHANGE-OVERLAY]
+let applyDidChange (state: FSharpWorkspaceState) (filePath: string) (newText: string) =
+    state.Overlays[filePath] <- newText
+
+/// Read a file's current source: the in-memory overlay when the editor has an
+/// open buffer for it, otherwise the on-disk contents. [FS-DIDCHANGE-OVERLAY]
+let internal readSource (state: FSharpWorkspaceState) (filePath: string) : string =
+    match state.Overlays.TryGetValue filePath with
+    | true, text -> text
+    | _ -> File.ReadAllText filePath
 
 /// Parse an .fsproj file to extract Compile Include entries.
 let internal parseFsprojSourceFiles (fsprojPath: string) : string array =
@@ -213,7 +235,7 @@ let getHover
             if not state.IsLoaded then
                 return None
             else
-                let source = File.ReadAllText(filePath)
+                let source = readSource state filePath
                 let sourceText = SourceText.ofString source
 
                 let! parseResults, checkAnswer =
@@ -250,7 +272,7 @@ let internal checkFileWithParse
         if not state.IsLoaded then
             return None
         else
-            let source = File.ReadAllText(filePath)
+            let source = readSource state filePath
             let sourceText = SourceText.ofString source
 
             let! parseResults, checkAnswer =

--- a/src/main.rs
+++ b/src/main.rs
@@ -819,8 +819,17 @@ fn pick_sidecar<'a>(
     csharp: Option<&'a Arc<SidecarManager>>,
     fsharp: Option<&'a Arc<SidecarManager>>,
 ) -> Option<&'a Arc<SidecarManager>> {
-    let uri = extract_document_uri(req);
-    match uri.and_then(|u| LangId::from_uri(&u)) {
+    extract_document_uri(req).map_or(csharp, |uri| sidecar_for_uri(&uri, csharp, fsharp))
+}
+
+/// Select the sidecar that owns a document, by file language. F# documents go to
+/// the F# sidecar; everything else (including unknown extensions) to C#.
+fn sidecar_for_uri<'a>(
+    uri: &Uri,
+    csharp: Option<&'a Arc<SidecarManager>>,
+    fsharp: Option<&'a Arc<SidecarManager>>,
+) -> Option<&'a Arc<SidecarManager>> {
+    match LangId::from_uri(uri) {
         Some(LangId::FSharp) => fsharp,
         _ => csharp,
     }
@@ -1107,11 +1116,13 @@ fn handle_notification(
                 info!("Opened: {}", doc.uri.as_str());
                 vfs.open(doc.uri.clone(), doc.version, doc.text.clone());
                 reparse(parsers, trees, &doc.uri, &doc.text);
-                // Sync text to sidecar so Roslyn sees the current source.
-                // Without this, the sidecar's _solution retains stale text
-                // from the initial workspace load or a previous didChange.
+                // Sync text to the document's own sidecar so the semantic engine
+                // (Roslyn / FCS) sees the current buffer. Routing by language is
+                // essential: without it F# edits never reach the F# sidecar, which
+                // then resolves hover/completion against stale on-disk text.
                 if let Ok(file_path) = semantic::uri_to_path(&doc.uri) {
-                    semantic::notify_did_change(&file_path, &doc.text, runtime, csharp_sidecar);
+                    let sidecar = sidecar_for_uri(&doc.uri, csharp_sidecar, fsharp_sidecar);
+                    semantic::notify_did_change(&file_path, &doc.text, runtime, sidecar);
                 }
                 trigger_diagnostics(
                     &doc.uri,
@@ -1137,14 +1148,11 @@ fn handle_notification(
                     vfs.change(uri, params.text_document.version, change.text.clone());
                     reparse(parsers, trees, uri, &change.text);
                     nav_cache.invalidate(uri);
-                    // Notify the sidecar so Roslyn sees the new source text.
+                    // Notify the document's own sidecar so the semantic engine
+                    // sees the new source text (F# → F# sidecar, C# → C#).
                     if let Ok(file_path) = semantic::uri_to_path(uri) {
-                        semantic::notify_did_change(
-                            &file_path,
-                            &change.text,
-                            runtime,
-                            csharp_sidecar,
-                        );
+                        let sidecar = sidecar_for_uri(uri, csharp_sidecar, fsharp_sidecar);
+                        semantic::notify_did_change(&file_path, &change.text, runtime, sidecar);
                     }
                     trigger_diagnostics(uri, runtime, csharp_sidecar, fsharp_sidecar, connection);
                 }
@@ -1193,11 +1201,7 @@ fn trigger_diagnostics(
     fsharp_sidecar: Option<&Arc<SidecarManager>>,
     connection: &Connection,
 ) {
-    let sidecar = match crate::tree_sitter_parse::LangId::from_uri(uri) {
-        Some(crate::tree_sitter_parse::LangId::FSharp) => fsharp_sidecar,
-        _ => csharp_sidecar,
-    };
-    let Some(sidecar) = sidecar else {
+    let Some(sidecar) = sidecar_for_uri(uri, csharp_sidecar, fsharp_sidecar) else {
         return;
     };
     let Ok(file_path) = semantic::uri_to_path(uri) else {

--- a/tests/e2e_modules/fsharp.rs
+++ b/tests/e2e_modules/fsharp.rs
@@ -275,6 +275,53 @@ fn test_full_stack_fsharp_hover_xml_docs() {
     client.wait_with_timeout();
 }
 
+// 43b. F# HOVER REFLECTS LIVE EDITS (didChange overlay, not stale disk)
+//
+// Regression for "F# hover is broken after typing": the F# sidecar was cut out
+// of document sync. `notify_did_change` was hardcoded to the C# sidecar and the
+// F# sidecar registered no `textDocument/didChange`, so `getHover` always read
+// the file from DISK. As soon as the editor buffer diverged from disk, F# hover
+// resolved the editor's line/char against stale on-disk text and returned the
+// wrong symbol (or null). C# already honored the in-memory buffer; this restores
+// F# to parity. [FS-DIDCHANGE-OVERLAY]
+#[test]
+fn test_full_stack_fsharp_hover_reflects_live_edit() {
+    let (_tmp, file_uri, mut client) = ready_fsharp_client();
+
+    // Replace the whole buffer (full-sync didChange) with a document whose only
+    // binding, `subtractEdited`, exists ONLY in the editor — never on disk.
+    let edited = "namespace TestFSharp\n\
+        \n\
+        /// Edited-only module that lives solely in the editor buffer.\n\
+        module Edited =\n    \
+        /// Subtracts two integers; present only after a didChange, never on disk.\n    \
+        let subtractEdited (a: int) (b: int) : int = a - b\n";
+    client.change_document(&file_uri, 2, edited);
+
+    // `subtractEdited` is on line 5 (0-based), column 12 sits inside the
+    // identifier. Poll so FCS can re-check the overlay; today this never yields
+    // the edited symbol because the sidecar re-reads the on-disk file.
+    let needle = "subtractEdited";
+    let deadline = std::time::Instant::now() + Duration::from_mins(1);
+    loop {
+        let h = hover(&mut client, &file_uri, 5, 12);
+        assert_hover_ok(&h);
+        let md = h["result"]["contents"]["value"].as_str().unwrap_or("");
+        if md.contains(needle) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "F# hover must reflect the in-memory edit (`{needle}`), not the stale \
+             on-disk file — the F# sidecar must honor didChange overlays. Last hover: {h}"
+        );
+        std::thread::sleep(Duration::from_secs(2));
+    }
+
+    client.shutdown_and_exit();
+    client.wait_with_timeout();
+}
+
 // ── F# Navigation (Full-Stack) ──────────────────────────────────
 // Exercises the host→F# sidecar routing for go-to-definition, type-definition,
 // project-wide references, and document highlights. FSAC parity: these are the


### PR DESCRIPTION
## TLDR
F# hover (and every per-file F# analysis) now resolves against the live editor buffer instead of stale on-disk text, fixing broken/empty F# hover that occurred the moment you started typing.

## Details
**Root cause.** The F# sidecar was excluded from document sync. `notify_did_change` in `src/main.rs` was hardcoded to the C# sidecar, the F# sidecar registered no `textDocument/didChange` handler, and `FSharpWorkspace.getHover` read source via `File.ReadAllText`. Once the editor buffer diverged from disk, the editor's line/char pointed into edited text while FCS parsed the old file — so hover returned the wrong symbol or `null`. C# was unaffected because Roslyn's workspace is updated in place on `didChange`; this restores F# to parity (CLAUDE.md aim #2).

**Modified behaviour**
- `src/main.rs`: new `sidecar_for_uri` helper. `didOpen`/`didChange` now route the text sync to the document's **own** sidecar by language (F#→F#, C#→C#) — previously every edit went to the C# sidecar. `pick_sidecar` and `trigger_diagnostics` now reuse `sidecar_for_uri`, removing the duplicated language→sidecar `match`.
- `sidecars/SharpLsp.Sidecar.FSharp/FSharpWorkspace.fs`: `FSharpWorkspaceState` gains a thread-safe `Overlays` map; new `applyDidChange` + `readSource`. `getHover` and `checkFileWithParse` read source via `readSource` (so hover, definition, completion, signature help, … all see live edits), falling back to disk only when no buffer is open.
- `sidecars/SharpLsp.Sidecar.FSharp/FSharpSidecar.fs`: registers `textDocument/didChange` → `applyDidChange`.

**New files / types / deps:** none. New wire type `DidChangeRequest` in `FSharpWire.fs` (positional MessagePack, mirrors the Rust `SidecarDidChangeReq` and C# `DidChangeRequest`). No new dependencies. No deletions.

**Spec:** `docs/specs/HOVER-SPEC.md` §5.4 documents the live-buffer requirement, tagged `[FS-DIDCHANGE-OVERLAY]` (cross-referenced in the code and tests).

## How Do The Automated Tests Prove It Works?
- **New full-stack regression** `e2e_modules::fsharp::test_full_stack_fsharp_hover_reflects_live_edit`: opens the F# fixture, sends a `didChange` adding `subtractEdited` (a binding that exists **only** in the buffer, never on disk), then hovers on it. Verified test-first: **before the fix it fails** — host log shows `Sidecar response … method=textDocument/hover … bytes=1` and `Hover: sidecar returned null`; **after the fix it passes** — `method=textDocument/didChange … bytes=3` (ok) followed by `Hover: sidecar returned content`.
- **New sidecar-level coverage** in `FSharpExtraCoverageTests.fs`:
  - `getHover reads the didChange overlay instead of on-disk source` — isolated real workspace, overlays a file with `overlayOnlyBinding`, asserts `getHover` resolves it from the overlay (proving `applyDidChange` + `readSource`).
  - `textDocument/didChange` added to the malformed-payload `Theory`, exercising the handler's `with ex -> Failure` branch (and that the sidecar still answers `ping` afterward).
- **Full suites green locally:** Rust e2e **640 passed, 0 skipped** (coverage 94.65%, gate ✓), incl. `test_did_change_then_definition_exercises_notify_path` and `test_definition_cache_invalidated_on_change`. F# sidecar **323 passed**, C# **394**, Common **63** (coverage F# 94.77% / C# 94.16% / Common 96.02%, all gates ✓). C# `hover` module **8 passed** incl. `test_hover_edit_hover_cycle` (no C# regression). `document_sync` **13 passed**. `_lint-rust` (fmt + clippy `-D warnings`), `csharpier check`, and `_lint-dotnet` (0 warn / 0 err, warnaserror) all clean; deslop reports no new duplication.
