### PR TITLE
fix(fsharp): first-class Solution Explorer + diagnostics (#118 #119 #120)

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -5,7 +5,7 @@
     "line_percent": 95.0
   },
   "vscode-extension": {
-    "line_percent": 84.8
+    "line_percent": 84.86
   },
   "sharplsp-sidecar-csharp": {
     "line_percent": 95.0

--- a/docs/specs/SOLUTION-EXPLORER-SPEC.md
+++ b/docs/specs/SOLUTION-EXPLORER-SPEC.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-The Solution Explorer is a VS Code tree view that displays the full code hierarchy of a .NET solution: solutions, projects, namespaces, types, and members. It accepts legacy `.sln` and XML `.slnx` solution files. It is powered by a custom LSP request (`sharplsp/workspaceSymbols`) backed by the sidecar `solution/read` model and tree-sitter parsing in the Rust host.
+The Solution Explorer is a VS Code tree view that displays the full code hierarchy of a .NET solution: solutions, projects, namespaces, types, and members. It accepts legacy `.sln` and XML `.slnx` solution files. It is powered by a custom LSP request (`sharplsp/workspaceSymbols`) backed by the sidecar `solution/read` model, tree-sitter parsing in the Rust host for C#, and the FCS sidecar's `documentSymbol` for F# ([SE-FSHARP-SYMBOLS]).
 
 See [LSP-ARCHITECTURE-SPEC.md](specs/LSP-ARCHITECTURE-SPEC.md) for shared LSP architecture.
 
@@ -19,9 +19,22 @@ VS Code Tree View
               └── Rust Host
                     ├── solution/read sidecar request
                     │     └── .sln/.slnx → projects, folders, solution items
-                    └── tree-sitter parsing
-                          └── .csproj/.fsproj → .cs/.fs files
+                    ├── tree-sitter parsing (C#)
+                    │     └── .csproj → .cs files
+                    └── FCS sidecar documentSymbol (F#)
+                          └── .fsproj → .fs files
 ```
+
+### Language-Specific Symbol Extraction [SE-FSHARP-SYMBOLS]
+
+Per-file symbols are sourced by language, never by a single parser:
+
+| Language | Source | Rationale |
+|----------|--------|-----------|
+| C# (`.cs`) | tree-sitter parsing in the Rust host | A C# grammar is integrated in the host. |
+| F# (`.fs`) | FCS sidecar `textDocument/documentSymbol` ([FS-DOCSYMBOL]) | The host has **no** F# tree-sitter grammar, so a tree-sitter-only path silently drops every `.fs` file (issue #119). F# is a first-class language — its files and symbols MUST appear under an `.fsproj` exactly as `.cs` files appear under a `.csproj`. |
+
+The F# path reuses the **same** sidecar `documentSymbol` request that powers the editor outline, mapping the nested FCS symbols (module, namespace, type, DU case, member) into the shared `FileSymbol`/`SymbolNode` tree model using each symbol's full range. The F# sidecar must be threaded into `workspace_symbols::handle`; when it is unavailable the project's `.fs` files contribute no symbols rather than failing the whole request.
 
 ### Request: `sharplsp/workspaceSymbols`
 
@@ -488,6 +501,32 @@ To support scoped context menus, symbol nodes set `contextValue` based on their 
 ## Navigation
 
 Clicking a symbol node opens the file and navigates to the symbol's declaration position.
+
+## Active Editor Synchronization `[SE-ACTIVE-EDITOR-SYNC]`
+
+The Solution Explorer MUST stay synchronized with the active text editor. When a
+C# or F# document becomes active — opened, focused, or navigated to (Go to
+Definition, Quick Open, tab switch) — the tree MUST reveal that document's node:
+expand its ancestors, scroll it into view, and **select (highlight)** it. Example:
+focusing `FSharpRename.fs` in the editor expands the tree to it and highlights it.
+Switching the active editor re-syncs the selection to the new document. This
+mirrors VS Code's built-in File Explorer `explorer.autoReveal` behaviour.
+
+This is the inverse of [Reveal in File Explorer](#reveal-in-file-explorer)
+(tree → editor); here the direction is **editor → tree**.
+
+### Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | A reference to the `TreeView` returned by `createTreeView` MUST be retained so `TreeView.reveal()` can be called. |
+| 2 | `SolutionExplorerProvider` MUST implement `getParent()` (VS Code requires it for `reveal()`). |
+| 3 | A `window.onDidChangeActiveTextEditor` listener MUST locate the node whose file URI (`symbolUri`) matches the active document and call `treeView.reveal(node, { select: true, focus: false, expand: true })`. |
+| 4 | Sync MUST re-run after the tree is (re)populated (`onDidChangeTreeData`) so a newly loaded tree still reveals the current editor — per [VSCODE-REACTIVITY-SPEC](VSCODE-REACTIVITY-SPEC.md). |
+| 5 | A setting (mirroring `explorer.autoReveal`, default **on**) MUST gate the behaviour so users can disable it. |
+| 6 | Revealing MUST NOT steal editor focus (`focus: false`) and MUST be a no-op when the active document has no corresponding node (e.g. files outside the loaded solution). |
+
+Tracked in [issue #118](https://github.com/Nimblesite/SharpLsp/issues/118).
 
 ## Key Files
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -203,6 +203,13 @@
           "scope": "resource",
           "order": 17
         },
+        "sharplsp.solutionExplorer.autoReveal": {
+          "type": "boolean",
+          "default": true,
+          "description": "%setting.solutionExplorer.autoReveal%",
+          "scope": "resource",
+          "order": 18
+        },
         "sharplsp.memberSortOrder.hierarchy": {
           "type": "array",
           "items": {

--- a/editors/vscode/package.nls.json
+++ b/editors/vscode/package.nls.json
@@ -19,6 +19,7 @@
   "setting.nuget.includePrerelease": "Include prerelease versions in NuGet package search results.",
   "setting.hotReload.onSave": "Automatically start hot reload on file save when a dotnet watch session is active.",
   "setting.testLens.enabled": "Show pass/fail status, Run Test, and Debug Test lenses above test methods.",
+  "setting.solutionExplorer.autoReveal": "Reveal and select the active editor's file in the SharpLsp Solution Explorer, mirroring `explorer.autoReveal`.",
   "setting.memberSortOrder.hierarchy": "Sort tiebreaker order for **Sort Members**. Members are grouped by the first criterion, then sub-sorted by the second, then the third.",
   "setting.memberSortOrder.accessibilityOrder": "Access modifier priority for **Sort Members** (first = highest priority).",
   "setting.memberSortOrder.categoryOrder": "Member kind priority for **Sort Members** (first = highest priority).",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -98,6 +98,47 @@ export async function activate(context: ExtensionContext): Promise<SharpLspExten
   }
 }
 
+/**
+ * Keep the Solution Explorer in sync with the active editor: reveal and select
+ * the tree node for the focused file, re-syncing whenever the tree repopulates
+ * or the view becomes visible. Mirrors VS Code's `explorer.autoReveal`; gated by
+ * the `sharplsp.solutionExplorer.autoReveal` setting (default on).
+ * [SE-ACTIVE-EDITOR-SYNC]
+ */
+function wireActiveEditorReveal(
+  context: ExtensionContext,
+  treeView: vscode.TreeView<ExplorerNode>,
+  provider: SolutionExplorerProvider,
+): void {
+  const reveal = (editor: vscode.TextEditor | undefined): void => {
+    if (editor === undefined || !treeView.visible) return;
+    const enabled = workspace
+      .getConfiguration('sharplsp')
+      .get<boolean>('solutionExplorer.autoReveal', true);
+    if (!enabled) return;
+    const node = provider.findNodeForUri(editor.document.uri.toString());
+    if (node === undefined) return;
+    void treeView
+      .reveal(node, { select: true, focus: false, expand: true })
+      .then(undefined, (err: unknown) => {
+        log.traceInfo(`Solution Explorer reveal failed: ${getErrorMessage(err)}`);
+      });
+  };
+
+  context.subscriptions.push(
+    window.onDidChangeActiveTextEditor(reveal),
+    // Re-sync after the tree (re)populates so the selection follows the editor.
+    provider.onDidChangeTreeData(() => {
+      reveal(window.activeTextEditor);
+    }),
+    // Sync the moment the view is revealed (it may have been hidden on open).
+    treeView.onDidChangeVisibility((event) => {
+      if (event.visible) reveal(window.activeTextEditor);
+    }),
+  );
+  reveal(window.activeTextEditor);
+}
+
 async function activateInner(context: ExtensionContext): Promise<SharpLspExtensionApi> {
   log.info('step 1: SharpLspStatusBar');
   statusBar = new SharpLspStatusBar();
@@ -106,12 +147,12 @@ async function activateInner(context: ExtensionContext): Promise<SharpLspExtensi
   log.info('step 2: SolutionExplorerProvider');
   explorerProvider = new SolutionExplorerProvider();
   log.info('step 3: createTreeView SOLUTION_EXPLORER');
-  context.subscriptions.push(
-    window.createTreeView(VIEW_SOLUTION_EXPLORER, {
-      treeDataProvider: explorerProvider,
-      showCollapseAll: true,
-    }),
-  );
+  const solutionTreeView = window.createTreeView<ExplorerNode>(VIEW_SOLUTION_EXPLORER, {
+    treeDataProvider: explorerProvider,
+    showCollapseAll: true,
+  });
+  context.subscriptions.push(solutionTreeView);
+  wireActiveEditorReveal(context, solutionTreeView, explorerProvider);
 
   log.info('step 4: ProfilerTreeProvider');
   profilerProvider = new profiler.ProfilerTreeProvider();

--- a/editors/vscode/src/test/suite/unit-tree.test.ts
+++ b/editors/vscode/src/test/suite/unit-tree.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { MarkdownString, ThemeColor, ThemeIcon, TreeItemCollapsibleState } from 'vscode';
+import { MarkdownString, ThemeColor, ThemeIcon, TreeItemCollapsibleState, Uri } from 'vscode';
 import { ExplorerNode, SolutionExplorerProvider, buildQualifiedName } from '../../tree.js';
 import { buildNonSymbolTooltip, SYMBOL_CONTEXT_VALUES } from '../../tree-tooltip.js';
 import * as state from '../../state.js';
@@ -889,6 +889,87 @@ suite('SolutionExplorerProvider — solution picker', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────
+// SolutionExplorerProvider — active editor reveal (issue #118)
+// ─────────────────────────────────────────────────────────────────
+
+suite('SolutionExplorerProvider — active editor reveal', () => {
+  let provider: SolutionExplorerProvider;
+
+  setup(() => {
+    resetTreeState();
+    provider = new SolutionExplorerProvider();
+  });
+
+  teardown(() => {
+    resetTreeState();
+  });
+
+  test('findNodeForUri resolves a tree node living in the given file', () => {
+    loadInto(provider, '/ar/Sol.sln', [
+      project('P', '/ar/P.csproj', [symbol({ name: 'Service', kind: 'Class' })]),
+    ]);
+    // project() places symbols in `${projectPath}.cs`.
+    const fileUri = Uri.file('/ar/P.csproj.cs').toString();
+
+    const node = provider.findNodeForUri(fileUri);
+    assert.ok(node !== undefined, 'must find a node whose file is the active editor');
+    assert.strictEqual(node.symbolUri, fileUri, 'resolved node must belong to the file');
+    assert.strictEqual(node.label, 'Service');
+  });
+
+  test('findNodeForUri returns undefined for a file with no symbols in the tree', () => {
+    loadInto(provider, '/ar0/Sol.sln', [
+      project('P', '/ar0/P.csproj', [symbol({ name: 'Only', kind: 'Class' })]),
+    ]);
+    const node = provider.findNodeForUri(Uri.file('/ar0/Unrelated.cs').toString());
+    assert.strictEqual(node, undefined, 'no node matches an unrelated file uri');
+  });
+
+  test('getParent yields a complete chain from a file node up to the solution root', () => {
+    const root = loadInto(provider, '/ar2/Sol.sln', [
+      project('P', '/ar2/P.csproj', [
+        symbol({
+          name: 'Ns',
+          kind: 'Namespace',
+          children: [symbol({ name: 'Widget', kind: 'Class' })],
+        }),
+      ]),
+    ]);
+    const fileUri = Uri.file('/ar2/P.csproj.cs').toString();
+    const node = provider.findNodeForUri(fileUri);
+    assert.ok(node !== undefined, 'symbol node must resolve');
+
+    // TreeView.reveal walks getParent() to the root; every ancestor must be
+    // returned or the reveal silently no-ops (the #118 symptom).
+    const chain: ExplorerNode[] = [];
+    let current: ExplorerNode | undefined = node;
+    while (current !== undefined) {
+      chain.push(current);
+      current = provider.getParent(current) as ExplorerNode | undefined;
+      assert.ok(chain.length < 50, 'parent chain must terminate (no cycle)');
+    }
+
+    const top = chain[chain.length - 1];
+    assert.ok(top !== undefined);
+    assert.strictEqual(nt(top), 'solution', 'chain must terminate at the solution root');
+    assert.strictEqual(top, root, 'chain must reach the exact solution root instance');
+    assert.ok(
+      chain.some((n) => nt(n) === 'project'),
+      'chain must pass through the project node so reveal expands it',
+    );
+    assert.ok(
+      chain.some((n) => nt(n) === 'namespace'),
+      'chain must pass through the namespace node',
+    );
+  });
+
+  test('getParent returns undefined for a solution root (top of the tree)', () => {
+    const root = loadInto(provider, '/ar3/Sol.sln', [project('P', '/ar3/P.csproj', [])]);
+    assert.strictEqual(provider.getParent(root), undefined, 'the root has no parent');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────
 // buildQualifiedName
 // ─────────────────────────────────────────────────────────────────
 
@@ -913,7 +994,7 @@ suite('tree — buildQualifiedName', () => {
     assert.strictEqual(buildQualifiedName(sym), 'Solo');
   });
 
-  test('a namespace node qualifies to its own name (project parent is not wired)', () => {
+  test('a namespace node qualifies to its own name (project ancestor is skipped)', () => {
     const root = loadInto(provider, '/q2/Sol.sln', [
       project('P', '/q2/P.csproj', [
         symbol({
@@ -971,8 +1052,9 @@ suite('tree — buildQualifiedName', () => {
   });
 
   test('walking upward skips non-symbol/non-namespace ancestors', () => {
-    // A symbol directly under the project: its parent chain is undefined, so the
-    // solution and project ancestors never contribute to the qualified name.
+    // A symbol directly under the project: buildQualifiedName walks the parent
+    // chain but contributes only Namespace/Symbol ancestors, so the wired
+    // project and solution ancestors never leak into the qualified name.
     const root = loadInto(provider, '/q5/Sol.sln', [
       project('MyProj', '/q5/P.csproj', [symbol({ name: 'Direct', kind: 'Class' })]),
     ]);

--- a/editors/vscode/src/tree.ts
+++ b/editors/vscode/src/tree.ts
@@ -166,6 +166,24 @@ export class SolutionExplorerProvider implements TreeDataProvider<ExplorerNode> 
     return element.children;
   }
 
+  /**
+   * Parent of a node, required by VS Code for `TreeView.reveal`. The whole
+   * chain from any revealable node up to a solution root must resolve, or the
+   * active-editor sync silently no-ops (issue #118).
+   */
+  public getParent(element: ExplorerNode): ProviderResult<ExplorerNode> {
+    return element.parent;
+  }
+
+  /**
+   * First tree node belonging to `uri` (a `file://` document URI), in document
+   * order. Used to reveal/select the active editor's file in the tree. Returns
+   * `undefined` when the file contributes no symbols. [SE-ACTIVE-EDITOR-SYNC]
+   */
+  public findNodeForUri(uri: string): ExplorerNode | undefined {
+    return findFirstNodeForUri(this.roots, uri);
+  }
+
   /** Resolve tooltip via LSP hover for symbols, instant for non-symbols. */
   public async resolveTreeItem(
     item: TreeItem,
@@ -202,6 +220,19 @@ export class SolutionExplorerProvider implements TreeDataProvider<ExplorerNode> 
   }
 }
 
+/** Depth-first search for the first node whose `symbolUri` matches `uri`. */
+function findFirstNodeForUri(
+  nodes: readonly ExplorerNode[],
+  uri: string,
+): ExplorerNode | undefined {
+  for (const node of nodes) {
+    if (node.symbolUri === uri) return node;
+    const found = findFirstNodeForUri(node.children, uri);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
 // ── Tree construction ────────────────────────────────────────────
 
 function buildTree(
@@ -217,6 +248,9 @@ function buildTree(
   node.projectFilePath = solutionPath;
   node.children = response.projects.map(buildProjectNode);
   for (const project of node.children) {
+    // Wire the project → solution link so TreeView.reveal can walk a complete
+    // parent chain from any file node up to the root (issue #118).
+    project.parent = node;
     sortProjectChildren(project, order);
   }
   return [node];
@@ -233,6 +267,11 @@ function buildProjectNode(project: ProjectNode): ExplorerNode {
   const depFolder = buildDependencyFolder(project.path);
   const symbols = groupByNamespace(project.symbols);
   node.children = depFolder !== undefined ? [depFolder, ...symbols] : symbols;
+  // Wire each direct child (namespace nodes, top-level symbols, Dependencies)
+  // back to the project so the reveal parent chain is unbroken (issue #118).
+  for (const child of node.children) {
+    child.parent = node;
+  }
   return node;
 }
 

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpAssets.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpAssets.fs
@@ -1,0 +1,124 @@
+/// [PKG-ASSETS-FS] Restored-package reference resolution from project.assets.json.
+///
+/// Single source of truth for turning a project's restored NuGet packages into
+/// FCS `-r:` reference arguments. Both the persistent workspace options
+/// ([FSharpWorkspace.buildProjectOptions]) and the unused-package analysis
+/// ([FSharpPackages]) consume this, so the reference set the compiler sees is
+/// identical across diagnostics, hover, and usage analysis — a file that builds
+/// must not report unresolved `open`s/types (issue #120).
+///
+/// Fail-safe by construction: a missing or malformed assets file yields `None`
+/// and callers fall back to a framework-only reference set rather than crashing.
+module SharpLsp.Sidecar.FSharp.FSharpAssets
+
+open System
+open System.IO
+open System.Text.Json
+open Serilog
+
+/// A restored package compile assembly: simple name + absolute path.
+[<NoComparison; NoEquality>]
+type PackageAssembly = { Simple: string; Path: string }
+
+/// Path to a project's restored assets file.
+let private assetsPath (fsprojPath: string) =
+    let dir = Path.GetDirectoryName(fsprojPath) |> string
+    Path.Combine(dir, "obj", "project.assets.json")
+
+/// Try to read an object property.
+let private tryProp (el: JsonElement) (name: string) : JsonElement option =
+    match el.TryGetProperty(name) with
+    | true, value -> Some value
+    | false, _ -> None
+
+/// First property name of an object element, if any.
+let private firstName (el: JsonElement) : string option =
+    if el.ValueKind = JsonValueKind.Object then
+        el.EnumerateObject() |> Seq.map (fun p -> p.Name) |> Seq.tryHead
+    else
+        None
+
+/// First property value of an object element, if any.
+let private firstValue (el: JsonElement) : JsonElement option =
+    if el.ValueKind = JsonValueKind.Object then
+        el.EnumerateObject() |> Seq.map (fun p -> p.Value) |> Seq.tryHead
+    else
+        None
+
+/// Folder path (relative to the packages root) for a library key.
+let private libraryPath (libraries: JsonElement option) (key: string) : string =
+    let fromLibraries =
+        libraries
+        |> Option.bind (fun lib -> tryProp lib key)
+        |> Option.bind (fun entry -> tryProp entry "path")
+        |> Option.map (fun path -> path.GetString() |> string)
+
+    match fromLibraries with
+    | Some path when not (String.IsNullOrEmpty path) -> path
+    | _ -> key.ToLowerInvariant()
+
+/// Replace forward slashes with the platform path separator.
+let private toLocal (rel: string) = rel.Replace('/', Path.DirectorySeparatorChar)
+
+/// Compile assemblies declared by one target-framework package entry.
+let private packageAssemblies
+    (root: string)
+    (libraries: JsonElement option)
+    (key: string)
+    (entry: JsonElement)
+    : PackageAssembly seq =
+    match tryProp entry "compile" with
+    | Some compile when compile.ValueKind = JsonValueKind.Object ->
+        let libPath = libraryPath libraries key
+
+        compile.EnumerateObject()
+        |> Seq.choose (fun file ->
+            if file.Name = "_._" then
+                None
+            else
+                let abs = Path.Combine(root, toLocal libPath, toLocal file.Name)
+                let simple = Path.GetFileNameWithoutExtension(file.Name) |> string
+                Some { Simple = simple; Path = abs })
+    | _ -> Seq.empty
+
+/// Parse compile assemblies + packages root from a project's restored assets.
+let parseAssets (fsprojPath: string) : (string * PackageAssembly list) option =
+    let path = assetsPath fsprojPath
+
+    if not (File.Exists path) then
+        None
+    else
+        try
+            use doc = JsonDocument.Parse(File.ReadAllText path)
+            let rootEl = doc.RootElement
+
+            let root =
+                tryProp rootEl "packageFolders"
+                |> Option.bind firstName
+                |> Option.defaultValue ""
+
+            let libraries = tryProp rootEl "libraries"
+            let target = tryProp rootEl "targets" |> Option.bind firstValue
+
+            match target with
+            | Some targetEl when targetEl.ValueKind = JsonValueKind.Object ->
+                let assemblies =
+                    targetEl.EnumerateObject()
+                    |> Seq.collect (fun pkg -> packageAssemblies root libraries pkg.Name pkg.Value)
+                    |> Seq.toList
+
+                Some(root, assemblies)
+            | _ -> None
+        with ex ->
+            Log.Debug(ex, "[F# Assets] assets parse failed")
+            None
+
+/// FCS `-r:` reference args for the compile assemblies that exist on disk.
+/// Nonexistent paths (e.g. project-reference `bin/placeholder` entries) are
+/// dropped so the compiler is never handed a missing-assembly reference — which
+/// would itself surface as a false diagnostic.
+let packageReferenceArgs (assemblies: PackageAssembly list) : string array =
+    assemblies
+    |> List.filter (fun assembly -> File.Exists assembly.Path)
+    |> List.map (fun assembly -> $"-r:{assembly.Path}")
+    |> List.toArray

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpPackages.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpPackages.fs
@@ -1,8 +1,8 @@
 /// [PKG-UNUSED-DETECT-FS] Unused-package detection for F# projects.
 ///
-/// The persistent workspace options omit NuGet refs, so this module builds an
-/// *isolated* FSharpProjectOptions that includes the project's restored compile
-/// assemblies (from obj/project.assets.json), runs a project-wide check, and
+/// Runs a project-wide check against the shared workspace options
+/// ([FSharpWorkspace.buildProjectOptions], which already resolve the restored
+/// compile assemblies from obj/project.assets.json via [FSharpAssets]) and
 /// reports which referenced assemblies are actually used. The host's
 /// [PKG-UNUSED-MAP] then maps assemblies → packages.
 ///
@@ -11,8 +11,6 @@
 module SharpLsp.Sidecar.FSharp.FSharpPackages
 
 open System
-open System.IO
-open System.Text.Json
 open System.Threading.Tasks
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Symbols
@@ -25,114 +23,8 @@ type UsedReferences =
       All: string array
       Root: string }
 
-/// A restored package compile assembly: simple name + absolute path.
-[<NoComparison; NoEquality>]
-type private PackageAssembly = { Simple: string; Path: string }
-
 /// Fail-safe empty result — the host flags nothing.
 let private emptyUsage = { Used = [||]; All = [||]; Root = "" }
-
-/// Path to a project's restored assets file.
-let private assetsPath (fsprojPath: string) =
-    let dir = Path.GetDirectoryName(fsprojPath) |> string
-    Path.Combine(dir, "obj", "project.assets.json")
-
-/// Try to read an object property.
-let private tryProp (el: JsonElement) (name: string) : JsonElement option =
-    match el.TryGetProperty(name) with
-    | true, value -> Some value
-    | false, _ -> None
-
-/// First property name of an object element, if any.
-let private firstName (el: JsonElement) : string option =
-    if el.ValueKind = JsonValueKind.Object then
-        el.EnumerateObject() |> Seq.map (fun p -> p.Name) |> Seq.tryHead
-    else
-        None
-
-/// First property value of an object element, if any.
-let private firstValue (el: JsonElement) : JsonElement option =
-    if el.ValueKind = JsonValueKind.Object then
-        el.EnumerateObject() |> Seq.map (fun p -> p.Value) |> Seq.tryHead
-    else
-        None
-
-/// Folder path (relative to the packages root) for a library key.
-let private libraryPath (libraries: JsonElement option) (key: string) : string =
-    let fromLibraries =
-        libraries
-        |> Option.bind (fun lib -> tryProp lib key)
-        |> Option.bind (fun entry -> tryProp entry "path")
-        |> Option.map (fun path -> path.GetString() |> string)
-
-    match fromLibraries with
-    | Some path when not (String.IsNullOrEmpty path) -> path
-    | _ -> key.ToLowerInvariant()
-
-/// Replace forward slashes with the platform path separator.
-let private toLocal (rel: string) = rel.Replace('/', Path.DirectorySeparatorChar)
-
-/// Compile assemblies declared by one target-framework package entry.
-let private packageAssemblies
-    (root: string)
-    (libraries: JsonElement option)
-    (key: string)
-    (entry: JsonElement)
-    : PackageAssembly seq =
-    match tryProp entry "compile" with
-    | Some compile when compile.ValueKind = JsonValueKind.Object ->
-        let libPath = libraryPath libraries key
-
-        compile.EnumerateObject()
-        |> Seq.choose (fun file ->
-            if file.Name = "_._" then
-                None
-            else
-                let abs = Path.Combine(root, toLocal libPath, toLocal file.Name)
-                let simple = Path.GetFileNameWithoutExtension(file.Name) |> string
-                Some { Simple = simple; Path = abs })
-    | _ -> Seq.empty
-
-/// Parse compile assemblies + packages root from project.assets.json.
-let private parseAssets (path: string) : (string * PackageAssembly list) option =
-    if not (File.Exists path) then
-        None
-    else
-        try
-            use doc = JsonDocument.Parse(File.ReadAllText path)
-            let rootEl = doc.RootElement
-
-            let root =
-                tryProp rootEl "packageFolders"
-                |> Option.bind firstName
-                |> Option.defaultValue ""
-
-            let libraries = tryProp rootEl "libraries"
-            let target = tryProp rootEl "targets" |> Option.bind firstValue
-
-            match target with
-            | Some targetEl when targetEl.ValueKind = JsonValueKind.Object ->
-                let assemblies =
-                    targetEl.EnumerateObject()
-                    |> Seq.collect (fun pkg -> packageAssemblies root libraries pkg.Name pkg.Value)
-                    |> Seq.toList
-
-                Some(root, assemblies)
-            | _ -> None
-        with ex ->
-            Log.Debug(ex, "[F# Packages] assets parse failed")
-            None
-
-/// Build isolated project options that resolve the restored package references.
-let private projectOptions
-    (state: FSharpWorkspace.FSharpWorkspaceState)
-    (fsprojPath: string)
-    (assemblies: PackageAssembly list)
-    =
-    let sources = FSharpWorkspace.parseFsprojSourceFiles fsprojPath
-    let packageRefs = assemblies |> List.map (fun a -> $"-r:{a.Path}") |> List.toArray
-    let other = Array.append (FSharpWorkspace.frameworkReferenceArgs ()) packageRefs
-    state.Checker.GetProjectOptionsFromCommandLineArgs(fsprojPath, Array.append other sources)
 
 /// Assembly simple name owning a symbol, if determinable.
 let private assemblyOf (sym: FSharpSymbol) : string option =
@@ -164,11 +56,11 @@ let getReferenceUsage
     : Task<UsedReferences> =
     task {
         try
-            match parseAssets (assetsPath fsprojPath) with
+            match FSharpAssets.parseAssets fsprojPath with
             | None -> return emptyUsage
             | Some(root, assemblies) when List.isEmpty assemblies -> return { emptyUsage with Root = root }
             | Some(root, assemblies) ->
-                let options = projectOptions state fsprojPath assemblies
+                let options = FSharpWorkspace.buildProjectOptions state fsprojPath
                 let! results = state.Checker.ParseAndCheckProject(options)
                 let allUses = results.GetAllUsesOfAllSymbols()
 

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpWorkspace.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpWorkspace.fs
@@ -140,6 +140,25 @@ let internal frameworkReferenceArgs () : string array =
        yield! frameworkRefs
        yield! fsharpCoreRef |]
 
+/// Build the persistent FCS project options for an .fsproj: framework reference
+/// assemblies + the project's restored NuGet package references ([FSharpAssets])
+/// + the project's compile sources. Including the package references is what
+/// keeps a building project free of false unresolved-`open` / unknown-type
+/// diagnostics — without them FCS cannot resolve any external reference and
+/// flags every `open`/type as an error even though the project compiles (#120).
+/// Shared with the unused-package analysis so the compiler sees one reference
+/// set across diagnostics, hover, and usage.
+let internal buildProjectOptions (state: FSharpWorkspaceState) (fsprojPath: string) : FSharpProjectOptions =
+    let sourceFiles = parseFsprojSourceFiles fsprojPath
+
+    let packageRefs =
+        FSharpAssets.parseAssets fsprojPath
+        |> Option.map (snd >> FSharpAssets.packageReferenceArgs)
+        |> Option.defaultValue [||]
+
+    let otherOptions = Array.append (frameworkReferenceArgs ()) packageRefs
+    state.Checker.GetProjectOptionsFromCommandLineArgs(fsprojPath, Array.append otherOptions sourceFiles)
+
 let private loadFirstProject (state: FSharpWorkspaceState) (fsprojFiles: string array) =
     if fsprojFiles.Length = 0 then
         Error "No .fsproj found"
@@ -148,15 +167,10 @@ let private loadFirstProject (state: FSharpWorkspaceState) (fsprojFiles: string 
             let fsprojPath = Array.head fsprojFiles
             if fsprojFiles.Length > 1 then
                 Log.Debug("F# workspace found {Count} projects; loading {Path}", fsprojFiles.Length, fsprojPath)
-            let sourceFiles = parseFsprojSourceFiles fsprojPath
-            let otherOptions = frameworkReferenceArgs ()
-            let options =
-                state.Checker.GetProjectOptionsFromCommandLineArgs(
-                    fsprojPath,
-                    [| yield! otherOptions; yield! sourceFiles |])
+            let options = buildProjectOptions state fsprojPath
             state.ProjectOptions <- Some options
             state.IsLoaded <- true
-            let fileList = String.Join(", ", sourceFiles |> Array.map Path.GetFileName)
+            let fileList = String.Join(", ", options.SourceFiles |> Array.map Path.GetFileName)
             Log.Debug("F# workspace loaded from {Path} with files: [{Files}]", fsprojPath, fileList)
             Ok()
         with ex ->

--- a/sidecars/SharpLsp.Sidecar.FSharp/SharpLsp.Sidecar.FSharp.fsproj
+++ b/sidecars/SharpLsp.Sidecar.FSharp/SharpLsp.Sidecar.FSharp.fsproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <Compile Include="Hover/FSharpHoverBuilder.fs" />
+    <Compile Include="FSharpAssets.fs" />
     <Compile Include="FSharpWorkspace.fs" />
     <Compile Include="FSharpPackages.fs" />
     <Compile Include="FSharpReferences.fs" />

--- a/src/document_symbols.rs
+++ b/src/document_symbols.rs
@@ -32,24 +32,39 @@ pub fn handle_fsharp(
     let params: DocumentSymbolParams = serde_json::from_value(req.params)?;
     let file_path = crate::semantic::uri_to_path(&params.text_document.uri)?;
 
-    let request = SidecarFileReq { file_path };
-    let payload = rmp_serde::to_vec(&request)?;
-    let response_bytes =
-        match runtime.block_on(sidecar.request("textDocument/documentSymbol", payload)) {
-            Ok(bytes) => bytes,
-            Err(err) => {
-                warn!("Sidecar documentSymbol unavailable: {err:#}");
-                return Ok(serde_json::to_value(DocumentSymbolResponse::Nested(
-                    vec![],
-                ))?);
-            }
-        };
-
-    let items: Vec<SidecarDocumentSymbol> = rmp_serde::from_slice(&response_bytes)?;
+    // A sidecar/parse failure yields an empty outline rather than a hard error —
+    // a transient outline gap is preferable to a failed request. [FS-DOCSYMBOL]
+    let items = match fetch_fsharp_document_symbols(runtime, sidecar, file_path) {
+        Ok(items) => items,
+        Err(err) => {
+            warn!("Sidecar documentSymbol unavailable: {err:#}");
+            return Ok(serde_json::to_value(DocumentSymbolResponse::Nested(
+                vec![],
+            ))?);
+        }
+    };
     let symbols: Vec<DocumentSymbol> = items.iter().map(map_symbol).collect();
     Ok(serde_json::to_value(DocumentSymbolResponse::Nested(
         symbols,
     ))?)
+}
+
+/// Fetch the FCS document-symbol tree for an F# file from the sidecar.
+///
+/// Shared by the `textDocument/documentSymbol` outline and the Solution
+/// Explorer's `sharplsp/workspaceSymbols` tree, so F# files contribute the same
+/// FCS-sourced symbols in both — the host has no F# tree-sitter grammar.
+/// [FS-DOCSYMBOL]
+pub(crate) fn fetch_fsharp_document_symbols(
+    runtime: &tokio::runtime::Runtime,
+    sidecar: &Arc<SidecarManager>,
+    file_path: String,
+) -> Result<Vec<SidecarDocumentSymbol>> {
+    let request = SidecarFileReq { file_path };
+    let payload = rmp_serde::to_vec(&request)?;
+    let response_bytes =
+        runtime.block_on(sidecar.request("textDocument/documentSymbol", payload))?;
+    Ok(rmp_serde::from_slice(&response_bytes)?)
 }
 
 /// Convert a sidecar document symbol (and its children) into an LSP one.
@@ -100,30 +115,32 @@ fn parse_document_symbol_kind(kind: &str) -> SymbolKind {
 
 /// A nested document symbol returned by the sidecar. Deserialized from a
 /// positional `MessagePack` array matching the sidecar's `DocumentSymbolResult`.
+/// `pub(crate)` so the Solution Explorer (`workspace_symbols`) can map the same
+/// FCS symbols into its tree model. [FS-DOCSYMBOL]
 #[derive(serde::Deserialize)]
-struct SidecarDocumentSymbol {
+pub(crate) struct SidecarDocumentSymbol {
     /// Display name of the symbol.
-    name: String,
+    pub(crate) name: String,
     /// Symbol kind string (e.g. "Module", "Class", "Function").
-    kind: String,
+    pub(crate) kind: String,
     /// Start line of the full symbol range.
-    start_line: u32,
+    pub(crate) start_line: u32,
     /// Start character of the full symbol range.
-    start_character: u32,
+    pub(crate) start_character: u32,
     /// End line of the full symbol range.
-    end_line: u32,
+    pub(crate) end_line: u32,
     /// End character of the full symbol range.
-    end_character: u32,
+    pub(crate) end_character: u32,
     /// Start line of the selection (identifier) range.
-    selection_start_line: u32,
+    pub(crate) selection_start_line: u32,
     /// Start character of the selection (identifier) range.
-    selection_start_character: u32,
+    pub(crate) selection_start_character: u32,
     /// End line of the selection (identifier) range.
-    selection_end_line: u32,
+    pub(crate) selection_end_line: u32,
     /// End character of the selection (identifier) range.
-    selection_end_character: u32,
+    pub(crate) selection_end_character: u32,
     /// Nested child symbols (members of a module, type, etc.).
-    children: Vec<SidecarDocumentSymbol>,
+    pub(crate) children: Vec<SidecarDocumentSymbol>,
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -761,6 +761,7 @@ fn handle_custom_request(
             vfs,
             runtime,
             csharp_sidecar.or(fsharp_sidecar),
+            fsharp_sidecar,
         ),
         "sharplsp/sortMembers" => handle_sort_members(req, parsers),
         // NuGet package management
@@ -950,9 +951,17 @@ fn handle_workspace_symbols(
     vfs: &Vfs,
     runtime: &tokio::runtime::Runtime,
     solution_sidecar: Option<&Arc<SidecarManager>>,
+    fsharp_sidecar: Option<&Arc<SidecarManager>>,
 ) -> Result<serde_json::Value> {
     let params: workspace_symbols::WorkspaceSymbolsParams = serde_json::from_value(req.params)?;
-    let response = workspace_symbols::handle(&params, parsers, vfs, runtime, solution_sidecar)?;
+    let response = workspace_symbols::handle(
+        &params,
+        parsers,
+        vfs,
+        runtime,
+        solution_sidecar,
+        fsharp_sidecar,
+    )?;
     Ok(serde_json::to_value(response)?)
 }
 

--- a/src/workspace_symbols.rs
+++ b/src/workspace_symbols.rs
@@ -183,6 +183,7 @@ pub fn handle(
     vfs: &Vfs,
     runtime: &tokio::runtime::Runtime,
     solution_sidecar: Option<&Arc<SidecarManager>>,
+    fsharp_sidecar: Option<&Arc<SidecarManager>>,
 ) -> Result<WorkspaceSymbolsResponse> {
     let sln_data = read_solution(params, runtime, solution_sidecar)?;
 
@@ -199,7 +200,7 @@ pub fn handle(
         .projects
         .iter()
         .filter_map(|proj| {
-            let mut node = build_project_node(proj, parsers, vfs).ok()?;
+            let mut node = build_project_node(proj, parsers, vfs, runtime, fsharp_sidecar).ok()?;
             node.parent_folder.clone_from(&proj.parent_folder);
             Some(node)
         })
@@ -399,10 +400,17 @@ struct ProjectInfo {
 }
 
 /// Build a `ProjectNode` by finding and parsing all source files.
+///
+/// `.cs` files are parsed syntactically with tree-sitter; `.fs` files have no
+/// host grammar, so their symbols are sourced from the FCS sidecar's
+/// documentSymbol — the same path the editor outline uses — so F# projects show
+/// their files and symbols exactly like C# projects (#119). [FS-DOCSYMBOL]
 fn build_project_node(
     project: &ProjectInfo,
     parsers: &TsParsers,
     vfs: &Vfs,
+    runtime: &tokio::runtime::Runtime,
+    fsharp_sidecar: Option<&Arc<SidecarManager>>,
 ) -> Result<ProjectNode> {
     let proj_dir = Path::new(&project.path)
         .parent()
@@ -412,7 +420,7 @@ fn build_project_node(
 
     let symbols: Vec<FileSymbol> = source_files
         .iter()
-        .filter_map(|file| parse_file_symbols(file, parsers, vfs).ok())
+        .filter_map(|file| file_symbols(file, parsers, vfs, runtime, fsharp_sidecar).ok())
         .filter(|fs| !fs.symbols.is_empty())
         .collect();
 
@@ -422,6 +430,62 @@ fn build_project_node(
         symbols,
         parent_folder: project.parent_folder.clone(),
     })
+}
+
+/// Extract a file's symbols, dispatching by language: tree-sitter for C#, the
+/// FCS sidecar for F#.
+fn file_symbols(
+    file_path: &str,
+    parsers: &TsParsers,
+    vfs: &Vfs,
+    runtime: &tokio::runtime::Runtime,
+    fsharp_sidecar: Option<&Arc<SidecarManager>>,
+) -> Result<FileSymbol> {
+    match LangId::from_path(Path::new(file_path)) {
+        Some(LangId::FSharp) => parse_fsharp_file_symbols(file_path, runtime, fsharp_sidecar),
+        _ => parse_file_symbols(file_path, parsers, vfs),
+    }
+}
+
+/// Extract an F# file's symbols via the FCS sidecar's documentSymbol, mapping
+/// the result into the Solution Explorer's symbol model. [FS-DOCSYMBOL]
+fn parse_fsharp_file_symbols(
+    file_path: &str,
+    runtime: &tokio::runtime::Runtime,
+    fsharp_sidecar: Option<&Arc<SidecarManager>>,
+) -> Result<FileSymbol> {
+    let sidecar = fsharp_sidecar.context("F# sidecar unavailable for F# symbol extraction")?;
+    let items = crate::document_symbols::fetch_fsharp_document_symbols(
+        runtime,
+        sidecar,
+        file_path.to_string(),
+    )?;
+    Ok(FileSymbol {
+        file: file_path.to_string(),
+        symbols: items.iter().map(map_sidecar_symbol).collect(),
+    })
+}
+
+/// Map a sidecar document symbol (and its children) into a `SymbolNode`. Uses
+/// the full symbol range to match the C# tree-sitter path's `node_to_symbol`.
+fn map_sidecar_symbol(item: &crate::document_symbols::SidecarDocumentSymbol) -> SymbolNode {
+    SymbolNode {
+        name: item.name.clone(),
+        kind: item.kind.clone(),
+        detail: None,
+        access: None,
+        range: SymbolRange {
+            start: SymbolPosition {
+                line: item.start_line,
+                character: item.start_character,
+            },
+            end: SymbolPosition {
+                line: item.end_line,
+                character: item.end_character,
+            },
+        },
+        children: item.children.iter().map(map_sidecar_symbol).collect(),
+    }
 }
 
 /// Recursively find `.cs` and `.fs` files under a directory.

--- a/tests/e2e_modules/fixtures.rs
+++ b/tests/e2e_modules/fixtures.rs
@@ -325,6 +325,78 @@ EndGlobal"#,
     (tmp, root_uri, file_uri, fs_source.to_string())
 }
 
+/// Create an F# workspace whose source `open`s a restored external package
+/// (`Newtonsoft.Json`). Used to prove the F# sidecar resolves package references
+/// in its persistent project options — a file that compiles must not report
+/// unresolved-namespace/type errors. Regression fixture for issue #120.
+pub fn create_fsharp_nuget_workspace() -> (tempfile::TempDir, String, String, String) {
+    let tmp = tempfile::tempdir().unwrap();
+    let proj_dir = tmp.path().join("TestFSharpNuget");
+    std::fs::create_dir_all(&proj_dir).unwrap();
+
+    std::fs::write(
+        proj_dir.join("TestFSharpNuget.fsproj"),
+        r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Serializer.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>"#,
+    )
+    .unwrap();
+
+    // `open Newtonsoft.Json` + `JsonConvert` exercise the external package
+    // reference. With the package resolved this compiles cleanly; with it
+    // missing FCS reports FS0039 (namespace not defined) — the #120 symptom.
+    let fs_source = r"namespace TestFSharpNuget
+
+open Newtonsoft.Json
+
+/// Serializes values to JSON via the Newtonsoft.Json package.
+module Serializer =
+
+    /// A simple record round-tripped through JSON.
+    type Payload = { Name: string; Value: int }
+
+    /// Serialize a payload to a JSON string.
+    let toJson (payload: Payload) : string =
+        JsonConvert.SerializeObject(payload)
+";
+    std::fs::write(proj_dir.join("Serializer.fs"), fs_source).unwrap();
+
+    std::fs::write(
+        tmp.path().join("TestFSharpNuget.sln"),
+        r#"Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "TestFSharpNuget", "TestFSharpNuget/TestFSharpNuget.fsproj", "{00000000-0000-0000-0000-000000000003}"
+EndProject
+Global
+EndGlobal"#,
+    )
+    .unwrap();
+
+    let restore = std::process::Command::new("dotnet")
+        .args(["restore", "--verbosity", "quiet"])
+        // Restore the project directly: the generated .sln has no
+        // ProjectConfigurationPlatforms, so restoring the cwd writes no
+        // obj/project.assets.json and the sidecar cannot resolve references.
+        .current_dir(&proj_dir)
+        .status()
+        .expect("dotnet restore failed");
+    assert!(restore.success(), "dotnet restore must succeed");
+
+    let real_root = std::fs::canonicalize(tmp.path()).unwrap();
+    let real_proj = real_root.join("TestFSharpNuget");
+    let root_uri = format!("file://{}", real_root.display());
+    let file_uri = format!("file://{}", real_proj.join("Serializer.fs").display());
+    (tmp, root_uri, file_uri, fs_source.to_string())
+}
+
 /// Create a .NET workspace with interfaces, implementations, overrides,
 /// and method calls — everything needed to test definition navigation.
 pub fn create_definition_workspace() -> (tempfile::TempDir, String, String, String) {

--- a/tests/e2e_modules/fsharp.rs
+++ b/tests/e2e_modules/fsharp.rs
@@ -322,6 +322,66 @@ fn test_full_stack_fsharp_hover_reflects_live_edit() {
     client.wait_with_timeout();
 }
 
+// ── F# Diagnostics (Full-Stack) ─────────────────────────────────
+// A file that compiles cleanly must not be flooded with false errors. The F#
+// sidecar's persistent project options must resolve the project's restored
+// NuGet package references; otherwise every external `open`/type is reported as
+// an unresolved-reference error even though `dotnet build` succeeds. Regression
+// guard for issue #120 (F# false errors everywhere despite compiling cleanly).
+#[test]
+fn test_full_stack_fsharp_nuget_reference_resolves_no_false_errors() {
+    require_dotnet();
+
+    let (_tmp, root_uri, file_uri, source) = create_fsharp_nuget_workspace();
+    let mut client = LspClient::start_verbose();
+    let _ = client.initialize_with_root(json!(root_uri));
+    client.open_document(&file_uri, &source);
+
+    // Block until the FCS background project load completes. Hover on the local
+    // `Serializer` module (line 5, char 7) resolves from in-source symbols and is
+    // unaffected by a missing external reference, so it is a clean readiness
+    // signal even while the (bug) reference set is incomplete.
+    let ready = poll_hover_until_ready(&mut client, &file_uri, 5, 7, Duration::from_secs(90));
+    assert!(
+        !ready.is_null(),
+        "F# sidecar must load the project before diagnostics can be trusted"
+    );
+
+    // Pull diagnostics synchronously — deterministic, no publish race.
+    let resp = client.request(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": file_uri } }),
+    );
+    assert!(
+        resp.get("error").is_none(),
+        "pull diagnostics must not return an error: {resp}"
+    );
+    assert!(
+        resp["result"]["items"].is_array(),
+        "diagnostic report must carry an items array: {resp}"
+    );
+    let items = resp["result"]["items"].as_array().unwrap();
+
+    // The file `open`s the restored Newtonsoft.Json package and calls
+    // `JsonConvert` — both resolve once the sidecar feeds FCS the project's
+    // package references. Any Error-severity diagnostic here is a false positive
+    // from an incomplete reference set (#120).
+    let errors: Vec<&Value> = items
+        .iter()
+        .filter(|d| d["severity"].as_u64() == Some(1))
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "F# file that opens a restored NuGet package must compile clean — the F# \
+         sidecar's project options are missing the resolved package references, so \
+         `open Newtonsoft.Json` / `JsonConvert` are falsely flagged (#120). \
+         Errors: {errors:?}"
+    );
+
+    client.shutdown_and_exit();
+    client.wait_with_timeout();
+}
+
 // ── F# Navigation (Full-Stack) ──────────────────────────────────
 // Exercises the host→F# sidecar routing for go-to-definition, type-definition,
 // project-wide references, and document highlights. FSAC parity: these are the

--- a/tests/e2e_modules/workspace_symbols.rs
+++ b/tests/e2e_modules/workspace_symbols.rs
@@ -221,6 +221,104 @@ fn test_workspace_symbols_access_modifiers() {
     client.wait_with_timeout();
 }
 
+// F# is a first-class language: an `.fsproj` in the Solution Explorer must show
+// its `.fs` source files and their symbols exactly the way a `.csproj` shows its
+// `.cs` files — not just the Dependencies node. The host has no F# tree-sitter
+// grammar, so F# file symbols must come from the FCS sidecar's documentSymbol,
+// not the (bailing) tree-sitter path that silently drops every `.fs` file.
+// Regression guard for issue #119 (F# files & symbols missing from the tree).
+#[test]
+fn test_workspace_symbols_includes_fsharp_files_and_symbols() {
+    // Collect symbol names recursively (declared first so it precedes statements).
+    fn collect_names(symbols: &[Value], out: &mut Vec<String>) {
+        for symbol in symbols {
+            if let Some(name) = symbol["name"].as_str() {
+                out.push(name.to_string());
+            }
+            if let Some(children) = symbol["children"].as_array() {
+                collect_names(children, out);
+            }
+        }
+    }
+
+    require_dotnet();
+
+    let (tmp, _root_uri, _file_uri, _source) = create_fsharp_test_workspace();
+    let sln_path = tmp
+        .path()
+        .canonicalize()
+        .unwrap()
+        .join("TestFSharp.sln")
+        .to_string_lossy()
+        .to_string();
+
+    let mut client = LspClient::start_verbose();
+    initialize_workspace_symbols_client(&mut client, &tmp);
+
+    // Poll until the F# project reports its file symbols — the FCS sidecar must
+    // finish its background project load first. Before the fix this never
+    // happens: F# files are dropped because the host parses them with
+    // tree-sitter, which has no F# grammar, so the project's `symbols` stays
+    // empty forever and the loop times out.
+    let deadline = std::time::Instant::now() + Duration::from_secs(90);
+    let mut last = json!(null);
+    let file_symbols = loop {
+        let resp = client.request("sharplsp/workspaceSymbols", json!({ "solution": sln_path }));
+        assert!(resp.get("error").is_none(), "must not error: {resp}");
+        last = resp.clone();
+
+        let symbols = resp["result"]["projects"]
+            .as_array()
+            .and_then(|projects| projects.iter().find(|p| p["name"] == "TestFSharp"))
+            .and_then(|proj| proj["symbols"].as_array().cloned());
+
+        if let Some(symbols) = symbols {
+            if !symbols.is_empty() {
+                break symbols;
+            }
+        }
+
+        assert!(
+            std::time::Instant::now() < deadline,
+            "F# project 'TestFSharp' must expose its `.fs` files and symbols in the \
+             Solution Explorer like C# projects do, but `symbols` stayed empty — F# \
+             files are dropped by the tree-sitter-only extraction (#119). Last: {last}"
+        );
+        std::thread::sleep(Duration::from_secs(2));
+    };
+
+    // The `.fs` source file must be present under the project node.
+    let library = file_symbols.iter().find(|f| {
+        f["file"]
+            .as_str()
+            .is_some_and(|path| path.ends_with("Library.fs"))
+    });
+    assert!(
+        library.is_some(),
+        "F# project must include Library.fs: {file_symbols:?}"
+    );
+    let library = library.unwrap();
+
+    // …and that file must carry its module + members, recursively.
+    let mut names = Vec::new();
+    collect_names(
+        library["symbols"]
+            .as_array()
+            .expect("Library.fs must carry a symbols array"),
+        &mut names,
+    );
+
+    for expected in ["Calculator", "add", "Shape", "area"] {
+        assert!(
+            names.iter().any(|name| name == expected),
+            "F# Library.fs must expose `{expected}` in the tree like C# symbols, got: {names:?}"
+        );
+    }
+
+    client.shutdown_and_exit();
+    client.wait_with_timeout();
+}
+
 #[test]
 fn test_workspace_symbols_nonexistent_solution() {
     let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## TLDR

Make F# a true first-class citizen in the Solution Explorer + diagnostics by fixing three critical bugs: F# files & symbols now appear in the tree (#119), restored package references resolve so a compiling file shows no false errors (#120), and the tree follows the active editor (#118).

## Details

**#120 — F# false errors everywhere despite compiling cleanly.** The F# sidecar built its persistent `FSharpProjectOptions` from only the framework reference assemblies + `FSharp.Core`, never the project's restored package references — so every external `open`/type (`open Newtonsoft.Json`, `Serilog`, `FSharp.Compiler.*`, …) was flagged `FS0039` even though the project builds. The `project.assets.json` resolution already existed but was used *only* by the unused-package analyzer. Extracted it into a new shared `FSharpAssets` module and routed it into a single project-options builder, `FSharpWorkspace.buildProjectOptions`, now used by diagnostics/hover/completion **and** the unused-package analyzer (DRY). Package `-r:` args are filtered to assemblies that exist on disk so project-reference `bin/placeholder` entries never reach FCS as missing references.
- New `sidecars/SharpLsp.Sidecar.FSharp/FSharpAssets.fs` (parse assets → compile assemblies → `-r:` args)
- `FSharpWorkspace.fs`: `buildProjectOptions` (framework refs + package refs + sources); `loadFirstProject` uses it
- `FSharpPackages.fs`: now consumes `FSharpAssets` + the shared options builder (duplicated JSON parsing removed)

**#119 — F# files & symbols missing from the Solution Explorer.** `workspace_symbols` extracted per-file symbols only via tree-sitter, which has no F# grammar and silently dropped every `.fs` file (F# projects showed only their Dependencies node). `.fs` files are now routed to the FCS sidecar's `textDocument/documentSymbol` — the same path that powers the editor outline — and mapped into the tree's `SymbolNode` model. The F# sidecar is threaded through `workspace_symbols::handle`.
- `workspace_symbols.rs`: `file_symbols` language dispatch, `parse_fsharp_file_symbols`, `map_sidecar_symbol`
- `document_symbols.rs`: `pub(crate)` `SidecarDocumentSymbol` + shared `fetch_fsharp_document_symbols`
- `main.rs`: pass `fsharp_sidecar` into the handler
- Spec: `SOLUTION-EXPLORER-SPEC.md` → new `[SE-FSHARP-SYMBOLS]`

**#118 — Solution Explorer doesn't sync with the active editor.** No `TreeView` handle was retained, the provider had no `getParent()`, and there was no active-editor listener. Added `getParent()` + `findNodeForUri()` to `SolutionExplorerProvider`, fully wired parent pointers (solution → project → namespace/symbol) so `reveal()` can walk a complete chain, retained the `TreeView`, and added `wireActiveEditorReveal` which reveals + selects the active file's node on editor change, tree repopulation, and view-visibility. Gated by a new `sharplsp.solutionExplorer.autoReveal` setting (default on). Implements `[SE-ACTIVE-EDITOR-SYNC]`.
- `tree.ts`, `extension.ts`, `package.json`, `package.nls.json`

**#110** — triaged as a separate **Windows-only sidecar start-up crash** (the process exits before emitting `READY:`), distinct from #120 (a *post*-READY project-options bug). Not reproducible on macOS/Linux; documented on the issue and intentionally excluded from this PR.

## How Do The Automated Tests Prove It Works?

Each fix has a test that fails before the change and passes after (TDD red→green confirmed locally).

- **#120** — `test_full_stack_fsharp_nuget_reference_resolves_no_false_errors` (`tests/e2e_modules/fsharp.rs`): loads a real F# project that `open`s a restored `Newtonsoft.Json`, pulls `textDocument/diagnostic`, and asserts **no** Error-severity diagnostics. Before the fix the pull returned two `FS0039` errors (`The namespace or module 'Newtonsoft' is not defined`; `'JsonConvert' is not defined`); after, zero. New fixture `create_fsharp_nuget_workspace`.
- **#119** — `test_workspace_symbols_includes_fsharp_files_and_symbols` (`tests/e2e_modules/workspace_symbols.rs`): issues `sharplsp/workspaceSymbols` on an `.fsproj` solution and asserts the F# project node contains `Library.fs` with `Calculator`, `add`, `Shape`, `area`. Before the fix the project returned `symbols: []`; after, the full symbol tree.
- **#118** — `SolutionExplorerProvider — active editor reveal` suite (4 tests, `unit-tree.test.ts`): `findNodeForUri` resolves the node for a file URI; `getParent` walks a **complete** chain from a file node up to the solution root. Before the fix the chain terminated at `namespace` (so `reveal()` would silently no-op); after, it reaches `solution`.

Full local CI is green: **Rust 642** tests, **.NET 780** tests, the **VS Code extension** suite, all lints (clippy/fmt, eslint/tsc/prettier, csharpier), with coverage within thresholds.

Closes #120, #119, #118.
