### PR TITLE
fix(completion): replace identifier at caret instead of appending (#178)

### DIFF
--- a/docs/specs/SHARPLSP-SPEC.md
+++ b/docs/specs/SHARPLSP-SPEC.md
@@ -288,12 +288,19 @@ This section specifies every feature SharpLsp will implement, mapped to the LSP 
 |---|---|---|---|---|
 | Auto-completion | `textDocument/completion` | [CompletionService.GetCompletionsAsync()](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.completion.completionservice.getcompletionsasync) | GetDeclarationListInfo() | P0 |
 | Completion resolve | `completionItem/resolve` | [CompletionService.GetDescriptionAsync()](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.completion.completionservice.getdescriptionasync) | GetDeclarationListInfo (detail) | P0 |
+| Completion edit semantics | `textDocument/completion` | `GetDefaultCompletionListSpan` + trailing-ident extension → `textEdit` — `[COMPLETION-EDIT-REPLACE]` | `QuickParse.GetPartialLongNameEx` island + trailing-ident extension → `textEdit` — `[COMPLETION-EDIT-REPLACE]` | P0 |
 | Hover / Quick Info | `textDocument/hover` | See [HOVER-SPEC.md](HOVER-SPEC.md) | See [HOVER-SPEC.md](HOVER-SPEC.md) | P0 |
 | Signature help | `textDocument/signatureHelp` | SignatureHelpService.GetItemsAsync() | GetMethods() | P0 |
 | Parameter hints | `textDocument/signatureHelp` | Same (active parameter tracking) | Same (active parameter tracking) | P0 |
 | Inlay hints (types) | `textDocument/inlayHint` | Type inference display | Type inference display | P1 |
 | Inlay hints (params) | `textDocument/inlayHint` | Parameter name hints | Parameter name hints | P1 |
 | Inline values | `textDocument/inlineValue` | Debugger expression eval | Debugger expression eval | P2 |
+
+#### Completion edit semantics `[COMPLETION-EDIT-REPLACE]`
+
+Every completion item returned by either sidecar carries an explicit LSP `textEdit`, not just an `insertText`. Its range is the identifier span **at the caret** — the typed prefix to the left of the cursor *plus any identifier characters that already follow it on the same line*. Accepting an item therefore **replaces** that identifier instead of being appended to it: completing `WriteLine` at `Console.|WriteLine` yields `Console.WriteLine`, never `Console.WriteLineWriteLine` (GitHub #178). Without a `textEdit` the editor falls back to its own word-boundary heuristic, which appends after a member-access trigger character and duplicates the identifier.
+
+The C# sidecar derives the span from [`CompletionService.GetDefaultCompletionListSpan`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.completion.completionservice.getdefaultcompletionlistspan) extended over trailing identifier characters; the F# sidecar derives it from the FCS partial-name island (`QuickParse.GetPartialLongNameEx`) with the same trailing-character extension. The `NewText` is the item's insert text. The Rust host maps the flat sidecar edit onto `CompletionItem.textEdit` in `src/semantic.rs`.
 
 ### 4.2 Navigation
 

--- a/sidecars/SharpLsp.Sidecar.CSharp.Tests/WorkspaceManagerFeatureCoverageTests.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp.Tests/WorkspaceManagerFeatureCoverageTests.cs
@@ -245,6 +245,26 @@ public sealed class WorkspaceManagerFeatureCoverageTests : IDisposable
     }
 
     [Fact]
+    public async Task Completion_supplies_text_edit_that_replaces_identifier_at_caret()
+    {
+        // GitHub #178 / [COMPLETION-EDIT-REPLACE]: the caret sits at the START of
+        // `Compute` in `var result = Compute(input);` (line 18, col 21). The item's
+        // textEdit must span the whole identifier so acceptance REPLACES it rather
+        // than appending (which would yield `ComputeCompute`).
+        using var manager = await OpenAsync();
+
+        var items = Unwrap(await manager.GetCompletionsAsync(_sourcePath, 18, 21));
+        var compute = items.Find(item => item.Label == "Compute");
+        Assert.NotNull(compute);
+        Assert.NotNull(compute!.TextEdit);
+        Assert.Equal(18, compute.TextEdit!.StartLine);
+        Assert.Equal(21, compute.TextEdit.StartCharacter);
+        Assert.Equal(18, compute.TextEdit.EndLine);
+        Assert.Equal(21 + "Compute".Length, compute.TextEdit.EndCharacter);
+        Assert.Equal("Compute", compute.TextEdit.NewText);
+    }
+
+    [Fact]
     public async Task ResolveCompletion_after_completion_returns_resolve_result()
     {
         using var manager = await OpenAsync();

--- a/sidecars/SharpLsp.Sidecar.CSharp/Messages.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp/Messages.cs
@@ -44,6 +44,15 @@ internal sealed class CompletionItem
 
     [Key(4)]
     public int Index { get; init; }
+
+    /// <summary>
+    /// Edit that REPLACES the identifier span at the caret when the item is
+    /// accepted. Without it the editor appends <see cref="InsertText"/> to the
+    /// trigger text, duplicating the member name (GitHub #178).
+    /// Implements [COMPLETION-EDIT-REPLACE].
+    /// </summary>
+    [Key(5)]
+    public TextEditResult? TextEdit { get; init; }
 }
 
 [MessagePackObject(AllowPrivate = true)]

--- a/sidecars/SharpLsp.Sidecar.CSharp/Workspace/WorkspaceManager.Helpers.cs
+++ b/sidecars/SharpLsp.Sidecar.CSharp/Workspace/WorkspaceManager.Helpers.cs
@@ -85,34 +85,74 @@ internal sealed partial class WorkspaceManager
 
         _lastCompletionList = completions;
         _lastCompletionDocument = document;
-        return MapCompletionItems(completions);
+        var editSpan = ComputeCompletionEditSpan(service, text, position);
+        return MapCompletionItems(completions, editSpan);
     }
 
-    private static List<CompletionItem> MapCompletionItems(CompletionList completions)
+    // Roslyn's default completion span covers the typed prefix to the LEFT of the
+    // caret; extend it over any identifier characters that already follow the caret
+    // so an accepted item REPLACES an existing member name instead of being appended
+    // to it (`Console.WriteLineWriteLine`). GitHub #178.
+    // Implements [COMPLETION-EDIT-REPLACE].
+    private static LinePositionSpan ComputeCompletionEditSpan(
+        CompletionService service,
+        SourceText text,
+        int position
+    )
     {
-        var results = new List<CompletionItem>();
+        var span = service.GetDefaultCompletionListSpan(text, position);
+        var end = span.End;
+        while (
+            end < text.Length
+            && Microsoft.CodeAnalysis.CSharp.SyntaxFacts.IsIdentifierPartCharacter(text[end])
+        )
+        {
+            end++;
+        }
+
+        return text.Lines.GetLinePositionSpan(TextSpan.FromBounds(span.Start, end));
+    }
+
+    private static List<CompletionItem> MapCompletionItems(
+        CompletionList completions,
+        LinePositionSpan editSpan
+    )
+    {
+        var results = new List<CompletionItem>(completions.ItemsList.Count);
         for (var i = 0; i < completions.ItemsList.Count; i++)
         {
-            var item = completions.ItemsList[i];
-            // Items from unimported namespaces have InlineDescription set to the namespace.
-            var hasImportHint =
-                item.InlineDescription.Length > 0 && !string.IsNullOrEmpty(item.InlineDescription);
-            var detail = hasImportHint
-                ? $"(import) {item.InlineDescription}"
-                : item.InlineDescription;
-            results.Add(
-                new CompletionItem
-                {
-                    Label = item.DisplayText,
-                    Kind = item.Tags.Length > 0 ? item.Tags[0] : "Text",
-                    Detail = detail,
-                    InsertText = item.FilterText,
-                    Index = i,
-                }
-            );
+            results.Add(MapOneCompletionItem(completions.ItemsList[i], i, editSpan));
         }
 
         return results;
+    }
+
+    private static CompletionItem MapOneCompletionItem(
+        Microsoft.CodeAnalysis.Completion.CompletionItem item,
+        int index,
+        LinePositionSpan editSpan
+    )
+    {
+        // Items from unimported namespaces have InlineDescription set to the namespace.
+        var hasImportHint =
+            item.InlineDescription.Length > 0 && !string.IsNullOrEmpty(item.InlineDescription);
+        var detail = hasImportHint ? $"(import) {item.InlineDescription}" : item.InlineDescription;
+        return new CompletionItem
+        {
+            Label = item.DisplayText,
+            Kind = item.Tags.Length > 0 ? item.Tags[0] : "Text",
+            Detail = detail,
+            InsertText = item.FilterText,
+            Index = index,
+            TextEdit = new TextEditResult
+            {
+                StartLine = editSpan.Start.Line,
+                StartCharacter = editSpan.Start.Character,
+                EndLine = editSpan.End.Line,
+                EndCharacter = editSpan.End.Character,
+                NewText = item.FilterText,
+            },
+        };
     }
 
     internal async Task<CompletionResolveResult> ResolveCompletionAsync(

--- a/sidecars/SharpLsp.Sidecar.FSharp.Tests/SidecarEndToEndTests.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp.Tests/SidecarEndToEndTests.fs
@@ -1005,6 +1005,22 @@ type SidecarEndToEndTests(fixture: SidecarFixture) =
     }
 
     [<Fact>]
+    member _.``completion supplies a text edit that replaces the member at the caret``() = task {
+        // GitHub #178 / [COMPLETION-EDIT-REPLACE]: `greeter.|Greet` at line 28 — the
+        // accepted item must REPLACE the identifier at the caret, so the edit spans
+        // `Greet` rather than being appended (which would yield `greeter.GreetGreet`).
+        let! r = fixture.Send("textDocument/completion", posPayload fixture.Src 28 12)
+        Assert.Null(r.Error)
+        let items = deserialize<CompletionItemResult array>(r.Payload)
+        let greet = items |> Array.find (fun i -> i.Label = "Greet")
+        Assert.Equal(28, greet.TextEdit.StartLine)
+        Assert.Equal(12, greet.TextEdit.StartCharacter)
+        Assert.Equal(28, greet.TextEdit.EndLine)
+        Assert.Equal(12 + "Greet".Length, greet.TextEdit.EndCharacter)
+        Assert.Equal(greet.InsertText, greet.TextEdit.NewText)
+    }
+
+    [<Fact>]
     member _.``completion items carry a kind and index``() = task {
         let! r = fixture.Send("textDocument/completion", posPayload fixture.Src 28 12)
         Assert.Null(r.Error)

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpCompletion.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpCompletion.fs
@@ -3,6 +3,7 @@
 /// docs/plans/FSHARP-FEATURES-PLAN.md.
 module SharpLsp.Sidecar.FSharp.FSharpCompletion
 
+open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Tokenization
 open Serilog
@@ -15,7 +16,13 @@ type CompletionEntry =
       Kind: string
       Detail: string option
       InsertText: string
-      Index: int }
+      Index: int
+      /// 0-based line/character span the accepted item REPLACES, so it is not
+      /// appended to the identifier at the caret (`product.PricePrice`). #178.
+      EditStartLine: int
+      EditStartCharacter: int
+      EditEndLine: int
+      EditEndCharacter: int }
 
 /// Map an FCS glyph to the kind strings the Rust host's `map_completion_kind`
 /// understands (see src/semantic.rs). Anything unmapped falls back to "Keyword".
@@ -51,13 +58,63 @@ let private detailFor (item: DeclarationListItem) : string option =
     | Some ns when not (System.String.IsNullOrEmpty ns) -> Some $"(open {ns})"
     | _ -> None
 
-/// Convert one FCS declaration item to a domain completion entry.
-let private toEntry (index: int) (item: DeclarationListItem) : CompletionEntry =
+/// F# identifier-continuation characters, used to grow the replacement span over
+/// any member name already present after the caret (mirrors the compiler lexer).
+let private isIdentifierPart (c: char) =
+    System.Char.IsLetterOrDigit c || c = '_' || c = '\''
+
+/// 0-based line/character span the accepted item must REPLACE: the typed partial
+/// identifier to the LEFT of the caret plus any identifier characters that already
+/// follow it on the same line. Prevents `product.PricePrice` (GitHub #178).
+/// Implements [COMPLETION-EDIT-REPLACE].
+let private editSpanFor (lineText: string) (line: int) (character: int) (partialIdent: string) =
+    let startCharacter = max 0 (character - partialIdent.Length)
+    let mutable endCharacter = min character lineText.Length
+    while endCharacter < lineText.Length && isIdentifierPart lineText[endCharacter] do
+        endCharacter <- endCharacter + 1
+    (line, startCharacter, line, endCharacter)
+
+/// Convert one FCS declaration item to a domain completion entry, stamping the
+/// shared replacement span so acceptance replaces (not appends) the identifier.
+let private toEntry
+    (spanLine: int, spanStart: int, spanEndLine: int, spanEnd: int)
+    (index: int)
+    (item: DeclarationListItem)
+    : CompletionEntry =
     { Label = item.NameInList
       Kind = glyphToKind item.Glyph
       Detail = detailFor item
       InsertText = item.NameInCode
-      Index = index }
+      Index = index
+      EditStartLine = spanLine
+      EditStartCharacter = spanStart
+      EditEndLine = spanEndLine
+      EditEndCharacter = spanEnd }
+
+/// Build completion entries from a completed FCS check. Kept synchronous and out
+/// of the `task` state machine in `getCompletions` so that block stays statically
+/// compilable (FS3511) as the mapping logic grows.
+let private buildEntries
+    (parseResults: FSharpParseFileResults)
+    (checkResults: FSharpCheckFileResults)
+    (source: string)
+    (line: int)
+    (character: int)
+    : CompletionEntry list =
+    let lines = source.Split('\n')
+    if line >= lines.Length then
+        []
+    else
+        let lineText = lines[line]
+        // GetPartialLongNameEx wants the 0-based index of the last character before
+        // the caret; the caret sits at `character`.
+        let index = min (character - 1) (lineText.Length - 1)
+        let partialName = QuickParse.GetPartialLongNameEx(lineText, index)
+        let span = editSpanFor lineText line character partialName.PartialIdent
+        let info =
+            checkResults.GetDeclarationListInfo(
+                Some parseResults, line + 1, lineText, partialName, (fun () -> []))
+        info.Items |> Array.mapi (toEntry span) |> Array.toList
 
 /// Get completion items at a 0-based position in an F# file.
 let getCompletions
@@ -72,19 +129,7 @@ let getCompletions
             match checkData with
             | None -> return []
             | Some(parseResults, checkResults, source) ->
-                let lines = source.Split('\n')
-                if line >= lines.Length then
-                    return []
-                else
-                    let lineText = lines[line]
-                    // GetPartialLongNameEx wants the 0-based index of the last
-                    // character before the caret; the caret sits at `character`.
-                    let index = min (character - 1) (lineText.Length - 1)
-                    let partialName = QuickParse.GetPartialLongNameEx(lineText, index)
-                    let info =
-                        checkResults.GetDeclarationListInfo(
-                            Some parseResults, line + 1, lineText, partialName, (fun () -> []))
-                    return info.Items |> Array.mapi toEntry |> Array.toList
+                return buildEntries parseResults checkResults source line character
         with ex ->
             Log.Debug(ex, "[F# Completion] failed")
             return []

--- a/sidecars/SharpLsp.Sidecar.FSharp/FSharpWire.fs
+++ b/sidecars/SharpLsp.Sidecar.FSharp/FSharpWire.fs
@@ -183,7 +183,10 @@ type CompletionItemResult =
       [<Key(1)>] Kind: string
       [<Key(2)>] Detail: string
       [<Key(3)>] InsertText: string
-      [<Key(4)>] Index: int }
+      [<Key(4)>] Index: int
+      /// Edit that REPLACES the identifier span at the caret so acceptance does
+      /// not append the member name to the trigger text (GitHub #178).
+      [<Key(5)>] TextEdit: TextEditResult }
 
 [<MessagePackObject(AllowPrivate = true)>]
 [<NoComparison; NoEquality>]
@@ -362,7 +365,13 @@ module internal Helpers =
           Kind = entry.Kind
           Detail = (match entry.Detail with Some value -> value | None -> Unchecked.defaultof<string>)
           InsertText = entry.InsertText
-          Index = entry.Index }
+          Index = entry.Index
+          TextEdit =
+            { StartLine = entry.EditStartLine
+              StartCharacter = entry.EditStartCharacter
+              EndLine = entry.EditEndLine
+              EndCharacter = entry.EditEndCharacter
+              NewText = entry.InsertText } }
 
     /// Group flat rename edits into a per-document workspace edit.
     let toWorkspaceEdit (edits: FSharpCodeActions.RawEdit list) : WorkspaceEditResult =

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -9,17 +9,17 @@ use std::sync::Arc;
 use anyhow::Result;
 use lsp_server::Request;
 use lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse, DocumentHighlight,
-    DocumentHighlightKind, DocumentHighlightParams, GotoDefinitionParams, GotoDefinitionResponse,
-    Hover, HoverContents, HoverParams, Location, MarkupContent, MarkupKind, OneOf, Position,
-    PrepareRenameResponse, Range, ReferenceParams, RenameParams, TextDocumentPositionParams,
-    TextEdit, Uri, WorkspaceEdit,
+    CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse, CompletionTextEdit,
+    DocumentHighlight, DocumentHighlightKind, DocumentHighlightParams, GotoDefinitionParams,
+    GotoDefinitionResponse, Hover, HoverContents, HoverParams, Location, MarkupContent, MarkupKind,
+    OneOf, Position, PrepareRenameResponse, Range, ReferenceParams, RenameParams,
+    TextDocumentPositionParams, TextEdit, Uri, WorkspaceEdit,
 };
 use tracing::{debug, info, warn};
 
 use crate::nav_cache::is_empty_nav_result;
 use crate::sidecar::manager::SidecarManager;
-use crate::utils::{map_text_edits, SidecarTextEdit};
+use crate::utils::{map_text_edit, map_text_edits, SidecarTextEdit};
 
 /// Handle `textDocument/completion` via the .NET sidecar + postfix templates.
 pub fn handle_completion(
@@ -65,6 +65,13 @@ pub fn handle_completion(
                         kind: Some(map_completion_kind(&item.kind)),
                         detail: item.detail,
                         insert_text: item.insert_text,
+                        // A textEdit makes acceptance REPLACE the identifier span
+                        // at the caret instead of appending it (GitHub #178).
+                        // Implements [COMPLETION-EDIT-REPLACE].
+                        text_edit: item
+                            .text_edit
+                            .as_ref()
+                            .map(|edit| CompletionTextEdit::Edit(map_text_edit(edit))),
                         data: Some(data),
                         ..CompletionItem::default()
                     }
@@ -816,6 +823,10 @@ struct SidecarCompletionItem {
     insert_text: Option<String>,
     /// Sidecar-internal index used for resolve requests.
     index: i32,
+    /// Edit that replaces the identifier span at the caret so acceptance does
+    /// not append the member name to the trigger text (GitHub #178).
+    /// Implements [COMPLETION-EDIT-REPLACE].
+    text_edit: Option<SidecarTextEdit>,
 }
 
 /// Sidecar request to resolve additional details for a completion item.

--- a/tests/e2e_modules/full_stack_semantic.rs
+++ b/tests/e2e_modules/full_stack_semantic.rs
@@ -53,6 +53,85 @@ fn test_full_stack_completion_returns_items() {
     client.wait_with_timeout();
 }
 
+/// Regression test for GitHub #178: member completion after `.` must return a
+/// `textEdit` that REPLACES the identifier at the caret, not a bare `insertText`
+/// the client appends. Accepting `Name` at `calc.|Name` must yield `calc.Name`,
+/// never `calc.NameName`. Implements [COMPLETION-EDIT-REPLACE].
+#[test]
+fn test_member_completion_replaces_identifier_not_appends_issue_178() {
+    require_dotnet();
+
+    let (_tmp, root_uri, file_uri, source) = create_test_workspace();
+    let mut client = LspClient::start_verbose();
+    let _ = client.initialize_with_root(json!(root_uri));
+    client.open_document(&file_uri, &source);
+
+    // Wait until the sidecar has loaded the workspace (hover answers).
+    let _ = poll_hover_until_ready(&mut client, &file_uri, 3, 14, Duration::from_secs(90));
+
+    // `        var name = calc.Name;` is 0-based line 43; char 24 is right after
+    // `calc.`, with the existing `Name` identifier immediately following the caret.
+    let (comp_line, comp_char) = (43_u32, 24_u32);
+    let member = "Name";
+
+    // Poll completion until the sidecar offers the member.
+    let deadline = Instant::now() + Duration::from_mins(1);
+    let name_item = loop {
+        let resp = client.request(
+            "textDocument/completion",
+            json!({
+                "textDocument": { "uri": file_uri },
+                "position": { "line": comp_line, "character": comp_char }
+            }),
+        );
+        assert!(
+            resp.get("error").is_none(),
+            "completion must not error: {resp}"
+        );
+        let found = resp["result"]
+            .as_array()
+            .or_else(|| resp["result"]["items"].as_array())
+            .and_then(|items| {
+                items
+                    .iter()
+                    .find(|i| i["label"].as_str() == Some(member))
+                    .cloned()
+            });
+        if let Some(item) = found {
+            break item;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "completion never offered `{member}` after `calc.`: {resp}"
+        );
+        std::thread::sleep(Duration::from_secs(2));
+    };
+
+    // The bug: the item carries only `insertText`, so the editor appends it to
+    // the trigger text, producing `calc.NameName`. The fix supplies a `textEdit`
+    // whose range covers the identifier at the caret so acceptance replaces it.
+    let text_edit = name_item["textEdit"].clone();
+    assert!(
+        text_edit.is_object(),
+        "completion item `{member}` must carry a textEdit that replaces the \
+         identifier at the caret (GitHub #178), got item: {name_item}"
+    );
+
+    // Applying the edit must REPLACE the identifier, never duplicate it.
+    let edited = apply_text_edits(&source, std::slice::from_ref(&text_edit));
+    assert!(
+        edited.contains("var name = calc.Name;"),
+        "applying the completion textEdit must yield `calc.Name` (replace), got:\n{edited}"
+    );
+    assert!(
+        !edited.contains("calc.NameName"),
+        "completion textEdit must not duplicate the identifier (GitHub #178), got:\n{edited}"
+    );
+
+    client.shutdown_and_exit();
+    client.wait_with_timeout();
+}
+
 #[test]
 fn test_full_stack_completion_no_sidecar_returns_postfix_or_null() {
     // Without a workspace root the C# sidecar is not started; completion

--- a/tests/e2e_modules/user_session_fsharp.rs
+++ b/tests/e2e_modules/user_session_fsharp.rs
@@ -145,6 +145,26 @@ fn test_full_stack_fsharp_user_session_medium_codebase() {
             "completion after `product.` must offer the record field `{field}`: {labels:?}"
         );
     }
+
+    // GitHub #178 (F# parity): the accepted item must carry a `textEdit` that
+    // REPLACES the identifier at the caret, so `product.|Price` yields
+    // `product.Price`, never `product.PricePrice`. Implements [COMPLETION-EDIT-REPLACE].
+    let price_item = items
+        .iter()
+        .find(|i| i["label"].as_str() == Some("Price"))
+        .unwrap_or_else(|| panic!("completion must offer `Price`: {completion}"));
+    let price_edit = price_item["textEdit"].clone();
+    assert!(
+        price_edit.is_object(),
+        "F# completion item `Price` must carry a textEdit that replaces the \
+         identifier at the caret (GitHub #178), got item: {price_item}"
+    );
+    let edited = apply_text_edits(&probe_source, std::slice::from_ref(&price_edit));
+    assert!(
+        edited.contains("= product.Price\n") && !edited.contains("product.PricePrice"),
+        "applying the F# completion textEdit must replace, not duplicate, the field (GitHub #178):\n{edited}"
+    );
+
     client.change_document(&calculations_uri, 3, CALCULATIONS_FS);
 
     // ── Signature help contract at the settle call site ([FS-SIGHELP]) ──


### PR DESCRIPTION
## TLDR

Member completion after `.` now returns an LSP `textEdit` that replaces the identifier at the caret, fixing the duplicated-member bug (`Console.WriteLineWriteLine`) in both the C# and F# sidecars. Closes #178.

## Details

**Root cause:** completion items were sent with only `insertText` and no `textEdit`. Per the LSP spec, without a `textEdit` the editor falls back to its own word-boundary heuristic, which — after a member-access trigger character — appends the accepted item instead of replacing the identifier at the caret, duplicating it.

**Fix** — new spec contract `[COMPLETION-EDIT-REPLACE]` (`docs/specs/SHARPLSP-SPEC.md`), cross-referenced from every implementing file:

- **C# sidecar** (`Workspace/WorkspaceManager.Helpers.cs`, `Messages.cs`): derive the replacement span from Roslyn's `CompletionService.GetDefaultCompletionListSpan`, extended over trailing identifier characters (`SyntaxFacts.IsIdentifierPartCharacter`), and attach it as a new `CompletionItem.TextEdit` (`TextEditResult`, MessagePack `Key(5)`) with `NewText = FilterText`.
- **F# sidecar** (`FSharpCompletion.fs`, `FSharpWire.fs`): derive the span from the FCS partial-name island (`QuickParse.GetPartialLongNameEx.PartialIdent`) with the same trailing-character extension; add wire-compatible `CompletionItemResult.TextEdit` (`Key(5)`). The synchronous mapping was extracted into `buildEntries` so the `task` state machine stays statically compilable (FS3511) as the logic grew.
- **Rust host** (`src/semantic.rs`): deserialize the new `text_edit` field and map it onto `CompletionItem.textEdit` via `CompletionTextEdit::Edit`.

**Modified behaviour:** accepting a member completion now replaces the identifier span at the caret rather than appending — `Console.WriteLine`, never `Console.WriteLineWriteLine`; `product.Price`, never `product.PricePrice`. No new dependencies, no deletions.

## How Do The Automated Tests Prove It Works?

Four coarse e2e tests were added/strengthened. Each was confirmed to **fail before the fix** (the item carried no `textEdit`) and pass after:

- **`test_member_completion_replaces_identifier_not_appends_issue_178`** (Rust full-stack, `tests/e2e_modules/full_stack_semantic.rs`): drives the real LSP host + Roslyn sidecar, requests completion at `calc.|Name`, asserts the `Name` item carries a `textEdit`, then applies it and asserts the result contains `var name = calc.Name;` and **not** `calc.NameName`.
- **`test_full_stack_fsharp_user_session_medium_codebase`** (Rust full-stack, F# parity, `tests/e2e_modules/user_session_fsharp.rs`): asserts the `Price` item at `product.|Price` carries a `textEdit` whose application yields `= product.Price` and **not** `product.PricePrice`.
- **`Completion_supplies_text_edit_that_replaces_identifier_at_caret`** (C# sidecar, real csproj + Roslyn): asserts the `Compute` item's textEdit spans line 18 cols 21→28 with `NewText = "Compute"`.
- **`completion supplies a text edit that replaces the member at the caret`** (F# sidecar, real FCS): asserts the `Greet` item's textEdit spans line 28 cols 12→17 with `NewText = InsertText`.

**Full local CI is green:** `cargo fmt`/`clippy -D warnings`, `csharpier check`, `.NET` warnings-as-errors build, ESLint + `tsc`, prettier, Zed `clippy`; **877 .NET sidecar tests** pass with coverage C# 95.04% / F# 94.11% / Common 95.67%, and **648 Rust tests** pass with coverage 95.55% — all above their ratcheted thresholds.
