### PR TITLE
Microsoft.Testing.Platform support in the Test Explorer

### DIFF
--- a/docs/plans/TEST-EXPLORER-MTP-PLAN.md
+++ b/docs/plans/TEST-EXPLORER-MTP-PLAN.md
@@ -1,0 +1,126 @@
+# Test Explorer — Microsoft.Testing.Platform Plan
+
+Implements [TEST-MTP-DETECT], [TEST-MTP-MODULES], [TEST-MTP-DISCOVERY], [TEST-MTP-RUN] and
+[TEST-MTP-DEBUG] in `docs/specs/TEST-EXPLORER-SPEC.md`. Source issue: Nimblesite/SharpLsp#249.
+
+## Why
+
+The Test Explorer was VSTest end to end. Microsoft.Testing.Platform (MTP) projects got an
+empty Testing view, because every VSTest command fails against them. On the .NET 10 SDK,
+MTP v2 removed the VSTest shim and `xunit.v3` 4.0.0 uses MTP v2 by default, so this is now
+the usual case, not an edge case.
+
+## Measured behaviour
+
+Recorded on this repo's SDK (10.0.303) against real probe projects. These measurements, not
+documentation, decide the design.
+
+| Package set | MTP version | `--list-tests json` | `--filter-uid` | `--report-trx` |
+|---|---|---|---|---|
+| `xunit.v3` 4.0.0 | 2.3.3 | yes | yes | needs `Microsoft.Testing.Extensions.TrxReport` |
+| `MSTest` 4.4.0 | 2.x | yes | yes | built in |
+| `NUnit` 4.4.0 + `NUnit3TestAdapter` 6.3.0 | 2.x | yes | yes | needs the TrxReport package |
+| `MSTest` 3.11.0 | 1.9.0 | **no** — "expects no arguments" | yes | built in |
+
+Facts that shaped the code:
+
+* `dotnet vstest` loads an MSTest MTP module (it keeps a VSTest adapter) but CANNOT load an
+  `xunit.v3` module. The `xunit.v3` case is the reported defect.
+* The JSON listing carries a `type` block (`namespace`, `typeName`, `methodName`). The test
+  id is built from it. MSTest's `displayName` is the bare method name, so a display name is
+  never an id.
+* The id built from `type` equals the `className` + `.` + `name` pair in the TRX report, for
+  all three frameworks in both languages. The existing TRX reader needs no change.
+* A data-driven test lists one node per row, each with its own uid, all sharing one `type`.
+  Rows collapse onto one id that owns several uids.
+* NUnit sends no `location`. xUnit and MSTest do.
+* An unrecognized option exits with code 5 and prints `Unknown option '--x'`.
+* `--no-progress` is deprecated in MTP 2.3 and warns on every run.
+* MTP coverage writes `<guid>.cobertura.xml` directly into the results directory.
+* `--debug` prints `Waiting for debugger to attach... Process Id: <pid>, Name: <name>`.
+  The module is the test host; there is no `testhost.dll` child.
+
+## Design
+
+`dotnet test` is used for neither MTP discovery nor MTP runs. The test module is asked
+directly with `dotnet exec`, which mirrors the two-pass VSTest path: build first, then ask
+the built artifact.
+
+| Step | VSTest path | MTP path |
+|---|---|---|
+| Build | `dotnet test --list-tests` | `dotnet build` |
+| Modules | `Test run for …` banners | `dotnet sln list` + `-getProperty:TargetPath` |
+| Names | `dotnet vstest --ListFullyQualifiedTests` | `dotnet exec … --list-tests json` |
+| Selection | `--filter FullyQualifiedName=…` | `--filter-uid …` |
+| Outcomes | `--logger trx` | `--report-trx` |
+
+Everything after the TRX file is shared: `test-trx.ts`, the worst-row merge, the reporting
+and the status lens.
+
+## What the work found
+
+Two defects that only a real fixture could show:
+
+1. **NUnit refuses an F# selection.** The NUnit bridge translates `--filter-uid` back into a
+   VSTest filter EXPRESSION and then rejects its own translation for any uid carrying a
+   SPACE. The whole module then reported nothing, and four runnable F# tests showed as
+   phantom failures. The remedy is the rule [TEST-FILTER-ESCAPE] already sets: re-run that
+   module ONCE unfiltered and read the outcomes by name. A rejected OPTION earns no retry —
+   it would be rejected again.
+2. **MSTest 3.11 has no JSON listing.** It carries MTP 1.9.0, whose `--list-tests` takes no
+   argument, and its text listing is bare method names. Current packages (MSTest 4.4.0,
+   NUnit3TestAdapter 6.3.0, `xunit.v3` 4.0.0) all carry MTP 2.3 or later, so the fixtures pin
+   those. A module on an older platform is reported with a warning naming the cause.
+
+## TODO
+
+- [x] Spec sections in `docs/specs/TEST-EXPLORER-SPEC.md`
+- [x] This plan
+- [x] `test-mtp.ts` — runner detection and the JSON listing reader (pure)
+- [x] `test-mtp-modules.ts` — build, project list, MSBuild module resolution
+- [x] `test-mtp-discovery.ts` — the `--list-tests json` sweep
+- [x] `test-mtp-run.ts` — `--filter-uid` runs, per-module TRX, unfiltered retry
+- [x] `test-trx-collect.ts` — the TRX collection both runners share
+- [x] `test-batching.ts` — one command-line batcher for all three argument lists
+- [x] `test-host-announce.ts` — the waiting-host pid reader, now pure and testable
+- [x] `msbuild.ts` — `IsTestingPlatformApplication` property
+- [x] `test-discovery.ts` — choose the runner, return the MTP plan
+- [x] `test-execution.ts` / `testing.ts` — route a run to the MTP plan
+- [x] `test-coverage.ts` — read Cobertura at both depths
+- [x] `test-debug.ts` — MTP debug environment and prefixed pid line
+- [x] MTP fixtures in `dotnet-project-kit.ts` and `test-explorer-mtp-fixtures.ts`
+- [x] `test-explorer-mtp-parsers.test.ts`
+- [x] `test-explorer-mtp.test.ts`
+- [x] `test-explorer-mtp-outcomes.test.ts`
+- [x] `test-chunks.json` — the new `testexplorer-mtp` chunk
+- [x] `testing.ts` back under 500 lines (628 → 480)
+- [ ] Deslop rescan — the CLI and the MCP server were not available in the session that did
+      this work. The three command-line batchers were unified by hand into
+      `test-batching.ts`; run `rescan` and `top-offenders` before merge.
+- [x] Run the two new e2e suites in the real extension host.
+
+## Verification run
+
+`make _test-vsix-shard CHUNK=<chunk>` on Linux, against the real LSP host and both sidecars:
+
+| Chunk | Result | Time |
+|---|---|---|
+| `testexplorer-mtp` (new) | 16 passing | 3 min |
+| `testexplorer` | 113 passing | 8 min |
+| `testexplorer-frameworks` | 51 passing | 5 min |
+| `debug-tests` | 54 passing | 5 min |
+
+The new chunk is well inside the 15-minute ceiling [DIST-CI-WIN-VSIX] sets. The other three
+are the chunks this work touched, and none regressed.
+
+The first host run found one more defect: the shared `assertFailed` helper hardcoded xUnit's
+`Assert.Equal() Failure` text, which no MSTest or NUnit failure carries. It now takes the
+framework's own text, defaulting to xUnit's so every existing caller is unchanged, and each
+MTP fixture declares the text its framework writes.
+
+## Not done
+
+* **MTP server mode** (`--server jsonrpc`) is how Visual Studio and Rider talk to a module.
+  It would give streaming results, cancellation and locations with no extension packages at
+  all. The CLI path here is simpler and reuses the whole TRX pipeline. Revisit if the TRX
+  extension requirement proves a burden for users.

--- a/docs/specs/TEST-EXPLORER-SPEC.md
+++ b/docs/specs/TEST-EXPLORER-SPEC.md
@@ -13,6 +13,11 @@ second-class case here: idiomatic F# backtick bindings produce fully-qualified n
 contain spaces, and an F# `[<TestClass>]` nested in a module produces a CLR nested-type name
 containing `+`. Both must survive discovery, filtering and result attribution verbatim.
 
+There are TWO runners, and the Test Explorer supports both. VSTest is the older one.
+Microsoft.Testing.Platform (MTP) is the newer one, and it is the default for `xunit.v3`
+4.0.0 and later. The two paths share the tree, the TRX reader and every report step; they
+differ only in the commands that discover and run the tests ([TEST-MTP-DETECT]).
+
 ```mermaid
 flowchart LR
     VIEW["VS Code Testing view"] --> CONTROLLER["SharpLspTestController<br/>testing.ts"]
@@ -21,8 +26,11 @@ flowchart LR
     CONTROLLER --> COVERAGE["coverage — Cobertura<br/>test-coverage.ts"]
     DISCOVERY --> LISTTESTS["dotnet test --list-tests<br/>builds; announces assemblies"]
     DISCOVERY --> VSTEST["dotnet vstest<br/>--ListFullyQualifiedTests"]
+    DISCOVERY --> MTPLIST["dotnet exec module.dll<br/>--list-tests json"]
     EXECUTION --> RUN["dotnet test<br/>--filter … --logger trx"]
+    EXECUTION --> MTPRUN["dotnet exec module.dll<br/>--filter-uid … --report-trx"]
     RUN --> TRX["TRX report<br/>→ per-test outcome<br/>test-trx.ts"]
+    MTPRUN --> TRX
 ```
 
 ## Discovery by Fully-Qualified Name `[TEST-DISCOVERY-FQN]`
@@ -44,8 +52,9 @@ The listing from pass 1 prints each test's **DisplayName**, not its FullyQualifi
 xUnit's DisplayName happens to equal `Namespace.Class.Method`, so scraping the listing
 worked for xUnit by accident; NUnit and MSTest default their DisplayName to the BARE method
 name, so those tests were dropped outright and could never have been run by FQN filter
-(issue #180). The DisplayName listing survives only as a fallback for projects VSTest cannot
-load at all (for example a Microsoft.Testing.Platform project).
+(issue #180). The DisplayName listing survives only as a last-resort fallback for a project
+that neither runner could enumerate. A Microsoft.Testing.Platform project is NOT that case:
+it has its own discovery path ([TEST-MTP-DISCOVERY]).
 
 Name shapes that MUST round-trip unchanged:
 
@@ -148,6 +157,155 @@ Windows agent. Per-test outcomes come from the TRX report VSTest writes for that
   failure (a build error) or a note that the filter matched nothing. It is never silently
   reported as a pass.
 
+## Microsoft.Testing.Platform: which runner `[TEST-MTP-DETECT]`
+
+Microsoft.Testing.Platform (MTP) is the second .NET test runner. A test project that uses it
+builds to an EXECUTABLE test module, and that module — not `vstest.console` — discovers and
+runs its own tests. On the .NET 10 SDK, MTP v2 removed the VSTest shim, and `xunit.v3` 4.0.0
+uses MTP v2 by default. Such a project is invisible to every VSTest command:
+
+* `dotnet test --list-tests --nologo` — `--nologo` is not a valid MTP option. The SDK exits
+  with code 5 and lists no test.
+* `dotnet vstest <module>` — the module has no VSTest test host, so discovery dies with
+  "The application to execute does not exist: …testhost.dll".
+* `dotnet test --filter … --logger trx` — neither option exists in MTP mode.
+
+The runner is chosen PER TARGET, not per project. The SDK makes MTP all-or-nothing: when
+`global.json` opts in, a VSTest project in the same solution is an error. SharpLsp chooses
+in two steps:
+
+1. Find the nearest `global.json` above the target. Read it with a JSON parser, never with a
+   regular expression or a string search. `test.runner` equal to `Microsoft.Testing.Platform`
+   (letter case ignored) selects MTP immediately, and the two doomed VSTest passes are not
+   run at all.
+2. With no opt-in, run the VSTest passes first. Only if they produced no fully-qualified name
+   does SharpLsp ask MSBuild. A project whose `IsTestingPlatformApplication` property is
+   `true` is an MTP test module. `IsTestProject` MUST NOT be used for this: `xunit.v3` leaves
+   it empty.
+
+This order costs a VSTest solution nothing. It also keeps the MTP probe out of the hot path
+for every sweep that already worked.
+
+## Microsoft.Testing.Platform: the test modules `[TEST-MTP-MODULES]`
+
+MTP prints no `Test run for <assembly>` banner, so the assemblies cannot be scraped out of a
+listing. They come from MSBuild, which is the only source that survives a custom
+`AssemblyName`, a custom `OutputPath`, an `ArtifactsPath` or a `RuntimeIdentifier`:
+
+1. `dotnet build <target>` once. It builds the same projects a VSTest sweep builds.
+2. `dotnet sln <solution> list` for the projects. The first two lines are a header and are
+   dropped; the rest are project paths RELATIVE to the solution. With no solution loaded,
+   the workspace folder is searched for `*.csproj` and `*.fsproj` instead.
+3. `dotnet msbuild <project> -getProperty:IsTestingPlatformApplication -getProperty:TargetPath`
+   per project. `TargetPath` of an MTP project is its test module.
+
+A multi-targeted project reports one module per target framework. They are ONE project and
+MUST collapse to one tree root, by the same union rule as [TEST-DISCOVERY-FQN].
+
+## Microsoft.Testing.Platform: discovery `[TEST-MTP-DISCOVERY]`
+
+Each module is asked directly: `dotnet exec <module.dll> --list-tests json --no-banner`.
+`dotnet test` cannot be used here — it does not forward the `json` argument (dotnet/sdk#49754)
+— and `dotnet exec` runs the module on every platform without an apphost or an execute bit.
+
+The module answers with a JSON document on standard output:
+
+```json
+{ "schemaVersion": 1,
+  "tests": [ { "uid": "9e472c8a…", "displayName": "Cs.Xunit.Mtp.CalculatorTests.Adds_TwoNumbers",
+               "type": { "namespace": "Cs.Xunit.Mtp", "typeName": "CalculatorTests",
+                         "methodName": "Adds_TwoNumbers" },
+               "location": { "file": "…/CalculatorTests.cs", "lineStart": 7, "lineEnd": 7 } } ] }
+```
+
+Three fields, three jobs, and they MUST NOT be confused:
+
+* **`type`** gives the test item's id, as `namespace` + `.` + `typeName` + `.` + `methodName`.
+  The id MUST come from here and never from `displayName`. MSTest reports the BARE method
+  name as its display name — `Adds_TwoNumbers`, with no namespace and no class — which is the
+  same defect as issue #180. `type` also carries no row data, so the rows of one data-driven
+  test collapse onto the one id they share, exactly as the VSTest path requires. The
+  reconstructed id is identical to the `className` + `.` + `name` pair the TRX report holds,
+  so [TEST-RUN-TRX] attributes MTP outcomes with no change at all.
+* **`uid`** is the run key, and nothing else. Its shape is the framework's business: a SHA-256
+  digest for `xunit.v3`, a GUID for MSTest, and the decorated name
+  `Cs.Nunit.Mtp.CalculatorTests.Adds_Case(2,2,4)` for NUnit. It is never shown and never
+  parsed. One id can own SEVERAL uids — one per row of a data-driven test — and running that
+  id runs all of them.
+* **`location`** gives the test item its file and line. NUnit sends none, so the field is
+  optional and its absence is not an error.
+
+The reader tolerates a leading blank line and a byte-order mark, and it starts at the first
+`{`. An unknown `schemaVersion` produces a warning, not an exception. A module that fails to
+list leaves the other modules alone, the same contract as [TEST-DISCOVERY-FQN].
+
+## Microsoft.Testing.Platform: runs `[TEST-MTP-RUN]`
+
+One invocation per MODULE for the whole selection, never one per test:
+
+```
+dotnet exec <module.dll> --filter-uid <uid> <uid> … \
+    --report-trx --report-trx-filename <module>.trx \
+    --results-directory <dir> --no-banner --no-ansi
+```
+
+* `--filter-uid` takes LITERAL values, so the [TEST-FILTER-ESCAPE] grammar does not apply and
+  MUST NOT be used. An NUnit uid contains parentheses and commas; escaping them would make it
+  match nothing. The uids are still BATCHED against the Windows 32 767-character
+  command-line ceiling, for the same reason the VSTest filter is.
+* An empty selection means "run everything", and then no `--filter-uid` is sent.
+* A module the selection does not touch is not started at all.
+* `--report-trx-filename` is set per module. Two modules writing one auto-named file in a
+  shared results directory would overwrite each other, which is the same defect
+  [TEST-RUN-TRX] avoids with auto-naming under VSTest.
+* `--no-progress` MUST NOT be used. MTP 2.3 deprecated it and prints a warning on every run.
+
+The TRX report is read back by the reader [TEST-RUN-TRX] already specifies, and the worst-row
+merge, the skip mapping and the assertion text all behave the same.
+
+A framework bridged onto MTP can translate `--filter-uid` back into a VSTest filter
+EXPRESSION and then REFUSE its own translation. NUnit does exactly that for any uid carrying
+a SPACE — which is every idiomatic F# backtick binding, and the same refusal
+[TEST-FILTER-ESCAPE] records for the VSTest path:
+
+```
+Unhandled exception. NUnit.VisualStudio.TestAdapter.TestFilterConverter.TestFilterParserException:
+Unexpected FQN 'case\(2,2,4\)' at position 46 in selection expression.
+```
+
+The whole module then reports nothing, and perfectly runnable tests show as phantom
+failures. The remedy is the one [TEST-FILTER-ESCAPE] already sets for VSTest: when a module
+FAILED and left a selected test unreported, that module is re-run ONCE without a filter and
+the outcomes are picked out of its report by name. Slower, but correct — and only ever when
+the module failed, never on a selection that legitimately matched nothing. A retry's counts
+REPLACE the refused attempt's; counts are summed only ACROSS modules.
+
+`--report-trx` is an EXTENSION, not part of MTP. A module that does not register
+`Microsoft.Testing.Extensions.TrxReport` rejects the option and exits with code 5, printing
+`Unknown option '--report-trx'`. That exit code MUST be reported as itself: the message tells
+the user to reference the package. A silent empty run would report every selected test as
+"No result reported" and hide the cause.
+
+Coverage is also an extension. MTP has no `--collect:"XPlat Code Coverage"`; it takes
+`--coverage --coverage-output-format cobertura`, and it writes `<guid>.cobertura.xml`
+DIRECTLY into the results directory, not one level below it as `coverlet.collector` does.
+[TEST-COVERAGE] therefore reads both depths.
+
+## Microsoft.Testing.Platform: debugging `[TEST-MTP-DEBUG]`
+
+An MTP module IS the test host: there is no `testhost.dll` grandchild. `--debug` makes the
+module print
+
+```
+Waiting for debugger to attach... Process Id: 212243, Name: dotnet
+```
+
+and then wait. The announcement carries the same `Process Id: <pid>, Name: <name>` text as
+VSTest, but a prefix comes before it, so the pid reader MUST find that text anywhere in the
+line rather than only at its start. Everything else in [DEBUG-FEATURES-TESTS] is unchanged:
+one invocation, attach to the announced pid, mirror the output into the terminal, and write
+no result to the cache.
+
 ## Reactivity `[TEST-REACTIVITY]`
 
 Discovery runs a full build, so it is NOT a side effect of merely loading a solution. Only
@@ -187,7 +345,10 @@ The Run-with-Coverage profile adds `--collect:XPlat Code Coverage` and points
 directory would show the previous run's report. The collector writes one Cobertura report per
 test project, each in its own run-id folder one level down, and **every** one of them is parsed
 into `vscode.FileCoverage` entries and attached to the run; taking only the first drops every
-other project's coverage, and which one is "first" is directory order. Per-file detail is
+other project's coverage, and which one is "first" is directory order. An MTP run collects
+with `--coverage --coverage-output-format cobertura` instead, and that extension writes
+`<guid>.cobertura.xml` DIRECTLY into the results directory. Both depths are read, so one
+rule covers both runners ([TEST-MTP-RUN]). Per-file detail is
 resolved lazily through `loadDetailedCoverage`.
 
 `coverlet.collector` leaves the TEST assembly out of its report by default
@@ -218,6 +379,9 @@ the `dotnet` CLI built — never mocks and never a hand-authored `.sln`. The sui
 | `debug-test-debugging-e2e.test.ts` | the Debug run profile on ONE test: a real DAP session attached to the waiting test host, a breakpoint in the body and in a helper, a failing test, a skipped one, `[Theory]` rows, nothing armed, and disabled/conditional breakpoints |
 | `debug-test-groups-e2e.test.ts` | debugging a SELECTION: the class row, the namespace row, the assembly root, a multi-select across classes, and the unselected test that must not run |
 | `debug-test-fsharp-e2e.test.ts` | F# first: a backtick name carrying SPACES debugged, its module helper on the stack, `[<Theory>]` rows, and Debug Test at the cursor |
+| `test-explorer-mtp.test.ts` | Microsoft.Testing.Platform, end to end: the `global.json` opt-in and the `IsTestingPlatformApplication` probe, module resolution through MSBuild, and the tree for `xunit.v3`, MSTest and NUnit × C# and F# — including the MSTest bare display name that MUST NOT become an id, the F# backtick name carrying SPACES, and the source location the JSON listing carries ([TEST-MTP-DETECT], [TEST-MTP-MODULES], [TEST-MTP-DISCOVERY]) |
+| `test-explorer-mtp-outcomes.test.ts` | MTP runs: pass, fail and skip attribution across all six projects, the assertion text, a data-driven test whose rows disagree collapsing onto one id, ▶ on one test and on a class row, ⏹, the unfiltered retry an F# NUnit refusal earns and the C# selection that must NOT be retried, and the exit-code-5 message a module without `Microsoft.Testing.Extensions.TrxReport` earns ([TEST-MTP-RUN]) |
+| `test-explorer-mtp-parsers.test.ts` | the JSON listing reader at its boundary: a byte-order mark, a leading blank line, an unknown `schemaVersion`, an empty `tests` array, a missing `location`, a missing `type`, and two rows collapsing onto one id with two uids; the `global.json` opt-in against every decoy that merely mentions MTP; the uid batcher; and the waiting-host pid line in BOTH its bare and its prefixed form ([TEST-MTP-DETECT], [TEST-MTP-DISCOVERY], [TEST-MTP-RUN], [TEST-MTP-DEBUG]) |
 
 Every suite is declared in `src/editors/vscode/test-chunks.json` so it runs in the Windows
 matrix ([DIST-CI-WIN-VSIX]).

--- a/src/editors/vscode/src/dap-emulate.ts
+++ b/src/editors/vscode/src/dap-emulate.ts
@@ -9,6 +9,14 @@
 
 /** One DAP message. The index signature keeps fields this file never names
  *  surviving a spread when the router rewrites a message. */
+import { isRecord } from './utils';
+
+// The DAP modules have always reached for `isRecord` here, and it is genuinely
+// theirs: every wire message body is an untyped bag. The definition now lives in
+// `utils.ts`, because five modules outside DAP had written it out identically.
+// Re-exported so the ten DAP importers keep one obvious place to get it.
+export { isRecord } from './utils';
+
 export interface DapMessage {
   type?: unknown;
   command?: unknown;
@@ -16,11 +24,6 @@ export interface DapMessage {
   arguments?: unknown;
   seq?: unknown;
   [field: string]: unknown;
-}
-
-/** Narrow an unknown to a plain non-null object. */
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /** Narrow an unknown to a list of plain objects, dropping anything else. */

--- a/src/editors/vscode/src/dap-hot-reload.ts
+++ b/src/editors/vscode/src/dap-hot-reload.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode';
 import type { DapMessage } from './dap-emulate';
 import { error, traceInfo } from './log';
 import * as state from './state';
-import { getErrorMessage } from './utils';
+import { getErrorMessage, isRecord } from './utils';
 
 interface HotReloadHost {
   request(command: string, args: Record<string, unknown>): Promise<DapMessage>;
@@ -544,8 +544,4 @@ function projectsAt(directory: string): string[] {
   } catch {
     return [];
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/src/editors/vscode/src/launch-profiles.ts
+++ b/src/editors/vscode/src/launch-profiles.ts
@@ -10,6 +10,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { isIgnoredDir } from './launch-target';
+import { isRecord } from './utils';
 
 /** One entry of a `launchSettings.json` / `<app>.run.json` profiles map. */
 export interface LaunchProfile {
@@ -25,11 +26,6 @@ const URLS_VARIABLE = 'ASPNETCORE_URLS';
 
 /** Only `Project` profiles describe launching the project itself. */
 const PROJECT_COMMAND = 'Project';
-
-/** A plain, non-null object. */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 /**
  * Sound type guard for a launch-settings document.

--- a/src/editors/vscode/src/msbuild.ts
+++ b/src/editors/vscode/src/msbuild.ts
@@ -14,6 +14,7 @@
 import * as path from 'node:path';
 import { runDotnet } from './dotnet-process';
 import { err, ok, type Result } from './result';
+import { isRecord } from './utils';
 
 /** The properties a launch needs from MSBuild. */
 export interface ProjectProperties {
@@ -25,6 +26,14 @@ export interface ProjectProperties {
   readonly targetFrameworks: readonly string[];
   /** `Exe`, `WinExe` or `Library`. */
   readonly outputType: string;
+  /**
+   * True when the project builds a Microsoft.Testing.Platform test module.
+   *
+   * This is the property the .NET SDK itself uses to tell the two runners
+   * apart, so it is the one SharpLsp asks. `IsTestProject` MUST NOT be used
+   * instead: `xunit.v3` leaves it empty. Spec: [TEST-MTP-DETECT].
+   */
+  readonly isTestingPlatformApplication: boolean;
 }
 
 /** MSBuild evaluation is a full project load; a cold one can take a while. */
@@ -36,6 +45,7 @@ const REQUESTED = [
   'TargetFrameworks',
   'OutputType',
   'RunCommand',
+  'IsTestingPlatformApplication',
 ] as const;
 
 /** `-getProperty:` arguments for a project, optionally pinned to one TFM. */
@@ -46,11 +56,6 @@ function evaluateArgs(projectFile: string, framework?: string): string[] {
   }
   for (const property of REQUESTED) args.push(`-getProperty:${property}`);
   return args;
-}
-
-/** A plain, non-null object — the only shape a properties bag can take. */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /** Every string-valued entry of a bag, ignoring anything else MSBuild emitted. */
@@ -106,6 +111,8 @@ export async function evaluateProject(
     targetFramework: bag.value.get('TargetFramework') ?? '',
     targetFrameworks: splitList(bag.value.get('TargetFrameworks')),
     outputType: bag.value.get('OutputType') ?? '',
+    isTestingPlatformApplication:
+      (bag.value.get('IsTestingPlatformApplication') ?? '').trim().toLowerCase() === 'true',
   });
 }
 

--- a/src/editors/vscode/src/test-batching.ts
+++ b/src/editors/vscode/src/test-batching.ts
@@ -1,0 +1,47 @@
+/**
+ * Splitting one argument list into command lines a process can actually take.
+ *
+ * Windows caps a process command line at 32 767 characters, and past it Node's
+ * `spawn` THROWS SYNCHRONOUSLY — `spawn ENAMETOOLONG`, before `dotnet` ever
+ * runs. Three argument lists reach that: the assemblies handed to one
+ * `dotnet vstest`, the `--filter` expression of one `dotnet test`, and the
+ * `--filter-uid` values of one MTP module. All three batch by the same rule, so
+ * they batch through the same function.
+ *
+ * Implements [TEST-DISCOVERY-FQN], [TEST-FILTER-ESCAPE] and [TEST-MTP-RUN].
+ */
+
+/**
+ * Ceiling on one argument list. The list is one part of a whole vector — the
+ * executable, the target, the results directory — so the budget leaves the
+ * whole vector well under the real limit.
+ */
+export const MAX_ARG_CHARS = 24_000;
+
+/**
+ * Split `items` into batches whose joined argument text stays under `maxChars`.
+ *
+ * A single over-budget item still gets its OWN batch: dropping it silently
+ * would lose a runnable test, and splitting it would corrupt the argument.
+ */
+export function batchByWidth<T>(
+  items: readonly T[],
+  cost: (item: T) => number,
+  maxChars: number = MAX_ARG_CHARS,
+): T[][] {
+  const batches: T[][] = [];
+  let current: T[] = [];
+  let width = 0;
+  for (const item of items) {
+    const size = cost(item);
+    if (current.length > 0 && width + size > maxChars) {
+      batches.push(current);
+      current = [];
+      width = 0;
+    }
+    current.push(item);
+    width += size;
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}

--- a/src/editors/vscode/src/test-coverage.ts
+++ b/src/editors/vscode/src/test-coverage.ts
@@ -46,20 +46,31 @@ const coberturaParser = new XMLParser({
   isArray: (tagName) => tagName === 'package' || tagName === 'class' || tagName === 'line',
 });
 
+/** Cobertura reports end with this, whichever collector wrote them. */
+const COBERTURA_SUFFIX = '.cobertura.xml';
+
 /**
- * EVERY `coverage.cobertura.xml` one directory below `resultsDir`.
+ * EVERY Cobertura report of one run, at either depth the collectors use.
  *
- * The collector writes one report per test project, each into its own
- * run-id folder. Taking only the first — as this did — silently dropped every
- * other project's coverage from a solution-wide run, and which one "first" meant
- * depended on directory order.
+ * `coverlet.collector` — the VSTest path — writes one `coverage.cobertura.xml`
+ * per test project, each into its own run-id folder ONE LEVEL DOWN. Taking only
+ * the first silently dropped every other project's coverage from a
+ * solution-wide run, and which one "first" meant depended on directory order.
+ *
+ * The Microsoft.Testing.Platform collector writes `<guid>.cobertura.xml`
+ * DIRECTLY into the results directory instead ([TEST-MTP-RUN]). Both depths are
+ * read, so one rule serves both runners and neither loses a report.
  */
 export function findCoberturaFiles(resultsDir: string): string[] {
   if (!fs.existsSync(resultsDir)) return [];
   const reports: string[] = [];
-  for (const entry of fs.readdirSync(resultsDir)) {
-    const candidate = path.join(resultsDir, entry, 'coverage.cobertura.xml');
-    if (fs.existsSync(candidate)) reports.push(candidate);
+  for (const entry of fs.readdirSync(resultsDir, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.toLowerCase().endsWith(COBERTURA_SUFFIX)) {
+      reports.push(path.join(resultsDir, entry.name));
+      continue;
+    }
+    const nested = path.join(resultsDir, entry.name, 'coverage.cobertura.xml');
+    if (entry.isDirectory() && fs.existsSync(nested)) reports.push(nested);
   }
   return reports.sort();
 }

--- a/src/editors/vscode/src/test-debug.ts
+++ b/src/editors/vscode/src/test-debug.ts
@@ -24,7 +24,8 @@ import { DEBUG_TYPE } from './constants';
 import { whenDebugSessionArmed } from './debug';
 import { TEST_HOST_ATTACH_FLAG } from './dap-attach';
 import { error, info, warn } from './log';
-import { runTests, type TestRunOptions, type TestRunOutcome } from './test-execution';
+import type { TestRunOptions, TestRunOutcome } from './test-execution';
+import { TestHostWatcher } from './test-host-announce';
 import { filterBatches } from './test-filter';
 import { runTarget } from './test-targets';
 
@@ -40,10 +41,18 @@ import { runTarget } from './test-targets';
 export const TEST_HOST_DEBUG_ENV: Readonly<Record<string, string>> = {
   VSTEST_HOST_DEBUG: '1',
   VSTEST_RUNNER_DEBUG: '0',
+  // A Microsoft.Testing.Platform module IS the test host — there is no
+  // `testhost.dll` child — and it waits on its OWN variable. Both are set
+  // because each runner ignores the other's, so one environment serves both
+  // and no runner flag has to be threaded through this flow.
+  // Spec: [TEST-MTP-DEBUG].
+  TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER: '1',
 };
 
 /** The terminal the Debug profile mirrors the run's output into. */
 export const TEST_DEBUG_TERMINAL_NAME = 'SharpLsp Test Debug';
+
+export { announcedTestHostPid, TestHostWatcher } from './test-host-announce';
 
 /**
  * How long a debug run may live. A debuggee parked on a breakpoint is the
@@ -53,71 +62,22 @@ export const TEST_DEBUG_TERMINAL_NAME = 'SharpLsp Test Debug';
  */
 const DEBUG_RUN_CEILING_MS = 24 * 60 * 60 * 1_000;
 
-/** The stable prefix of VSTest's waiting-host announcement, en-US pinned. */
-const PROCESS_ID_PREFIX = 'Process Id:';
-
 /** What the debug flow needs from the owning test controller. */
 export interface TestDebugHost {
   /** Serialise behind every other `dotnet` invocation the controller makes. */
   enqueue<T>(work: () => Promise<T>): Promise<T>;
+  /**
+   * Start the selection with whichever runner the last discovery sweep chose.
+   * The debug flow is identical for both; only the command differs.
+   * Spec: [TEST-MTP-DEBUG].
+   */
+  runSelection(
+    ids: readonly string[],
+    cwd: string,
+    options: TestRunOptions,
+  ): Promise<TestRunOutcome>;
   /** Report a finished invocation onto the RUN — never onto the result cache. */
   finish(run: vscode.TestRun, tests: readonly vscode.TestItem[], outcome: TestRunOutcome): void;
-}
-
-/** ASCII digits only, checked per UTF-16 unit — a pid is never a surrogate. */
-function isAllDigits(candidate: string): boolean {
-  for (let index = 0; index < candidate.length; index += 1) {
-    const code = candidate.charCodeAt(index);
-    if (code < 0x30 || code > 0x39) return false;
-  }
-  return true;
-}
-
-/**
- * The pid a waiting test host announced on `line`, or undefined.
- *
- * The contract is VSTest's own console line, `Process Id: {0}, Name: {1}`,
- * printed by the HOST about itself — the parent never prints it with
- * `VSTEST_RUNNER_DEBUG` pinned off. The digits are validated whole: a partial
- * `parseInt` would accept a corrupted line and aim the debugger at noise.
- */
-export function announcedTestHostPid(line: string): number | undefined {
-  const trimmed = line.trim();
-  if (!trimmed.startsWith(PROCESS_ID_PREFIX)) return undefined;
-  const rest = trimmed.slice(PROCESS_ID_PREFIX.length);
-  const comma = rest.indexOf(',');
-  const digits = (comma === -1 ? rest : rest.slice(0, comma)).trim();
-  if (digits.length === 0 || !isAllDigits(digits)) return undefined;
-  const pid = Number.parseInt(digits, 10);
-  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
-}
-
-/**
- * Watches a debug run's live output for waiting test hosts, once each.
- *
- * Chunk boundaries fall anywhere, so lines are reassembled before parsing; a
- * solution with several test projects announces one host PER ASSEMBLY, and
- * every one of them is waiting — each new pid is handed on exactly once.
- */
-export class TestHostWatcher {
-  private tail = '';
-  private readonly announced = new Set<number>();
-
-  constructor(private readonly onHost: (pid: number) => void) {}
-
-  /** Feed one raw output chunk; complete lines are scanned for announcements. */
-  public absorb(chunk: string): void {
-    const lines = (this.tail + chunk).split('\n');
-    this.tail = lines.pop() ?? '';
-    for (const line of lines) this.offer(line);
-  }
-
-  private offer(line: string): void {
-    const pid = announcedTestHostPid(line);
-    if (pid === undefined || this.announced.has(pid)) return;
-    this.announced.add(pid);
-    this.onHost(pid);
-  }
 }
 
 /** The attach configuration aimed at one waiting test host. */
@@ -310,7 +270,7 @@ class DebugRunFlow {
     options: TestRunOptions,
   ): Promise<TestRunOutcome> {
     const { started } = await this.host.enqueue(async () => {
-      const running = runTests(ids, this.cwd, options);
+      const running = this.host.runSelection(ids, this.cwd, options);
       await Promise.race([this.attached, running]);
       return { started: running };
     });

--- a/src/editors/vscode/src/test-discovery.ts
+++ b/src/editors/vscode/src/test-discovery.ts
@@ -28,11 +28,21 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { DOTNET_TIMEOUT_MS, runDotnet, type DotnetRun } from './dotnet-process.js';
+import { batchByWidth, MAX_ARG_CHARS } from './test-batching.js';
 import { parseTestList } from './test-listing.js';
 import { HEX_DIGITS, parseFullyQualifiedTestList } from './test-names.js';
+import {
+  mergeMultiTargeted,
+  type TestAssemblyListing,
+  type TestListing,
+} from './test-listing-model.js';
+import { listMtpTests } from './test-mtp-discovery.js';
+import { usesMtpRunner } from './test-mtp.js';
 
 export { parseFullyQualifiedTestList, withoutAdapterUniqueId } from './test-names.js';
 export { isDiscoveredTestLine, parseTestList } from './test-listing.js';
+export { mergeMultiTargeted } from './test-listing-model.js';
+export type { TestAssemblyListing, TestListing } from './test-listing-model.js';
 
 /** VSTest prints one of these per test assembly it was handed. */
 const ASSEMBLY_BANNER = 'Test run for ';
@@ -48,37 +58,11 @@ const VSTEST_LISTING_OUTPUT = '-p:VsTestUseMSBuildOutput=false';
 
 /**
  * Ceiling on the assembly arguments handed to a single `dotnet vstest`.
- * Windows caps a process command line at 32 767 characters, and a solution with
- * many test projects — each contributing a long `bin/Debug/netX/Name.dll` path —
- * reaches that, at which point the spawn fails outright instead of enumerating.
+ * A solution with many test projects — each contributing a long
+ * `bin/Debug/netX/Name.dll` path — reaches the Windows command-line limit, at
+ * which point the spawn fails outright instead of enumerating.
  */
-const MAX_ASSEMBLY_ARG_CHARS = 24_000;
-
-/** The outcome of enumerating one target. Never an exception. */
-export interface TestListing {
-  /** Fully-qualified names, in discovery order, de-duplicated. */
-  readonly names: readonly string[];
-  /** True when the enumeration ran to completion (so an empty list is real). */
-  readonly ok: boolean;
-  /** Diagnostics worth writing to the extension log. */
-  readonly warnings: readonly string[];
-  /**
-   * The names grouped by the assembly that contributed them — the grouping the
-   * Test Explorer renders as Assembly → Namespace → Class → Test. Empty for
-   * the weaker display-name fallback, which cannot attribute names.
-   */
-  readonly byAssembly: readonly TestAssemblyListing[];
-}
-
-/** One built test assembly and the fully-qualified names it contributed. */
-export interface TestAssemblyListing {
-  /** Assembly file name without extension — the tree's root label. */
-  readonly name: string;
-  /** Absolute path of the built assembly — the stable, unique group id. */
-  readonly path: string;
-  /** Fully-qualified test names this assembly contributed, in listing order. */
-  readonly names: readonly string[];
-}
+const MAX_ASSEMBLY_ARG_CHARS = MAX_ARG_CHARS;
 
 /**
  * Extract the assembly path from a `Test run for <path> (<framework>)` banner.
@@ -167,21 +151,7 @@ export function batchAssemblies(
   assemblies: readonly string[],
   maxChars: number = MAX_ASSEMBLY_ARG_CHARS,
 ): string[][] {
-  const batches: string[][] = [];
-  let current: string[] = [];
-  let width = 0;
-  for (const assembly of assemblies) {
-    const cost = assembly.length + 3;
-    if (current.length > 0 && width + cost > maxChars) {
-      batches.push(current);
-      current = [];
-      width = 0;
-    }
-    current.push(assembly);
-    width += cost;
-  }
-  if (current.length > 0) batches.push(current);
-  return batches;
+  return batchByWidth(assemblies, (assembly) => assembly.length + 3, maxChars);
 }
 
 /**
@@ -202,6 +172,29 @@ export async function listTests(
       byAssembly: [],
     };
   }
+  // [TEST-MTP-DETECT]: a `global.json` opt-in makes the whole target MTP, and
+  // every VSTest command below would fail against it — `--nologo` alone exits
+  // with code 5 and lists nothing. Go straight to the runner that can answer.
+  if (usesMtpRunner(cwd)) return await listMtpTests(target, cwd, timeoutMs);
+  const vstest = await listWithVsTest(target, cwd, timeoutMs);
+  // No assembly attributed a name: either a genuinely empty solution, or an MTP
+  // project with no opt-in — which MTP v2 on the .NET 10 SDK makes ordinary,
+  // because it removed the VSTest shim. Ask MSBuild before settling for the
+  // display-name fallback, which cannot run anything it lists.
+  if (vstest.byAssembly.length > 0) return vstest;
+  const mtp = await listMtpTests(target, cwd, timeoutMs);
+  if (mtp.names.length === 0) {
+    return { ...vstest, warnings: [...vstest.warnings, ...mtp.warnings] };
+  }
+  return { ...mtp, warnings: [...vstest.warnings, ...mtp.warnings] };
+}
+
+/** The two VSTest passes: build and announce, then ask for the real names. */
+async function listWithVsTest(
+  target: string,
+  cwd: string,
+  timeoutMs: number,
+): Promise<TestListing> {
   const positional = cwd === target ? [] : [target];
   const args = [
     'test',
@@ -257,82 +250,6 @@ function listFailure(run: DotnetRun): string {
   return run.killed
     ? `dotnet test --list-tests was killed (timeout or signal); output truncated: ${cause}${detail}`
     : `dotnet test --list-tests failed: ${cause}${detail}`;
-}
-
-/**
- * Collapse the assemblies ONE multi-targeted project produced into one listing.
- *
- * `dotnet test --list-tests` announces a `Test run for …` banner per TARGET
- * FRAMEWORK, so a project declaring `<TargetFrameworks>net8.0;net9.0</…>` reports
- * two assemblies carrying the same file name under different
- * `bin/<config>/<tfm>/` directories. That is one project, and so one root of the
- * Assembly → Namespace → Class → Test tree: keeping them apart rendered every
- * namespace, class and test of that project TWICE, under two labels the user
- * cannot tell apart.
- *
- * Names are UNIONED, never taken from whichever framework was announced first: a
- * test compiled behind `#if NET8_0` exists in only one of the assemblies, and
- * dropping it would trade a duplicated tree for a missing test. The surviving
- * path is the identity the frameworks SHARE (see {@link sharedOutputPath}), so
- * the group ids the tree builds from it stay put across sweeps however the
- * build ordered its banners.
- */
-export function mergeMultiTargeted(
-  listings: readonly TestAssemblyListing[],
-): TestAssemblyListing[] {
-  const merged = new Map<string, { paths: string[]; names: string[] }>();
-  for (const listing of listings) {
-    const existing = merged.get(listing.name);
-    if (existing === undefined) {
-      merged.set(listing.name, { paths: [listing.path], names: [...listing.names] });
-      continue;
-    }
-    existing.paths.push(listing.path);
-    existing.names.push(...listing.names);
-  }
-  return [...merged].map(([name, entry]) => ({
-    name,
-    path: sharedOutputPath(entry.paths),
-    names: [...new Set(entry.names)],
-  }));
-}
-
-/**
- * The identity several builds of ONE assembly share.
- *
- * Two target frameworks put the same assembly under `bin/<config>/net8.0/` and
- * `bin/<config>/net9.0/`, so their paths agree everywhere except the segments
- * that name a build. Keeping one of them as the merged group id keys the whole
- * project's tree on a framework it merely happens to target: the id moves the
- * moment the build announces its banners in another order, and a project
- * targeting four frameworks gets a row identified by exactly one of them.
- *
- * Taking the common prefix back to its last separator and re-attaching the file
- * name leaves what every build of the project agrees on. A project with one
- * target framework has nothing to reconcile and keeps its real path.
- */
-function sharedOutputPath(paths: readonly string[]): string {
-  const [first, ...rest] = paths;
-  if (first === undefined) return '';
-  if (rest.length === 0) return first;
-  const shared = rest.reduce(commonPrefix, first);
-  return shared.slice(0, lastSeparator(shared) + 1) + first.slice(lastSeparator(first) + 1);
-}
-
-/** The leading characters two paths agree on. */
-function commonPrefix(left: string, right: string): string {
-  let index = 0;
-  while (index < left.length && index < right.length && left[index] === right[index]) index += 1;
-  return left.slice(0, index);
-}
-
-/**
- * Index of the last `/` or `\`, or -1. Both are checked rather than `path.sep`
- * because the separator comes from whichever host BUILT the listing, which is
- * not necessarily the one reading it.
- */
-function lastSeparator(value: string): number {
-  return Math.max(value.lastIndexOf('/'), value.lastIndexOf('\\'));
 }
 
 /** Prefer VSTest's fully-qualified names; fall back to the display listing. */

--- a/src/editors/vscode/src/test-execution.ts
+++ b/src/editors/vscode/src/test-execution.ts
@@ -24,13 +24,9 @@ import type * as vscode from 'vscode';
 import { DOTNET_TIMEOUT_MS, runDotnet, type DotnetHooks } from './dotnet-process.js';
 import { runTarget } from './test-targets.js';
 import { filterBatches, filterExpression } from './test-filter.js';
-import {
-  parseFailureMessage,
-  parseRunSummary,
-  type TestOutcome,
-  type TestRunSummary,
-} from './test-run-output.js';
-import { isRunError, parseTrxReport, type TrxRunInfo, type TrxTestResult } from './test-trx.js';
+import { parseFailureMessage, parseRunSummary, type TestRunSummary } from './test-run-output.js';
+import { isRunError, type TrxRunInfo, type TrxTestResult } from './test-trx.js';
+import { collectReport, trxFiles } from './test-trx-collect.js';
 
 /** What one `dotnet test` invocation produced. */
 export interface TestRunOutcome {
@@ -294,79 +290,4 @@ function runFailure(
   if (killed) return `dotnet test was killed (timeout or signal): ${errorMessage ?? 'no detail'}`;
   if (!failed || resultCount > 0) return undefined;
   return parseFailureMessage(output) ?? errorMessage ?? 'dotnet test failed';
-}
-
-/** Every `.trx` this run created, merged: results keyed by FQN, plus run info. */
-function collectReport(
-  dir: string,
-  before: ReadonlySet<string>,
-): { results: Map<string, TrxTestResult>; runInfos: TrxRunInfo[] } {
-  const results = new Map<string, TrxTestResult>();
-  const runInfos: TrxRunInfo[] = [];
-  for (const file of trxFiles(dir)) {
-    if (before.has(file)) continue;
-    const report = readTrx(file);
-    runInfos.push(...report.runInfos);
-    for (const result of report.results) {
-      const existing = results.get(result.fullyQualifiedName);
-      results.set(
-        result.fullyQualifiedName,
-        existing === undefined ? result : worse(existing, result),
-      );
-    }
-  }
-  return { results, runInfos };
-}
-
-/** Severity order, so a data-driven test is judged by its WORST row. */
-const OUTCOME_SEVERITY: Record<TestOutcome, number> = {
-  passed: 0,
-  skipped: 1,
-  notRun: 2,
-  failed: 3,
-};
-
-/**
- * Merge two results reported under the SAME fully-qualified name.
- *
- * A theory or `[TestCase]` with several rows writes one TRX entry PER ROW, all
- * carrying the same FQN. Keeping the last one seen would report a green tree for
- * a theory whose second row failed, purely because of the order VSTest happened
- * to write them. The worst outcome wins and the durations add up.
- */
-function worse(left: TrxTestResult, right: TrxTestResult): TrxTestResult {
-  const durationMs = sumDurations(left.durationMs, right.durationMs);
-  const dominant = OUTCOME_SEVERITY[right.outcome] > OUTCOME_SEVERITY[left.outcome] ? right : left;
-  return { ...dominant, durationMs };
-}
-
-/** Add two optional durations, keeping `undefined` only when both are absent. */
-function sumDurations(left: number | undefined, right: number | undefined): number | undefined {
-  if (left === undefined) return right;
-  if (right === undefined) return left;
-  return left + right;
-}
-
-/** Absolute paths of the `.trx` reports directly inside `dir`. */
-function trxFiles(dir: string): string[] {
-  try {
-    return fs
-      .readdirSync(dir)
-      .filter((entry) => entry.toLowerCase().endsWith('.trx'))
-      .map((entry) => path.join(dir, entry));
-  } catch {
-    return [];
-  }
-}
-
-/** Parse one TRX file, tolerating a truncated or unreadable report. */
-function readTrx(file: string): {
-  results: readonly TrxTestResult[];
-  runInfos: readonly TrxRunInfo[];
-} {
-  try {
-    return parseTrxReport(fs.readFileSync(file, 'utf8'));
-  } catch {
-    return { results: [], runInfos: [] };
-  }
 }

--- a/src/editors/vscode/src/test-filter.ts
+++ b/src/editors/vscode/src/test-filter.ts
@@ -11,6 +11,8 @@
  * Implements [TEST-FILTER-ESCAPE].
  */
 
+import { batchByWidth, MAX_ARG_CHARS } from './test-batching.js';
+
 /** Characters VSTest's filter grammar reserves; each is escaped with a backslash. */
 const FILTER_METACHARACTERS = new Set(['\\', '(', ')', '&', '|', '=', '!', '~']);
 
@@ -45,17 +47,12 @@ export function filterExpression(fullyQualifiedNames: readonly string[]): string
  * Windows caps a process command line at 32 767 characters, and past it
  * Node's `spawn` THROWS SYNCHRONOUSLY (issue: 816 discovered tests, ▶ on the
  * root of the Testing view, `spawn ENAMETOOLONG` rejected the run handler).
- * The filter is one argv entry among several — exe, target, `--logger trx`,
- * `--results-directory <path>` — so the budget keeps the WHOLE vector well
- * under the ceiling. Mirrors `MAX_ASSEMBLY_ARG_CHARS` in discovery.
  */
-export const MAX_FILTER_ARG_CHARS = 24_000;
+export const MAX_FILTER_ARG_CHARS = MAX_ARG_CHARS;
 
 /**
  * Split fully-qualified names into batches whose joined filter expression
- * stays under the Windows command-line ceiling. A single over-budget name
- * still gets its own batch: dropping it silently would lose a runnable test,
- * and splitting a NAME would corrupt the filter.
+ * stays under the Windows command-line ceiling.
  *
  * The cost of a name is its escaped clause plus the joining `|` — escaping can
  * GROW the text (every `(` gains a backslash), so the clause is measured, not
@@ -65,19 +62,5 @@ export function filterBatches(
   fullyQualifiedNames: readonly string[],
   maxChars: number = MAX_FILTER_ARG_CHARS,
 ): string[][] {
-  const batches: string[][] = [];
-  let current: string[] = [];
-  let width = 0;
-  for (const name of fullyQualifiedNames) {
-    const cost = filterClause(name).length + 1;
-    if (current.length > 0 && width + cost > maxChars) {
-      batches.push(current);
-      current = [];
-      width = 0;
-    }
-    current.push(name);
-    width += cost;
-  }
-  if (current.length > 0) batches.push(current);
-  return batches;
+  return batchByWidth(fullyQualifiedNames, (name) => filterClause(name).length + 1, maxChars);
 }

--- a/src/editors/vscode/src/test-host-announce.ts
+++ b/src/editors/vscode/src/test-host-announce.ts
@@ -1,0 +1,81 @@
+/**
+ * Reading a waiting test host's pid out of a debug run's live output.
+ *
+ * Under a debug run every test host announces itself and then BLOCKS until a
+ * debugger attaches, so this text is the only signal saying which process to
+ * attach to. Both runners print it: VSTest from its `testhost.dll` child, and a
+ * Microsoft.Testing.Platform module about itself.
+ *
+ * Pure — no VS Code, no process — so it is asserted at its own boundary rather
+ * than only through a real debug session.
+ *
+ * Implements [DEBUG-FEATURES-TESTS] and [TEST-MTP-DEBUG].
+ */
+
+/** The stable text of a waiting host's announcement, en-US pinned. */
+const PROCESS_ID_PREFIX = 'Process Id:';
+
+/** ASCII digits only, checked per UTF-16 unit — a pid is never a surrogate. */
+function isAllDigits(candidate: string): boolean {
+  for (let index = 0; index < candidate.length; index += 1) {
+    const code = candidate.charCodeAt(index);
+    if (code < 0x30 || code > 0x39) return false;
+  }
+  return true;
+}
+
+/**
+ * The pid a waiting test host announced on `line`, or undefined.
+ *
+ * The contract is the console line `Process Id: {0}, Name: {1}`, printed by the
+ * HOST about itself — the parent never prints it with `VSTEST_RUNNER_DEBUG`
+ * pinned off.
+ *
+ * A Microsoft.Testing.Platform module prints the SAME text behind a prefix:
+ * `Waiting for debugger to attach... Process Id: 212243, Name: dotnet`. The
+ * text is therefore found ANYWHERE in the line rather than only at its start —
+ * anchored to the start, every MTP debug run hung on a module nothing ever
+ * attached to. Spec: [TEST-MTP-DEBUG].
+ *
+ * The digits are validated whole: a partial `parseInt` would accept a corrupted
+ * line and aim the debugger at noise.
+ */
+export function announcedTestHostPid(line: string): number | undefined {
+  const trimmed = line.trim();
+  const marker = trimmed.indexOf(PROCESS_ID_PREFIX);
+  if (marker < 0) return undefined;
+  const rest = trimmed.slice(marker + PROCESS_ID_PREFIX.length);
+  const comma = rest.indexOf(',');
+  const digits = (comma === -1 ? rest : rest.slice(0, comma)).trim();
+  if (digits.length === 0 || !isAllDigits(digits)) return undefined;
+  const pid = Number.parseInt(digits, 10);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
+}
+
+/**
+ * Watches a debug run's live output for waiting test hosts, once each.
+ *
+ * Chunk boundaries fall anywhere, so lines are reassembled before parsing; a
+ * solution with several test projects announces one host PER ASSEMBLY, and
+ * every one of them is waiting — each new pid is handed on exactly once.
+ */
+export class TestHostWatcher {
+  private tail = '';
+  private readonly announced = new Set<number>();
+
+  constructor(private readonly onHost: (pid: number) => void) {}
+
+  /** Feed one raw output chunk; complete lines are scanned for announcements. */
+  public absorb(chunk: string): void {
+    const lines = (this.tail + chunk).split('\n');
+    this.tail = lines.pop() ?? '';
+    for (const line of lines) this.offer(line);
+  }
+
+  private offer(line: string): void {
+    const pid = announcedTestHostPid(line);
+    if (pid === undefined || this.announced.has(pid)) return;
+    this.announced.add(pid);
+    this.onHost(pid);
+  }
+}

--- a/src/editors/vscode/src/test-items.ts
+++ b/src/editors/vscode/src/test-items.ts
@@ -1,0 +1,153 @@
+/**
+ * Building the rows the Testing view shows.
+ *
+ * The tree is **Assembly → Namespace → Class → Test**, and only the leaves are
+ * tests. It lives apart from `testing.ts` so the controller file stays about
+ * the VS Code Testing API wiring and nothing else.
+ *
+ * Both runners build the same tree from the same ids, because both discovery
+ * paths report `namespace.Type.Method` ([TEST-DISCOVERY-FQN],
+ * [TEST-MTP-DISCOVERY]). A Microsoft.Testing.Platform sweep also reports where
+ * each test is WRITTEN, so its leaves carry a file and a line; a VSTest sweep
+ * reports none, and its leaves carry the target folder as before.
+ *
+ * Implements [TEST-EXPLORER].
+ */
+
+import * as vscode from 'vscode';
+import type { TestAssemblyListing, TestLocation } from './test-listing-model.js';
+import { isExpectoTest, isFsCheckTest } from './test-targets.js';
+
+/**
+ * Id prefix marking the row that explains WHY discovery failed. Error rows are
+ * leaves that never run; a successful sweep removes them.
+ */
+export const ERROR_ITEM_PREFIX = 'discovery-error:';
+
+/** What every row of one sweep is built from. */
+export interface ItemContext {
+  readonly controller: vscode.TestController;
+  /** Fallback uri for a row whose test reported no source file. */
+  readonly uri: vscode.Uri;
+  /** Source location per test id, when the runner reported one. */
+  readonly locations: ReadonlyMap<string, TestLocation> | undefined;
+}
+
+/** The uri a test row points at: its own source file, else the target folder. */
+function uriFor(context: ItemContext, fullName: string): vscode.Uri {
+  const location = context.locations?.get(fullName);
+  return location === undefined ? context.uri : vscode.Uri.file(location.file);
+}
+
+/** The one-line range a test row selects, when its line is known. */
+function rangeFor(context: ItemContext, fullName: string): vscode.Range | undefined {
+  const line = context.locations?.get(fullName)?.line;
+  if (line === undefined) return undefined;
+  const zeroBased = Math.max(0, line - 1);
+  return new vscode.Range(zeroBased, 0, zeroBased, 0);
+}
+
+/** Build a TestItem for a fully-qualified name, tagging F# tests. */
+export function makeTestItem(context: ItemContext, fullName: string): vscode.TestItem {
+  const parts = fullName.split('.');
+  const label = parts.at(-1) ?? fullName;
+  const item = context.controller.createTestItem(fullName, label, uriFor(context, fullName));
+  item.description = fullName;
+  item.range = rangeFor(context, fullName);
+  if (isExpectoTest(fullName) || isFsCheckTest(fullName)) {
+    item.tags = [new vscode.TestTag('fsharp')];
+  }
+  return item;
+}
+
+/** A non-test group node: an assembly, a namespace or a class. */
+function makeGroupItem(context: ItemContext, id: string, label: string): vscode.TestItem {
+  const item = context.controller.createTestItem(id, label, context.uri);
+  item.canResolveChildren = true;
+  return item;
+}
+
+/** The namespace and class labels one fully-qualified name sits under. */
+function levelsOf(fullName: string): { namespaceLabel: string; classLabel: string } {
+  const parts = fullName.split('.');
+  return {
+    namespaceLabel: parts.length >= 3 ? parts.slice(0, -2).join('.') : '',
+    classLabel: parts.length >= 2 ? (parts.at(-2) ?? '') : '',
+  };
+}
+
+/** Find or create one level of the tree under `parent`. */
+function levelItem(
+  context: ItemContext,
+  cache: Map<string, vscode.TestItem>,
+  parent: vscode.TestItem,
+  level: { id: string; label: string },
+): vscode.TestItem {
+  const existing = cache.get(level.id);
+  if (existing !== undefined) return existing;
+  const item = makeGroupItem(context, level.id, level.label);
+  cache.set(level.id, item);
+  parent.children.add(item);
+  return item;
+}
+
+/**
+ * Build one assembly's Assembly → Namespace → Class → Test subtree.
+ *
+ * The last dotted segment is the test, the one before it the class, the rest
+ * joined the namespace — deterministic for C# namespaces and dotted F# modules
+ * alike (`Fs.Xunit.Fixtures.adds two numbers` → `Fs.Xunit` / `Fixtures` /
+ * `adds two numbers`). Shorter names nest under whatever levels exist; nothing
+ * is ever dropped.
+ */
+export function makeAssemblyItem(
+  context: ItemContext,
+  assembly: TestAssemblyListing,
+): vscode.TestItem {
+  const root = makeGroupItem(context, `assembly:${assembly.path}`, assembly.name);
+  const namespaces = new Map<string, vscode.TestItem>();
+  const classes = new Map<string, vscode.TestItem>();
+  for (const fqn of assembly.names) {
+    const { namespaceLabel, classLabel } = levelsOf(fqn);
+    let parent = root;
+    if (namespaceLabel !== '') {
+      parent = levelItem(context, namespaces, parent, {
+        id: `namespace:${assembly.path}|${namespaceLabel}`,
+        label: namespaceLabel,
+      });
+    }
+    if (classLabel !== '') {
+      parent = levelItem(context, classes, parent, {
+        id: `class:${assembly.path}|${namespaceLabel}|${classLabel}`,
+        label: classLabel,
+      });
+    }
+    parent.children.add(makeTestItem(context, fqn));
+  }
+  return root;
+}
+
+/**
+ * The row that explains WHY discovery failed: the real `dotnet` diagnostic plus
+ * a remedy, so the user acts instead of staring at an empty view.
+ */
+export function makeErrorItem(
+  context: ItemContext,
+  target: string,
+  warnings: readonly string[],
+): vscode.TestItem {
+  const item = context.controller.createTestItem(
+    `${ERROR_ITEM_PREFIX}${target}`,
+    'Test discovery failed',
+    context.uri,
+  );
+  item.description = target;
+  const diagnostics =
+    warnings.length > 0 ? warnings.join('\n\n') : 'dotnet test produced no test listing.';
+  item.error = new vscode.MarkdownString(
+    `SharpLsp could not enumerate tests for \`${target}\`.\n\n` +
+      `${diagnostics}\n\n` +
+      'Load one solution with the **SharpLsp: Select Solution** command, fix the build errors above, then refresh the Testing view.',
+  );
+  return item;
+}

--- a/src/editors/vscode/src/test-listing-model.ts
+++ b/src/editors/vscode/src/test-listing-model.ts
@@ -1,0 +1,156 @@
+/**
+ * The shape a discovery sweep reports, whichever runner produced it.
+ *
+ * Both runners fill the same model — VSTest through
+ * `dotnet vstest --ListFullyQualifiedTests`, Microsoft.Testing.Platform through
+ * a module's own `--list-tests json` — so the Test Explorer builds one tree and
+ * the two paths never diverge past this point.
+ *
+ * Implements [TEST-DISCOVERY-FQN] and [TEST-MTP-DISCOVERY].
+ */
+
+/** The outcome of enumerating one target. Never an exception. */
+export interface TestListing {
+  /** Fully-qualified names, in discovery order, de-duplicated. */
+  readonly names: readonly string[];
+  /** True when the enumeration ran to completion (so an empty list is real). */
+  readonly ok: boolean;
+  /** Diagnostics worth writing to the extension log. */
+  readonly warnings: readonly string[];
+  /**
+   * The names grouped by the assembly that contributed them — the grouping the
+   * Test Explorer renders as Assembly → Namespace → Class → Test. Empty for
+   * the weaker display-name fallback, which cannot attribute names.
+   */
+  readonly byAssembly: readonly TestAssemblyListing[];
+  /**
+   * How to RUN what was discovered, when the runner was
+   * Microsoft.Testing.Platform. Absent for a VSTest sweep, whose ids are the
+   * filter values themselves. Spec: [TEST-MTP-RUN].
+   */
+  readonly mtp?: MtpRunPlan;
+  /**
+   * Source location per test id, when the runner reported one. The VSTest path
+   * reports none; MTP reports one for every framework except NUnit.
+   */
+  readonly locations?: ReadonlyMap<string, TestLocation>;
+}
+
+/** Where a test is written, as the discovery pass reported it. */
+export interface TestLocation {
+  readonly file: string;
+  /** 1-based first line, when the framework reported one. */
+  readonly line: number | undefined;
+}
+
+/** Everything an MTP run needs that the test ids do not carry themselves. */
+export interface MtpRunPlan {
+  readonly modules: readonly MtpModuleRun[];
+}
+
+/** One test module, and the uids each of its test ids owns. */
+export interface MtpModuleRun {
+  /** Absolute path of the built test module. */
+  readonly modulePath: string;
+  /** Test id to the `--filter-uid` values that run it. */
+  readonly uidsById: ReadonlyMap<string, readonly string[]>;
+}
+
+/** One built test assembly and the fully-qualified names it contributed. */
+export interface TestAssemblyListing {
+  /** Assembly file name without extension — the tree's root label. */
+  readonly name: string;
+  /** Absolute path of the built assembly — the stable, unique group id. */
+  readonly path: string;
+  /** Fully-qualified test names this assembly contributed, in listing order. */
+  readonly names: readonly string[];
+}
+
+/**
+ * Collapse the assemblies ONE multi-targeted project produced into one listing.
+ *
+ * `dotnet test --list-tests` announces a `Test run for …` banner per TARGET
+ * FRAMEWORK, so a project declaring `<TargetFrameworks>net8.0;net9.0</…>` reports
+ * two assemblies carrying the same file name under different
+ * `bin/<config>/<tfm>/` directories. That is one project, and so one root of the
+ * Assembly → Namespace → Class → Test tree: keeping them apart rendered every
+ * namespace, class and test of that project TWICE, under two labels the user
+ * cannot tell apart.
+ *
+ * Names are UNIONED, never taken from whichever framework was announced first: a
+ * test compiled behind `#if NET8_0` exists in only one of the assemblies, and
+ * dropping it would trade a duplicated tree for a missing test. The surviving
+ * path is the identity the frameworks SHARE (see {@link sharedOutputPath}), so
+ * the group ids the tree builds from it stay put across sweeps however the
+ * build ordered its banners.
+ */
+export function mergeMultiTargeted(
+  listings: readonly TestAssemblyListing[],
+): TestAssemblyListing[] {
+  const merged = new Map<string, { paths: string[]; names: string[] }>();
+  for (const listing of listings) {
+    const existing = merged.get(listing.name);
+    if (existing === undefined) {
+      merged.set(listing.name, { paths: [listing.path], names: [...listing.names] });
+      continue;
+    }
+    existing.paths.push(listing.path);
+    existing.names.push(...listing.names);
+  }
+  return [...merged].map(([name, entry]) => ({
+    name,
+    path: sharedOutputPath(entry.paths),
+    names: [...new Set(entry.names)],
+  }));
+}
+
+/**
+ * The identity several builds of ONE assembly share.
+ *
+ * Two target frameworks put the same assembly under `bin/<config>/net8.0/` and
+ * `bin/<config>/net9.0/`, so their paths agree everywhere except the segments
+ * that name a build. Keeping one of them as the merged group id keys the whole
+ * project's tree on a framework it merely happens to target: the id moves the
+ * moment the build announces its banners in another order, and a project
+ * targeting four frameworks gets a row identified by exactly one of them.
+ *
+ * Taking the common prefix back to its last separator and re-attaching the file
+ * name leaves what every build of the project agrees on. A project with one
+ * target framework has nothing to reconcile and keeps its real path.
+ */
+function sharedOutputPath(paths: readonly string[]): string {
+  const [first, ...rest] = paths;
+  if (first === undefined) return '';
+  if (rest.length === 0) return first;
+  const shared = rest.reduce(commonPrefix, first);
+  return shared.slice(0, lastSeparator(shared) + 1) + first.slice(lastSeparator(first) + 1);
+}
+
+/** The leading characters two paths agree on. */
+function commonPrefix(left: string, right: string): string {
+  let index = 0;
+  while (index < left.length && index < right.length && left[index] === right[index]) index += 1;
+  return left.slice(0, index);
+}
+
+/**
+ * Index of the last `/` or `\`, or -1. Both are checked rather than `path.sep`
+ * because the separator comes from whichever host BUILT the listing, which is
+ * not necessarily the one reading it.
+ */
+function lastSeparator(value: string): number {
+  return Math.max(value.lastIndexOf('/'), value.lastIndexOf('\\'));
+}
+
+/**
+ * One run plan for every target of a sweep.
+ *
+ * A workspace with several folders enumerates each one, and a run selects tests
+ * across all of them. Concatenating the modules keeps that one invocation set;
+ * an empty result means the sweep found no MTP module at all, and the VSTest
+ * path stays in charge.
+ */
+export function mergePlans(plans: readonly MtpRunPlan[]): MtpRunPlan | undefined {
+  const modules = plans.flatMap((plan) => [...plan.modules]);
+  return modules.length === 0 ? undefined : { modules };
+}

--- a/src/editors/vscode/src/test-mtp-discovery.ts
+++ b/src/editors/vscode/src/test-mtp-discovery.ts
@@ -1,0 +1,154 @@
+/**
+ * Discovering the tests of Microsoft.Testing.Platform modules.
+ *
+ * The VSTest path builds with `dotnet test --list-tests` and then asks
+ * `dotnet vstest` for the names. This path does the same two things with the
+ * MTP commands: `dotnet build` first, then the built MODULE is asked directly.
+ *
+ * `dotnet test` cannot be used here. It does not forward the `json` argument of
+ * `--list-tests` (dotnet/sdk#49754), and the text listing it does forward is
+ * display names — which MSTest renders as the BARE method name, the same defect
+ * as issue #180. `dotnet exec` runs a module on every platform, with no apphost
+ * and no execute bit.
+ *
+ * Nothing here throws. A module that cannot be listed adds a warning and leaves
+ * every other module alone.
+ *
+ * Implements [TEST-MTP-DISCOVERY].
+ */
+
+import * as path from 'node:path';
+import { DOTNET_TIMEOUT_MS, runDotnet } from './dotnet-process.js';
+import {
+  mergeMultiTargeted,
+  type MtpModuleRun,
+  type TestAssemblyListing,
+  type TestListing,
+  type TestLocation,
+} from './test-listing-model.js';
+import {
+  mtpIds,
+  mtpLocationsById,
+  mtpUidsById,
+  parseMtpTestList,
+  rejectedMtpOption,
+  type MtpTest,
+} from './test-mtp.js';
+import { scanMtpProjects, type MtpProject } from './test-mtp-modules.js';
+
+/** Ask a module for its tests as JSON, and nothing else. */
+export function listArgs(modulePath: string): string[] {
+  return ['exec', modulePath, '--list-tests', 'json', '--no-banner', '--no-ansi'];
+}
+
+/** One module's tests, plus whatever went wrong asking for them. */
+interface ModuleListing {
+  readonly tests: readonly MtpTest[];
+  readonly warnings: readonly string[];
+}
+
+/** Run `--list-tests json` against one module. */
+async function listModule(
+  modulePath: string,
+  cwd: string,
+  timeoutMs: number,
+): Promise<ModuleListing> {
+  const run = await runDotnet(listArgs(modulePath), cwd, timeoutMs);
+  const output = `${run.stdout}\n${run.stderr}`;
+  const rejected = rejectedMtpOption(output);
+  if (rejected !== undefined) {
+    return {
+      tests: [],
+      warnings: [
+        `${path.basename(modulePath)} rejected ${rejected}. ` +
+          'Its Microsoft.Testing.Platform version is older than 2.3, which is the first ' +
+          'to list tests as JSON. Update the test framework package.',
+      ],
+    };
+  }
+  const listing = parseMtpTestList(run.stdout);
+  const failure =
+    listing.tests.length === 0 && run.failed
+      ? [`${path.basename(modulePath)} listed no test: ${run.errorMessage ?? 'no detail'}`]
+      : [];
+  return { tests: listing.tests, warnings: [...listing.warnings, ...failure] };
+}
+
+/** The tree root and the run plan one module contributes. */
+interface ModuleResult {
+  readonly assembly: TestAssemblyListing;
+  readonly run: MtpModuleRun;
+  readonly locations: ReadonlyMap<string, TestLocation>;
+  readonly warnings: readonly string[];
+}
+
+/** List one module and shape what it reported for both the tree and the run. */
+async function scanModule(
+  modulePath: string,
+  cwd: string,
+  timeoutMs: number,
+): Promise<ModuleResult> {
+  const listed = await listModule(modulePath, cwd, timeoutMs);
+  return {
+    assembly: {
+      name: path.basename(modulePath, path.extname(modulePath)),
+      path: modulePath,
+      names: mtpIds(listed.tests),
+    },
+    run: { modulePath, uidsById: mtpUidsById(listed.tests) },
+    locations: mtpLocationsById(listed.tests),
+    warnings: listed.warnings,
+  };
+}
+
+/** Every module of every MTP project the scan found. */
+function modulesOf(projects: readonly MtpProject[]): string[] {
+  return projects.flatMap((project) => [...project.modules]);
+}
+
+/** Merge one module's locations into the sweep-wide map, first report winning. */
+function collectLocations(
+  into: Map<string, TestLocation>,
+  from: ReadonlyMap<string, TestLocation>,
+): void {
+  for (const [id, location] of from) {
+    if (!into.has(id)) into.set(id, location);
+  }
+}
+
+/**
+ * Enumerate every MTP test of `target`.
+ *
+ * `ok` says whether an EMPTY result can be trusted, because that is what
+ * decides whether the caller blanks the Testing view. A target with no MTP
+ * project at all is a truthful empty answer; a target whose modules all failed
+ * to list is not.
+ */
+export async function listMtpTests(
+  target: string,
+  cwd: string,
+  timeoutMs: number = DOTNET_TIMEOUT_MS,
+): Promise<TestListing> {
+  const scan = await scanMtpProjects(target, cwd, timeoutMs);
+  const warnings = [...scan.warnings];
+  const modules = modulesOf(scan.projects);
+  const byAssembly: TestAssemblyListing[] = [];
+  const runs: MtpModuleRun[] = [];
+  const locations = new Map<string, TestLocation>();
+  for (const modulePath of modules) {
+    const scanned = await scanModule(modulePath, cwd, timeoutMs);
+    warnings.push(...scanned.warnings);
+    byAssembly.push(scanned.assembly);
+    runs.push(scanned.run);
+    collectLocations(locations, scanned.locations);
+  }
+  const names = [...new Set(byAssembly.flatMap((assembly) => [...assembly.names]))];
+  return {
+    names,
+    ok: names.length > 0 || modules.length === 0,
+    warnings,
+    byAssembly: mergeMultiTargeted(byAssembly.filter((assembly) => assembly.names.length > 0)),
+    mtp: { modules: runs },
+    locations,
+  };
+}

--- a/src/editors/vscode/src/test-mtp-modules.ts
+++ b/src/editors/vscode/src/test-mtp-modules.ts
@@ -1,0 +1,175 @@
+/**
+ * Finding the Microsoft.Testing.Platform test modules of a target.
+ *
+ * MTP prints no `Test run for <assembly>` banner, so the assemblies cannot be
+ * scraped out of a listing the way the VSTest path scrapes them. They come from
+ * MSBuild instead, which is the only source that survives a custom
+ * `AssemblyName`, a custom `OutputPath`, an `ArtifactsPath` or a
+ * `RuntimeIdentifier`.
+ *
+ * Nothing here throws: a project that cannot be evaluated adds a warning and
+ * leaves the other projects alone.
+ *
+ * Implements [TEST-MTP-MODULES].
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { DOTNET_TIMEOUT_MS, runDotnet } from './dotnet-process.js';
+import { evaluateProject } from './msbuild.js';
+
+/** Project file extensions the Test Explorer knows. */
+const PROJECT_EXTENSIONS = ['.csproj', '.fsproj'];
+
+/** Solution file extensions `dotnet sln list` accepts. */
+const SOLUTION_EXTENSIONS = ['.sln', '.slnx', '.slnf'];
+
+/** One MTP test project and the modules its target frameworks produced. */
+export interface MtpProject {
+  /** Absolute path of the project file. */
+  readonly projectFile: string;
+  /** Absolute paths of the built test modules, one per target framework. */
+  readonly modules: readonly string[];
+}
+
+/** What a module sweep found. Never an exception. */
+export interface MtpProjectScan {
+  readonly projects: readonly MtpProject[];
+  readonly warnings: readonly string[];
+}
+
+/** True when `target` is a solution file `dotnet sln list` understands. */
+export function isSolutionFile(target: string): boolean {
+  return SOLUTION_EXTENSIONS.includes(path.extname(target).toLowerCase());
+}
+
+/**
+ * The project paths in `dotnet sln <solution> list` output.
+ *
+ * The command prints a two-line header (`Project(s)` and a rule) before the
+ * paths, and the paths are RELATIVE to the solution. Lines are classified one
+ * by one rather than sliced past a fixed header: a localized or a future header
+ * would otherwise turn into a project path that does not exist.
+ */
+export function parseSolutionProjects(output: string, solutionDir: string): string[] {
+  const projects: string[] = [];
+  for (const raw of output.split('\n')) {
+    const line = raw.trim();
+    if (!PROJECT_EXTENSIONS.includes(path.extname(line).toLowerCase())) continue;
+    projects.push(path.resolve(solutionDir, line));
+  }
+  return projects;
+}
+
+/** Every project file directly under `dir` or below it, without `bin`/`obj`. */
+function projectsUnder(dir: string, depth = 6): string[] {
+  const found: string[] = [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isFile() && PROJECT_EXTENSIONS.includes(path.extname(entry.name).toLowerCase())) {
+      found.push(full);
+    }
+    if (entry.isDirectory() && depth > 0 && !isIgnoredDirectory(entry.name)) {
+      found.push(...projectsUnder(full, depth - 1));
+    }
+  }
+  return found;
+}
+
+/** Build output and package directories never hold a source project. */
+function isIgnoredDirectory(name: string): boolean {
+  const lower = name.toLowerCase();
+  return lower === 'bin' || lower === 'obj' || lower === 'node_modules' || name.startsWith('.');
+}
+
+/** The project files of a solution, or of a directory that has none. */
+export async function projectsOf(target: string, timeoutMs: number): Promise<string[]> {
+  if (!isSolutionFile(target)) {
+    return projectsUnder(fs.statSync(target).isDirectory() ? target : path.dirname(target));
+  }
+  const dir = path.dirname(target);
+  const run = await runDotnet(['sln', target, 'list'], dir, timeoutMs);
+  return parseSolutionProjects(run.stdout, dir);
+}
+
+/**
+ * Every built module of one MTP project.
+ *
+ * A multi-targeted project reports an EMPTY `TargetPath` from the outer build —
+ * it has no single target — and one module per declared framework instead. Both
+ * shapes are handled here so the caller sees a plain list of modules.
+ */
+async function modulesOf(projectFile: string): Promise<string[]> {
+  const evaluated = await evaluateProject(projectFile);
+  if (!evaluated.ok) return [];
+  if (evaluated.value.targetPath.length > 0) return [evaluated.value.targetPath];
+  const modules: string[] = [];
+  for (const framework of evaluated.value.targetFrameworks) {
+    const pinned = await evaluateProject(projectFile, framework);
+    if (pinned.ok && pinned.value.targetPath.length > 0) modules.push(pinned.value.targetPath);
+  }
+  return modules;
+}
+
+/** One project's MTP verdict, plus any diagnostic worth logging. */
+async function scanProject(
+  projectFile: string,
+): Promise<{ project: MtpProject | undefined; warnings: string[] }> {
+  const evaluated = await evaluateProject(projectFile);
+  if (!evaluated.ok) {
+    return {
+      project: undefined,
+      warnings: [`Could not evaluate ${projectFile}: ${evaluated.error}`],
+    };
+  }
+  if (!evaluated.value.isTestingPlatformApplication) return { project: undefined, warnings: [] };
+  const modules = (await modulesOf(projectFile)).filter((module) => fs.existsSync(module));
+  if (modules.length === 0) {
+    return {
+      project: undefined,
+      warnings: [`MTP test project built no module that exists on disk: ${projectFile}`],
+    };
+  }
+  return { project: { projectFile, modules }, warnings: [] };
+}
+
+/** Build `target` so every test module exists before anything is asked of it. */
+export async function buildTarget(
+  target: string,
+  cwd: string,
+  timeoutMs: number,
+): Promise<string[]> {
+  const positional = cwd === target ? [] : [target];
+  const run = await runDotnet(['build', ...positional, '--nologo'], cwd, timeoutMs);
+  if (!run.failed) return [];
+  const detail = `${run.stdout}\n${run.stderr}`.trim().slice(-2_000);
+  return [`dotnet build reported a failure: ${run.errorMessage ?? 'unknown'}; output: ${detail}`];
+}
+
+/**
+ * Build `target`, then report its MTP test projects and their modules.
+ *
+ * A build FAILURE is a warning, not a stop: a solution whose sibling project
+ * does not compile still has modules from the projects that did, and dropping
+ * them would blank the Testing view over an unrelated error.
+ */
+export async function scanMtpProjects(
+  target: string,
+  cwd: string,
+  timeoutMs: number = DOTNET_TIMEOUT_MS,
+): Promise<MtpProjectScan> {
+  const warnings = await buildTarget(target, cwd, timeoutMs);
+  const projects: MtpProject[] = [];
+  for (const projectFile of await projectsOf(target, timeoutMs)) {
+    const scanned = await scanProject(projectFile);
+    warnings.push(...scanned.warnings);
+    if (scanned.project !== undefined) projects.push(scanned.project);
+  }
+  return { projects, warnings };
+}

--- a/src/editors/vscode/src/test-mtp-run.ts
+++ b/src/editors/vscode/src/test-mtp-run.ts
@@ -1,0 +1,312 @@
+/**
+ * Running Microsoft.Testing.Platform tests.
+ *
+ * One invocation per MODULE for the whole selection, never one per test — the
+ * same rule [TEST-RUN-TRX] sets for VSTest, and for the same reason: a class of
+ * twenty tests must not pay twenty starts.
+ *
+ * Selection is by `--filter-uid`, which takes the module's own run keys. Those
+ * keys are LITERAL values, so the [TEST-FILTER-ESCAPE] grammar does not apply
+ * and must not be used: an NUnit uid is
+ * `Cs.Nunit.Mtp.CalculatorTests.Adds_Case(2,2,4)`, and escaping its parentheses
+ * would make it match nothing.
+ *
+ * Outcomes come from the TRX report the module writes, read by the same reader
+ * the VSTest path uses.
+ *
+ * Implements [TEST-MTP-RUN].
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { batchByWidth, MAX_ARG_CHARS } from './test-batching.js';
+import { DOTNET_TIMEOUT_MS, runDotnet } from './dotnet-process.js';
+import type { MtpModuleRun, MtpRunPlan } from './test-listing-model.js';
+import { MTP_INVALID_COMMAND_LINE, rejectedMtpOption } from './test-mtp.js';
+import { parseMtpSummary, type TestOutcome, type TestRunSummary } from './test-run-output.js';
+import { collectReport, trxFiles, worse } from './test-trx-collect.js';
+import type { TrxRunInfo, TrxTestResult } from './test-trx.js';
+import type { TestRunOptions, TestRunOutcome } from './test-execution.js';
+
+/** Ceiling on the uid arguments handed to ONE invocation. */
+export const MAX_UID_ARG_CHARS = MAX_ARG_CHARS;
+
+/**
+ * Split uids into batches whose joined argument text stays under the ceiling.
+ * A uid is passed as its own argv entry, so its cost is its length plus the
+ * separator and the quoting a shell would add.
+ */
+export function uidBatches(uids: readonly string[], maxChars = MAX_UID_ARG_CHARS): string[][] {
+  return batchByWidth(uids, (uid) => uid.length + 3, maxChars);
+}
+
+/** The uids one module must run for `testIds`; empty ids mean "run everything". */
+export function uidsFor(module: MtpModuleRun, testIds: readonly string[]): string[] {
+  if (testIds.length === 0) return [];
+  return testIds.flatMap((id) => [...(module.uidsById.get(id) ?? [])]);
+}
+
+/** True when the module owns none of the selected ids, so it must not start. */
+function untouched(module: MtpModuleRun, testIds: readonly string[]): boolean {
+  return testIds.length > 0 && uidsFor(module, testIds).length === 0;
+}
+
+/**
+ * A TRX name unique to this module.
+ *
+ * Two modules writing one auto-named report into a shared results directory
+ * would overwrite each other, which is the defect [TEST-RUN-TRX] avoids under
+ * VSTest by never pinning `LogFileName`.
+ */
+export function trxNameFor(modulePath: string, batchIndex: number): string {
+  const stem = path.basename(modulePath, path.extname(modulePath));
+  return `${stem}.${String(batchIndex)}.trx`;
+}
+
+/** The argument vector for one module invocation. */
+export function runArgs(
+  modulePath: string,
+  uids: readonly string[],
+  resultsDirectory: string,
+  options: TestRunOptions,
+  trxName: string,
+): string[] {
+  return [
+    'exec',
+    modulePath,
+    ...(uids.length === 0 ? [] : ['--filter-uid', ...uids]),
+    '--report-trx',
+    '--report-trx-filename',
+    trxName,
+    '--results-directory',
+    resultsDirectory,
+    '--no-banner',
+    '--no-ansi',
+    // `--no-progress` is deprecated since MTP 2.3 and warns on every run.
+    ...(options.coverage === true ? ['--coverage', '--coverage-output-format', 'cobertura'] : []),
+  ];
+}
+
+/** An empty outcome, so a run that started nothing still has a shape. */
+function emptyOutcome(failure: string | undefined): TestRunOutcome {
+  return {
+    results: new Map(),
+    summary: undefined,
+    failure,
+    runInfos: [],
+    retriedUnfiltered: false,
+    durationMs: 0,
+    output: '',
+  };
+}
+
+/**
+ * The message an invocation earns when it produced no result.
+ *
+ * Exit code 5 is MTP's "I did not understand the command line". `--report-trx`
+ * and `--coverage` are EXTENSIONS, so a module that does not register them
+ * exits that way. Naming the missing package is the whole point: a silent empty
+ * run reports every selected test as "No result reported" and hides the cause.
+ */
+function invocationFailure(
+  modulePath: string,
+  output: string,
+  errorMessage: string | undefined,
+  resultCount: number,
+): string | undefined {
+  const rejected = rejectedMtpOption(output);
+  if (rejected === '--report-trx') {
+    return (
+      `${path.basename(modulePath)} does not support ${rejected} (MTP exit code ` +
+      `${String(MTP_INVALID_COMMAND_LINE)}). Add a PackageReference to ` +
+      'Microsoft.Testing.Extensions.TrxReport so the Test Explorer can read per-test results.'
+    );
+  }
+  if (rejected !== undefined) {
+    return `${path.basename(modulePath)} does not support ${rejected}.`;
+  }
+  return resultCount > 0 ? undefined : (errorMessage ?? undefined);
+}
+
+/** One `dotnet exec <module>` invocation into `resultsDirectory`. */
+async function invoke(
+  module: MtpModuleRun,
+  uids: readonly string[],
+  batchIndex: number,
+  context: { resultsDirectory: string; cwd: string; options: TestRunOptions },
+): Promise<TestRunOutcome> {
+  const { resultsDirectory, cwd, options } = context;
+  fs.mkdirSync(resultsDirectory, { recursive: true });
+  const before = new Set(trxFiles(resultsDirectory));
+  const args = runArgs(
+    module.modulePath,
+    uids,
+    resultsDirectory,
+    options,
+    trxNameFor(module.modulePath, batchIndex),
+  );
+  const started = Date.now();
+  const run = await runDotnet(
+    args,
+    cwd,
+    options.timeoutMs ?? DOTNET_TIMEOUT_MS,
+    options.signal,
+    options.hooks,
+  );
+  const output = `${run.stdout}\n${run.stderr}`;
+  const report = collectReport(resultsDirectory, before);
+  return {
+    results: report.results,
+    summary: parseMtpSummary(output),
+    failure: run.killed
+      ? `${path.basename(module.modulePath)} was killed: ${run.errorMessage ?? 'no detail'}`
+      : invocationFailure(module.modulePath, output, run.errorMessage, report.results.size),
+    runInfos: report.runInfos,
+    retriedUnfiltered: false,
+    durationMs: Date.now() - started,
+    output,
+  };
+}
+
+/** Sum two summaries; one module's counts are never the whole run's. */
+function mergeSummaries(
+  left: TestRunSummary | undefined,
+  right: TestRunSummary | undefined,
+): TestRunSummary | undefined {
+  if (left === undefined) return right;
+  if (right === undefined) return left;
+  const totals = {
+    passed: left.passed + right.passed,
+    failed: left.failed + right.failed,
+    skipped: left.skipped + right.skipped,
+    total: left.total + right.total,
+  };
+  return { ...totals, outcome: worstSummaryOutcome(left, right) };
+}
+
+/** A run of several modules is as bad as its worst module. */
+function worstSummaryOutcome(left: TestRunSummary, right: TestRunSummary): TestOutcome {
+  const ranked: readonly TestOutcome[] = ['passed', 'skipped', 'notRun', 'failed'];
+  return ranked.indexOf(right.outcome) > ranked.indexOf(left.outcome)
+    ? right.outcome
+    : left.outcome;
+}
+
+/** Merge two invocations, keeping the WORST outcome reported for each id. */
+export function mergeOutcomes(left: TestRunOutcome, right: TestRunOutcome): TestRunOutcome {
+  const results = new Map<string, TrxTestResult>(left.results);
+  for (const [name, result] of right.results) {
+    const existing = results.get(name);
+    results.set(name, existing === undefined ? result : worse(existing, result));
+  }
+  const runInfos: TrxRunInfo[] = [...left.runInfos, ...right.runInfos];
+  return {
+    results,
+    summary: mergeSummaries(left.summary, right.summary),
+    failure: results.size > 0 ? undefined : (left.failure ?? right.failure),
+    runInfos,
+    retriedUnfiltered: false,
+    durationMs: left.durationMs + right.durationMs,
+    output: `${left.output}\n${right.output}`,
+  };
+}
+
+/** Every batch of one module, merged, plus its one unfiltered recovery. */
+async function runModule(
+  module: MtpModuleRun,
+  testIds: readonly string[],
+  context: { resultsDirectory: string; cwd: string; options: TestRunOptions },
+): Promise<TestRunOutcome | undefined> {
+  const uids = uidsFor(module, testIds);
+  const batches = testIds.length === 0 ? [[]] : uidBatches(uids);
+  let merged: TestRunOutcome | undefined;
+  let index = 0;
+  for (const batch of batches) {
+    if (context.options.signal?.aborted === true) break;
+    const one = await invoke(module, batch, index, context);
+    merged = merged === undefined ? one : mergeOutcomes(merged, one);
+    index += 1;
+  }
+  if (merged === undefined || !needsUnfilteredRetry(module, merged, testIds, context)) {
+    return merged;
+  }
+  const unfiltered = await invoke(module, [], index, context);
+  return {
+    ...mergeOutcomes(merged, unfiltered),
+    // The retry re-ran the SAME module, so its counts REPLACE the refused
+    // attempt's rather than adding to them. Summing is right only ACROSS
+    // modules, which is what `mergeOutcomes` does everywhere else.
+    summary: unfiltered.summary ?? merged.summary,
+    retriedUnfiltered: true,
+  };
+}
+
+/**
+ * True when the module REFUSED the selection rather than merely matching none.
+ *
+ * A framework bridged onto MTP can translate `--filter-uid` back into a VSTest
+ * filter EXPRESSION and then reject its own translation. NUnit does exactly
+ * that for a uid carrying both a SPACE and PARENTHESES — which is every
+ * idiomatic F# `[<TestCase>]` binding
+ * (`Fs.Nunit.Fixtures.adds case(2,2,4)` → "Unexpected FQN 'case\(2,2,4\)' at
+ * position 46 in selection expression") — and the whole module then reports
+ * nothing, so perfectly runnable tests show as phantom failures.
+ *
+ * The remedy is the one [TEST-FILTER-ESCAPE] already sets for the VSTest path:
+ * re-run the module ONCE without a filter and pick the outcomes out of the
+ * report by name. Slower, but correct, and only ever when the module both
+ * failed AND left a selected test unreported — never on a selection that
+ * legitimately matched nothing.
+ */
+function needsUnfilteredRetry(
+  module: MtpModuleRun,
+  outcome: TestRunOutcome,
+  testIds: readonly string[],
+  context: { options: TestRunOptions },
+): boolean {
+  if (testIds.length === 0) return false;
+  if (context.options.signal?.aborted === true) return false;
+  if (outcome.failure === undefined) return false;
+  // A REJECTED option is rejected again without a filter, so retrying only
+  // doubles the wait before the user reads the same message.
+  if (rejectedMtpOption(outcome.output) !== undefined) return false;
+  const mine = testIds.filter((id) => module.uidsById.has(id));
+  return mine.some((id) => !outcome.results.has(id));
+}
+
+/** Run `testIds` (all tests when empty) across the plan's modules. */
+export async function runMtpTests(
+  plan: MtpRunPlan,
+  testIds: readonly string[],
+  cwd: string,
+  options: TestRunOptions = {},
+): Promise<TestRunOutcome> {
+  const owned = options.resultsDirectory === undefined;
+  const resultsDirectory = options.resultsDirectory ?? freshTempDir();
+  const context = { resultsDirectory, cwd, options };
+  try {
+    let merged: TestRunOutcome | undefined;
+    for (const module of plan.modules) {
+      if (options.signal?.aborted === true) break;
+      if (untouched(module, testIds)) continue;
+      const one = await runModule(module, testIds, context);
+      if (one === undefined) continue;
+      merged = merged === undefined ? one : mergeOutcomes(merged, one);
+    }
+    return merged ?? emptyOutcome(noModuleRan(plan, options));
+  } finally {
+    if (owned) fs.rmSync(resultsDirectory, { recursive: true, force: true });
+  }
+}
+
+/** Why a plan started nothing: cancelled first, or simply empty. */
+function noModuleRan(plan: MtpRunPlan, options: TestRunOptions): string | undefined {
+  if (options.signal?.aborted === true) return 'Run cancelled before any module started';
+  return plan.modules.length === 0 ? 'No Microsoft.Testing.Platform module to run' : undefined;
+}
+
+/** A private, empty directory for one run's TRX output. */
+function freshTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'sharplsp-mtp-'));
+}

--- a/src/editors/vscode/src/test-mtp.ts
+++ b/src/editors/vscode/src/test-mtp.ts
@@ -1,0 +1,240 @@
+/**
+ * Microsoft.Testing.Platform: choosing the runner, and reading what a test
+ * module reports.
+ *
+ * An MTP test project builds to an EXECUTABLE test module, and that module —
+ * not `vstest.console` — discovers and runs its own tests. Every VSTest command
+ * fails against it: `--nologo` is not a valid MTP option, `dotnet vstest`
+ * cannot load the assembly, and neither `--filter` nor `--logger trx` exists.
+ *
+ * This module is PURE: no process, no VS Code. It decides which runner a target
+ * uses, and it turns the module's `--list-tests json` answer into test ids.
+ *
+ * Implements [TEST-MTP-DETECT] and [TEST-MTP-DISCOVERY].
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { isRecord } from './utils.js';
+
+/** The `global.json` value that selects MTP, lower-cased for comparison. */
+const MTP_RUNNER = 'microsoft.testing.platform';
+
+/** The JSON listing schema this reader was written against. */
+const KNOWN_SCHEMA_VERSION = 1;
+
+/** One test node a module reported. */
+export interface MtpTest {
+  /**
+   * `namespace.Type.Method`, the Test Explorer's id. Built from the listing's
+   * `type` block and NEVER from its display name: MSTest reports the BARE
+   * method name as the display name, which is the issue-#180 defect again.
+   */
+  readonly id: string;
+  /** The module's own run key, passed back verbatim to `--filter-uid`. */
+  readonly uid: string;
+  /** The name the module shows a human. Carries row data; a label, not a key. */
+  readonly label: string;
+  /** Source file, when the framework reports one. NUnit does not. */
+  readonly file: string | undefined;
+  /** 1-based first line of the test, when the framework reports one. */
+  readonly line: number | undefined;
+}
+
+/** What one module's listing produced. Never an exception. */
+export interface MtpListing {
+  readonly tests: readonly MtpTest[];
+  readonly warnings: readonly string[];
+}
+
+/** A non-empty string at `key`, or `undefined`. */
+function text(bag: Record<string, unknown>, key: string): string | undefined {
+  const value = bag[key];
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+/**
+ * True when `globalJson` opts the whole target into MTP.
+ *
+ * Parsed, never searched: `"Microsoft.Testing.Platform"` also appears in a
+ * comment, in a package name and in an unrelated property, and a string search
+ * would switch a VSTest solution onto a path that cannot run it.
+ */
+export function mtpRunnerSelected(globalJson: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(globalJson);
+    if (!isRecord(parsed)) return false;
+    const test: unknown = parsed.test;
+    if (!isRecord(test)) return false;
+    return (text(test, 'runner') ?? '').toLowerCase() === MTP_RUNNER;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The nearest `global.json` at or above `startDir`, or `undefined`.
+ *
+ * The SDK resolves the runner the same way, so a solution in a sub-directory of
+ * the repository that holds the opt-in must find it too.
+ */
+export function findGlobalJson(startDir: string): string | undefined {
+  let current = path.resolve(startDir);
+  for (;;) {
+    const candidate = path.join(current, 'global.json');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+/** True when the `global.json` above `startDir` selects the MTP runner. */
+export function usesMtpRunner(startDir: string): boolean {
+  const file = findGlobalJson(startDir);
+  if (file === undefined) return false;
+  try {
+    return mtpRunnerSelected(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The id of one listed test.
+ *
+ * The `type` block holds the namespace, the type and the method separately, and
+ * it carries NO row data — so the rows of a data-driven test collapse onto the
+ * one id they share, as [TEST-DISCOVERY-FQN] requires. The joined value is also
+ * exactly the `className` + `.` + `name` pair the TRX report holds, which is
+ * what lets [TEST-RUN-TRX] attribute an MTP outcome with no change.
+ *
+ * A module that sends no `type` block falls back to the display name. That is
+ * weaker — MSTest would give a bare method name — but it is never worse than
+ * dropping the test.
+ */
+function idOf(node: Record<string, unknown>, label: string): string {
+  const type = node.type;
+  if (!isRecord(type)) return label;
+  const parts = [text(type, 'namespace'), text(type, 'typeName'), text(type, 'methodName')];
+  const named = parts.filter((part): part is string => part !== undefined);
+  return named.length === 0 ? label : named.join('.');
+}
+
+/** The 1-based start line of a node's `location`, when it has one. */
+function lineOf(node: Record<string, unknown>): number | undefined {
+  const location = node.location;
+  if (!isRecord(location)) return undefined;
+  const start: unknown = location.lineStart;
+  return typeof start === 'number' && Number.isInteger(start) && start > 0 ? start : undefined;
+}
+
+/** The source file of a node's `location`, when it has one. */
+function fileOf(node: Record<string, unknown>): string | undefined {
+  const location = node.location;
+  return isRecord(location) ? text(location, 'file') : undefined;
+}
+
+/** One `tests[]` entry, or `undefined` when it carries no usable uid. */
+function toTest(entry: unknown): MtpTest | undefined {
+  if (!isRecord(entry)) return undefined;
+  const uid = text(entry, 'uid');
+  if (uid === undefined) return undefined;
+  const label = text(entry, 'displayName') ?? uid;
+  return { id: idOf(entry, label), uid, label, file: fileOf(entry), line: lineOf(entry) };
+}
+
+/** The JSON document inside a module's stdout, or `undefined`. */
+function documentIn(stdout: string): Record<string, unknown> | undefined {
+  // The listing is preceded by a blank line, and on Windows by a byte-order
+  // mark, so the scan starts at the first brace rather than at character zero.
+  const start = stdout.indexOf('{');
+  if (start < 0) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(stdout.slice(start));
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** A warning when the module answered in a schema this reader does not know. */
+function schemaWarning(document: Record<string, unknown>): string[] {
+  const version: unknown = document.schemaVersion;
+  if (version === KNOWN_SCHEMA_VERSION) return [];
+  return [
+    `Test listing reported schemaVersion ${String(version)}; ` +
+      `this reader was written for ${String(KNOWN_SCHEMA_VERSION)}`,
+  ];
+}
+
+/** Read one module's `--list-tests json` answer. Never throws. */
+export function parseMtpTestList(stdout: string): MtpListing {
+  const document = documentIn(stdout);
+  if (document === undefined) {
+    return { tests: [], warnings: ['Test listing was not a JSON document'] };
+  }
+  const entries: unknown = document.tests;
+  if (!Array.isArray(entries)) {
+    return { tests: [], warnings: ['Test listing carried no "tests" array'] };
+  }
+  const tests = entries
+    .map((entry) => toTest(entry))
+    .filter((test): test is MtpTest => test !== undefined);
+  return { tests, warnings: schemaWarning(document) };
+}
+
+/** The ids one module reported, in listing order, without repeats. */
+export function mtpIds(tests: readonly MtpTest[]): string[] {
+  return [...new Set(tests.map((test) => test.id))];
+}
+
+/**
+ * Every uid each id owns, in listing order.
+ *
+ * A data-driven test lists one node PER ROW, each with its own uid and all
+ * sharing one id. Running that id must run every row, so the map holds a list.
+ */
+export function mtpUidsById(tests: readonly MtpTest[]): Map<string, string[]> {
+  const uids = new Map<string, string[]>();
+  for (const test of tests) {
+    const existing = uids.get(test.id);
+    if (existing === undefined) uids.set(test.id, [test.uid]);
+    else existing.push(test.uid);
+  }
+  return uids;
+}
+
+/** The first source location reported for each id, when there is one. */
+export function mtpLocationsById(
+  tests: readonly MtpTest[],
+): Map<string, { file: string; line: number | undefined }> {
+  const locations = new Map<string, { file: string; line: number | undefined }>();
+  for (const test of tests) {
+    if (test.file === undefined || locations.has(test.id)) continue;
+    locations.set(test.id, { file: test.file, line: test.line });
+  }
+  return locations;
+}
+
+/** The MTP exit code for a command line the module could not understand. */
+export const MTP_INVALID_COMMAND_LINE = 5;
+
+/** Prefix of the message a module prints when it rejects an option. */
+const UNKNOWN_OPTION = "Unknown option '";
+
+/**
+ * The option a module rejected, or `undefined`.
+ *
+ * `--report-trx` and `--coverage` are EXTENSIONS, not part of MTP. A module
+ * that does not register the extension exits with code 5 and prints this line.
+ * Reporting it as itself is what tells the user to reference the package;
+ * swallowing it would report every selected test as "No result reported".
+ */
+export function rejectedMtpOption(output: string): string | undefined {
+  const start = output.indexOf(UNKNOWN_OPTION);
+  if (start < 0) return undefined;
+  const rest = output.slice(start + UNKNOWN_OPTION.length);
+  const end = rest.indexOf("'");
+  return end <= 0 ? undefined : rest.slice(0, end);
+}

--- a/src/editors/vscode/src/test-profiles.ts
+++ b/src/editors/vscode/src/test-profiles.ts
@@ -1,0 +1,48 @@
+/**
+ * The three profiles the Testing view offers: Run, Debug, and Run with
+ * Coverage, in the order it shows them.
+ *
+ * Kept apart from `testing.ts` so the controller file stays about state and
+ * dispatch. The handlers themselves belong to the controller; this module only
+ * declares the profiles and wires the lazy coverage lookup.
+ *
+ * Implements [TEST-EXPLORER] and [TEST-COVERAGE].
+ */
+
+import * as vscode from 'vscode';
+import { loadDetailedCoverage } from './test-coverage.js';
+
+/** One profile's handler, as VS Code invokes it. */
+export type RunProfileHandler = (
+  request: vscode.TestRunRequest,
+  token: vscode.CancellationToken,
+) => Promise<void>;
+
+/** What the controller supplies for each profile. */
+export interface RunProfileHandlers {
+  readonly run: RunProfileHandler;
+  readonly debug: RunProfileHandler;
+  readonly coverage: RunProfileHandler;
+}
+
+/** Register the three profiles and return them in display order. */
+export function registerRunProfiles(
+  controller: vscode.TestController,
+  handlers: RunProfileHandlers,
+): vscode.TestRunProfile[] {
+  const run = controller.createRunProfile('Run', vscode.TestRunProfileKind.Run, handlers.run, true);
+  const debug = controller.createRunProfile(
+    'Debug',
+    vscode.TestRunProfileKind.Debug,
+    handlers.debug,
+  );
+  const coverage = controller.createRunProfile(
+    'Run with Coverage',
+    vscode.TestRunProfileKind.Coverage,
+    handlers.coverage,
+  );
+  coverage.loadDetailedCoverage =
+    // eslint-disable-next-line @typescript-eslint/require-await -- VS Code API requires Thenable return but lookup is synchronous
+    async (_run, fileCoverage, _token) => loadDetailedCoverage(fileCoverage);
+  return [run, debug, coverage];
+}

--- a/src/editors/vscode/src/test-queue.ts
+++ b/src/editors/vscode/src/test-queue.ts
@@ -1,0 +1,37 @@
+/**
+ * One `dotnet` invocation at a time, for the whole Test Explorer.
+ *
+ * Discovery BUILDS the solution and a run rebuilds the same projects, so two
+ * overlapping invocations race on the shared `bin/`/`obj/` output — VSTest then
+ * dies with "The application to execute does not exist: …testhost.dll", and a
+ * Microsoft.Testing.Platform module cannot even be started while it is being
+ * written. Reactive re-discovery is debounced, not cancelled, so that overlap
+ * is reachable whenever a user runs a test while a sweep is still building.
+ *
+ * Implements [TEST-REACTIVITY].
+ */
+
+/** A serial queue of `dotnet` invocations. */
+export class DotnetQueue {
+  private tail: Promise<unknown> = Promise.resolve();
+
+  /** Queue `work` behind any invocation already in flight. */
+  public async enqueue<T>(work: () => Promise<T>): Promise<T> {
+    const next = this.tail.then(work, work);
+    this.tail = next.catch(() => undefined);
+    return await next;
+  }
+
+  /**
+   * Resolve once no invocation is outstanding. Tests use this to settle
+   * reactive re-discovery before touching the fixture on disk; a `dotnet test`
+   * left pointing at a deleted directory hangs and poisons the next run.
+   */
+  public async whenIdle(): Promise<void> {
+    let seen: Promise<unknown> | undefined;
+    while (seen !== this.tail) {
+      seen = this.tail;
+      await seen;
+    }
+  }
+}

--- a/src/editors/vscode/src/test-result-cache.ts
+++ b/src/editors/vscode/src/test-result-cache.ts
@@ -1,0 +1,71 @@
+/**
+ * The last known outcome of every discovered test.
+ *
+ * The status CodeLens ([TEST-STATUS-LENS]) paints from this cache, so it
+ * outlives the run that filled it — and therefore has to be pruned when the
+ * tree changes. A result must not outlive the test it belongs to: after the
+ * loaded solution changes, a stale entry would paint an outcome for a test that
+ * was never run here.
+ *
+ * Implements [TEST-REACTIVITY].
+ */
+
+import * as vscode from 'vscode';
+import type { CacheWriter, CachedTestResult } from './test-reporting.js';
+import { forEachLeafIn } from './test-tree.js';
+
+/** Cached outcomes keyed by test id, with a change signal for the lens. */
+export class TestResultCache {
+  private readonly results = new Map<string, CachedTestResult>();
+  private readonly changed = new vscode.EventEmitter<void>();
+
+  /** Fires after any test run completes and results are cached. */
+  public readonly onChanged = this.changed.event;
+
+  /** Look up the last known result for a test id. */
+  public get(testId: string): CachedTestResult | undefined {
+    return this.results.get(testId);
+  }
+
+  /** All cached results keyed by test id. */
+  public get all(): ReadonlyMap<string, CachedTestResult> {
+    return this.results;
+  }
+
+  /** Announce that results changed, so the lens repaints. */
+  public fire(): void {
+    this.changed.fire();
+  }
+
+  /** The writer a real RUN reports through; a debug run passes none. */
+  public writer(): CacheWriter {
+    return (id, result) => {
+      this.results.set(id, result);
+    };
+  }
+
+  /** Record one result without announcing it. */
+  public set(testId: string, result: CachedTestResult): void {
+    this.results.set(testId, result);
+  }
+
+  /**
+   * Drop cached outcomes for tests no longer in the tree. Listeners hear about
+   * it only when something was actually dropped.
+   */
+  public pruneTo(items: readonly vscode.TestItem[]): void {
+    const alive = new Set<string>();
+    forEachLeafIn(items, (item) => alive.add(item.id));
+    let dropped = 0;
+    for (const id of [...this.results.keys()]) {
+      if (alive.has(id)) continue;
+      this.results.delete(id);
+      dropped += 1;
+    }
+    if (dropped > 0) this.changed.fire();
+  }
+
+  public dispose(): void {
+    this.changed.dispose();
+  }
+}

--- a/src/editors/vscode/src/test-run-output.ts
+++ b/src/editors/vscode/src/test-run-output.ts
@@ -100,3 +100,48 @@ function isErrorMessageTerminator(line: string): boolean {
   const trimmed = line.trim();
   return ERROR_MESSAGE_TERMINATORS.some((terminator) => trimmed.startsWith(terminator));
 }
+
+/**
+ * The per-module summary a Microsoft.Testing.Platform run prints.
+ *
+ * MTP does not print VSTest's `Passed! - Failed: 0, …` line. It prints a block
+ * instead, one per module, and the counts are summed the same way:
+ *
+ * ```
+ * Test run summary: Failed! - …/CsXunitMtp.dll (net10.0|x64)
+ *   total: 5
+ *   failed: 2
+ *   succeeded: 2
+ *   skipped: 1
+ * ```
+ *
+ * Implements [TEST-MTP-RUN]. The text is English because [TEST-ENV-LOCALE]
+ * pins `DOTNET_CLI_UI_LANGUAGE`.
+ */
+export function parseMtpSummary(output: string): TestRunSummary | undefined {
+  const totals = { passed: 0, failed: 0, skipped: 0, total: 0 };
+  let seen = false;
+  for (const raw of output.split('\n')) {
+    const match = MTP_COUNT_PATTERN.exec(raw.trim());
+    if (match === null) continue;
+    seen = true;
+    addMtpCount(totals, match[1] ?? '', Number(match[2] ?? '0'));
+  }
+  return seen ? { ...totals, outcome: outcomeOf(totals) } : undefined;
+}
+
+/** One `  <label>: <count>` line of an MTP summary block. */
+const MTP_COUNT_PATTERN = /^(total|failed|succeeded|skipped):\s+(\d+)$/;
+
+/** Add one counted line into the running totals. */
+function addMtpCount(
+  totals: { passed: number; failed: number; skipped: number; total: number },
+  label: string,
+  count: number,
+): void {
+  if (!Number.isFinite(count)) return;
+  if (label === 'total') totals.total += count;
+  if (label === 'failed') totals.failed += count;
+  if (label === 'succeeded') totals.passed += count;
+  if (label === 'skipped') totals.skipped += count;
+}

--- a/src/editors/vscode/src/test-targets.ts
+++ b/src/editors/vscode/src/test-targets.ts
@@ -57,3 +57,15 @@ export function isExpectoTest(name: string): boolean {
 export function isFsCheckTest(name: string): boolean {
   return name.includes('FsCheck') || name.includes('Property');
 }
+/**
+ * The filter ids a run uses. "Run everything, nothing excluded" is how VS Code
+ * expresses ▶ on the root of the Testing view; passing NO filter then runs every
+ * test in ONE `dotnet test` — instead of N command-line-sized filter batches.
+ */
+export function filterIdsFor(
+  request: vscode.TestRunRequest,
+  tests: readonly vscode.TestItem[],
+): readonly string[] {
+  const unfiltered = request.include === undefined && (request.exclude ?? []).length === 0;
+  return unfiltered ? [] : tests.map((test) => test.id);
+}

--- a/src/editors/vscode/src/test-trx-collect.ts
+++ b/src/editors/vscode/src/test-trx-collect.ts
@@ -1,0 +1,90 @@
+/**
+ * Reading back the `.trx` files ONE invocation created.
+ *
+ * Both runners end here. VSTest writes its reports with `--logger trx`, a
+ * Microsoft.Testing.Platform module writes its own with `--report-trx`, and the
+ * two documents carry the same `className` + `.` + `name` pair — so the same
+ * collection, the same worst-row merge and the same reader serve both.
+ *
+ * Implements [TEST-RUN-TRX] and [TEST-MTP-RUN].
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { TestOutcome } from './test-run-output.js';
+import { parseTrxReport, type TrxRunInfo, type TrxTestResult } from './test-trx.js';
+
+/** Every `.trx` this run created, merged: results keyed by FQN, plus run info. */
+export function collectReport(
+  dir: string,
+  before: ReadonlySet<string>,
+): { results: Map<string, TrxTestResult>; runInfos: TrxRunInfo[] } {
+  const results = new Map<string, TrxTestResult>();
+  const runInfos: TrxRunInfo[] = [];
+  for (const file of trxFiles(dir)) {
+    if (before.has(file)) continue;
+    const report = readTrx(file);
+    runInfos.push(...report.runInfos);
+    for (const result of report.results) {
+      const existing = results.get(result.fullyQualifiedName);
+      results.set(
+        result.fullyQualifiedName,
+        existing === undefined ? result : worse(existing, result),
+      );
+    }
+  }
+  return { results, runInfos };
+}
+
+/** Severity order, so a data-driven test is judged by its WORST row. */
+const OUTCOME_SEVERITY: Record<TestOutcome, number> = {
+  passed: 0,
+  skipped: 1,
+  notRun: 2,
+  failed: 3,
+};
+
+/**
+ * Merge two results reported under the SAME fully-qualified name.
+ *
+ * A theory or `[TestCase]` with several rows writes one TRX entry PER ROW, all
+ * carrying the same FQN. Keeping the last one seen would report a green tree for
+ * a theory whose second row failed, purely because of the order VSTest happened
+ * to write them. The worst outcome wins and the durations add up.
+ */
+export function worse(left: TrxTestResult, right: TrxTestResult): TrxTestResult {
+  const durationMs = sumDurations(left.durationMs, right.durationMs);
+  const dominant = OUTCOME_SEVERITY[right.outcome] > OUTCOME_SEVERITY[left.outcome] ? right : left;
+  return { ...dominant, durationMs };
+}
+
+/** Add two optional durations, keeping `undefined` only when both are absent. */
+function sumDurations(left: number | undefined, right: number | undefined): number | undefined {
+  if (left === undefined) return right;
+  if (right === undefined) return left;
+  return left + right;
+}
+
+/** Absolute paths of the `.trx` reports directly inside `dir`. */
+export function trxFiles(dir: string): string[] {
+  try {
+    return fs
+      .readdirSync(dir)
+      .filter((entry) => entry.toLowerCase().endsWith('.trx'))
+      .map((entry) => path.join(dir, entry));
+  } catch {
+    return [];
+  }
+}
+
+/** Parse one TRX file, tolerating a truncated or unreadable report. */
+function readTrx(file: string): {
+  results: readonly TrxTestResult[];
+  runInfos: readonly TrxRunInfo[];
+} {
+  try {
+    return parseTrxReport(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return { results: [], runInfos: [] };
+  }
+}

--- a/src/editors/vscode/src/test/suite/dotnet-project-kit.ts
+++ b/src/editors/vscode/src/test/suite/dotnet-project-kit.ts
@@ -59,6 +59,91 @@ export const MSTEST_PACKAGES: readonly PackageRef[] = [
   { id: 'Microsoft.NET.Test.Sdk', version: '17.11.1' },
 ];
 
+/**
+ * The TRX report extension every Microsoft.Testing.Platform fixture references.
+ *
+ * `--report-trx` is NOT part of MTP: a module that does not register this
+ * extension rejects the option and exits with code 5 ([TEST-MTP-RUN]). MSTest
+ * carries it already, `xunit.v3` and NUnit do not. One version is pinned for
+ * every fixture, because a TrxReport built against a newer platform than the
+ * framework brought in fails at load with a `TypeLoadException`.
+ */
+export const MTP_TRX_REPORT: PackageRef = {
+  id: 'Microsoft.Testing.Extensions.TrxReport',
+  version: '2.4.0',
+};
+
+/**
+ * `xunit.v3` on Microsoft.Testing.Platform — the reported case (issue #249).
+ *
+ * From 4.0.0 the package supports MTP v2 ONLY. It carries no VSTest adapter at
+ * all, so `dotnet vstest` cannot load the module and the whole VSTest discovery
+ * path reports nothing for it.
+ */
+export const MTP_XUNIT_PACKAGES: readonly PackageRef[] = [
+  { id: 'xunit.v3', version: '4.0.0' },
+  MTP_TRX_REPORT,
+];
+
+/**
+ * MSTest on its own runner. Its listed DISPLAY name is the BARE method name, so
+ * this fixture is what proves an MTP id comes from the listing's `type` block
+ * and never from the display name ([TEST-MTP-DISCOVERY]).
+ */
+export const MTP_MSTEST_PACKAGES: readonly PackageRef[] = [{ id: 'MSTest', version: '4.4.0' }];
+
+/**
+ * NUnit on its own runner. Its uid is a DECORATED name carrying parentheses and
+ * commas — `Ns.Class.Adds_Case(2,2,4)` — which is what proves `--filter-uid`
+ * takes literal values and must never be escaped. It also reports no source
+ * location, which is what proves the location is optional.
+ */
+export const MTP_NUNIT_PACKAGES: readonly PackageRef[] = [
+  { id: 'NUnit', version: '4.4.0' },
+  { id: 'NUnit3TestAdapter', version: '6.3.0' },
+  MTP_TRX_REPORT,
+];
+
+/**
+ * The project properties that put a fixture on the MTP runner.
+ *
+ * `OutputType` is `Exe` because an MTP test project builds an EXECUTABLE test
+ * module — that module is what discovery and runs talk to. Each framework has
+ * its own switch, and setting a framework's switch on another framework does
+ * nothing, so one bag serves all three.
+ */
+export const MTP_PROPERTIES: Readonly<Record<string, string>> = {
+  OutputType: 'Exe',
+  UseMicrosoftTestingPlatformRunner: 'true',
+  EnableMSTestRunner: 'true',
+  EnableNUnitRunner: 'true',
+};
+
+/**
+ * Opt a fixture solution into the MTP mode of `dotnet test`.
+ *
+ * This is the switch a real user throws, and it is what [TEST-MTP-DETECT] reads
+ * first. The SDK version is pinned to whatever built the fixture, so the file
+ * never changes which SDK the agent resolves.
+ */
+export function writeMtpGlobalJson(root: string): string {
+  const file = path.join(root, 'global.json');
+  fs.writeFileSync(
+    file,
+    `${JSON.stringify({ test: { runner: 'Microsoft.Testing.Platform' } }, null, 2)}\n`,
+    'utf8',
+  );
+  return file;
+}
+
+/** Project XML for an MTP test project: the runner switches plus its packages. */
+export function mtpProjectXml(
+  packages: readonly PackageRef[],
+  ...compileIncludes: readonly string[]
+): string {
+  return buildProjectXml({ packages, compileIncludes, properties: MTP_PROPERTIES });
+}
+
 /** Every framework the Test Explorer claims to support, for table-driven suites. */
 export const TEST_FRAMEWORKS = {
   xunit: XUNIT_PACKAGES,

--- a/src/editors/vscode/src/test/suite/test-explorer-kit.ts
+++ b/src/editors/vscode/src/test/suite/test-explorer-kit.ts
@@ -173,6 +173,28 @@ export async function drainDiscovery(
   await controller.whenIdle();
 }
 
+/**
+ * Tear one fixture solution down: unload it, empty the tree, let reactive
+ * re-discovery settle, and only THEN delete the fixture from disk.
+ *
+ * The order is the whole point. Discovery is debounced, not cancelled, so a
+ * teardown that deletes first leaves a `dotnet test` pointed at a removed
+ * directory, where it hangs forever and poisons every later run in the same
+ * extension host. Every Test Explorer suite needs exactly this, so it lives
+ * here rather than being written out once per suite.
+ */
+export async function teardownFixtureSolution(
+  api: SharpLspExtensionApi,
+  root: string,
+  removeDir: (dir: string) => void,
+): Promise<void> {
+  await drainDiscovery(() => {
+    api.explorerProvider.clear();
+    api.testController.items.replace([]);
+  }, api.testController);
+  removeDir(root);
+}
+
 /** Load a solution and force one discovery sweep, then wait for `expected`. */
 export async function discoverSolution(
   api: SharpLspExtensionApi,

--- a/src/editors/vscode/src/test/suite/test-explorer-mtp-fixtures.ts
+++ b/src/editors/vscode/src/test/suite/test-explorer-mtp-fixtures.ts
@@ -1,0 +1,349 @@
+// The Microsoft.Testing.Platform projects the MTP Test Explorer suites build.
+//
+// Every framework appears twice — once in F# and once in C#, F# FIRST (project
+// rule) — because each one exercises a different part of [TEST-MTP-DISCOVERY]:
+//
+//   • `xunit.v3` 4.0.0 supports MTP v2 ONLY and carries no VSTest adapter, so
+//     `dotnet vstest` cannot load it at all. This is the reported case (#249).
+//   • MSTest reports the BARE method name as its DISPLAY name, so it is what
+//     proves the id comes from the listing's `type` block and never from the
+//     display name — the issue-#180 defect in its MTP shape.
+//   • NUnit's uid is a DECORATED name carrying parentheses and commas
+//     (`Ns.Class.Adds_Case(2,2,4)`), which proves `--filter-uid` takes literal
+//     values and must never be escaped; and NUnit reports NO source location,
+//     which proves the location is optional.
+//
+// The F# shapes matter on their own: a backtick binding produces an id carrying
+// SPACES, and an F# `[<TestClass>]` nested in a module produces a CLR
+// nested-type id carrying `+`.
+//
+// Each project holds a passing, a failing and a skipped test plus a data-driven
+// one, so outcome attribution is asserted per test rather than per run. Their
+// namespaces are their own, so their ids never collide with the VSTest fixtures
+// in the shared result cache.
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  createSolution,
+  mtpProjectXml,
+  writeMtpGlobalJson,
+  writeProject,
+  MTP_MSTEST_PACKAGES,
+  MTP_NUNIT_PACKAGES,
+  MTP_XUNIT_PACKAGES,
+  type PackageRef,
+} from './dotnet-project-kit';
+
+/** One buildable MTP fixture project plus the ids it is expected to expose. */
+export interface MtpFixture {
+  /** Stable key: `<framework>-<language>`. */
+  readonly key: string;
+  readonly framework: 'xunit' | 'mstest' | 'nunit';
+  readonly language: 'fsharp' | 'csharp';
+  readonly packages: readonly PackageRef[];
+  readonly projectName: string;
+  readonly projectFileName: string;
+  readonly sourceFileName: string;
+  readonly source: string;
+  /** Id of the test that passes. */
+  readonly passing: string;
+  /** Id of the test that fails. */
+  readonly failing: string;
+  /** Id of the test that is skipped or ignored. */
+  readonly skipped: string;
+  /** Id of the data-driven test whose rows all pass. */
+  readonly parameterized: string;
+  /**
+   * Id of a data-driven test whose rows DISAGREE — one passes, one fails. Both
+   * rows report under this one id, so the merged outcome must be a failure.
+   * Only the xUnit fixtures carry one.
+   */
+  readonly mixedParameterized?: string;
+  /**
+   * Whether the framework reports a source location for its tests. NUnit does
+   * not, and its rows must still appear in the tree.
+   */
+  readonly reportsLocation: boolean;
+  /**
+   * A distinctive fragment of the assertion text this framework writes for
+   * {@link failing}. Each one is different, and surfacing the framework's OWN
+   * text — rather than a generic "Test failed" — is what [TEST-RUN-TRX]
+   * requires of the report reader.
+   */
+  readonly failureText: string;
+}
+
+const FS_XUNIT_SOURCE = [
+  'module Fs.XunitMtp.Fixtures',
+  '',
+  'open Xunit',
+  '',
+  '[<Fact>]',
+  'let ``adds two numbers with spaces`` () = Assert.Equal(3, 1 + 2)',
+  '',
+  '[<Fact>]',
+  'let ``fails on purpose`` () = Assert.Equal(4, 1 + 2)',
+  '',
+  '[<Fact(Skip = "fixture: deliberately skipped")>]',
+  'let ``skipped on purpose`` () = ()',
+  '',
+  '[<Theory>]',
+  '[<InlineData(2, 2, 4)>]',
+  '[<InlineData(1, 1, 2)>]',
+  'let ``adds theory rows`` (a: int) (b: int) (expected: int) = Assert.Equal(expected, a + b)',
+  '',
+].join('\n');
+
+const CS_XUNIT_SOURCE = [
+  'using Xunit;',
+  '',
+  'namespace Cs.XunitMtp.Fixtures',
+  '{',
+  '    public class CalculatorTests',
+  '    {',
+  '        [Fact] public void Adds_TwoNumbers() => Assert.Equal(3, 1 + 2);',
+  '        [Fact] public void Fails_OnPurpose() => Assert.Equal(4, 1 + 2);',
+  '        [Fact(Skip = "fixture: deliberately skipped")] public void Skipped_OnPurpose() { }',
+  '        [Theory]',
+  '        [InlineData(2, 2, 4)]',
+  '        [InlineData(1, 1, 2)]',
+  '        public void Adds_Theory(int a, int b, int expected) => Assert.Equal(expected, a + b);',
+  '        [Theory]',
+  '        [InlineData(2, 2, 4)]',
+  '        [InlineData(1, 1, 99)]',
+  '        public void Mixed_Theory(int a, int b, int expected) => Assert.Equal(expected, a + b);',
+  '    }',
+  '}',
+  '',
+].join('\n');
+
+const FS_MSTEST_SOURCE = [
+  'module Fs.MstestMtp.Fixtures',
+  '',
+  'open Microsoft.VisualStudio.TestTools.UnitTesting',
+  '',
+  '[<TestClass>]',
+  'type CalculatorTests() =',
+  '    [<TestMethod>]',
+  '    member _.AddsTwoNumbers() = Assert.AreEqual(3, 1 + 2)',
+  '',
+  '    [<TestMethod>]',
+  '    member _.FailsOnPurpose() = Assert.AreEqual(4, 1 + 2)',
+  '',
+  '    [<TestMethod; Ignore>]',
+  '    member _.SkippedOnPurpose() = ()',
+  '',
+  '    [<TestMethod; DataRow(2, 2, 4)>]',
+  '    member _.AddsRow(a: int, b: int, expected: int) = Assert.AreEqual(expected, a + b)',
+  '',
+].join('\n');
+
+const CS_MSTEST_SOURCE = [
+  'using Microsoft.VisualStudio.TestTools.UnitTesting;',
+  '',
+  'namespace Cs.MstestMtp.Fixtures',
+  '{',
+  '    [TestClass]',
+  '    public class CalculatorTests',
+  '    {',
+  '        [TestMethod] public void Adds_TwoNumbers() => Assert.AreEqual(3, 1 + 2);',
+  '        [TestMethod] public void Fails_OnPurpose() => Assert.AreEqual(4, 1 + 2);',
+  '        [TestMethod, Ignore] public void Skipped_OnPurpose() { }',
+  '        [TestMethod]',
+  '        [DataRow(2, 2, 4)]',
+  '        public void Adds_Row(int a, int b, int expected) => Assert.AreEqual(expected, a + b);',
+  '    }',
+  '}',
+  '',
+].join('\n');
+
+const FS_NUNIT_SOURCE = [
+  'module Fs.NunitMtp.Fixtures',
+  '',
+  'open NUnit.Framework',
+  '',
+  '[<Test>]',
+  'let ``adds two numbers with spaces`` () = Assert.That(1 + 2, Is.EqualTo(3))',
+  '',
+  '[<Test>]',
+  'let ``fails on purpose`` () = Assert.That(1 + 2, Is.EqualTo(4))',
+  '',
+  '[<Test; Ignore("fixture: deliberately skipped")>]',
+  'let ``skipped on purpose`` () = ()',
+  '',
+  '[<TestCase(2, 2, 4)>]',
+  'let ``adds case`` (a: int) (b: int) (expected: int) = Assert.That(a + b, Is.EqualTo(expected))',
+  '',
+].join('\n');
+
+const CS_NUNIT_SOURCE = [
+  'using NUnit.Framework;',
+  '',
+  'namespace Cs.NunitMtp.Fixtures',
+  '{',
+  '    public class CalculatorTests',
+  '    {',
+  '        [Test] public void Adds_TwoNumbers() => Assert.That(1 + 2, Is.EqualTo(3));',
+  '        [Test] public void Fails_OnPurpose() => Assert.That(1 + 2, Is.EqualTo(4));',
+  '        [Test, Ignore("fixture: deliberately skipped")] public void Skipped_OnPurpose() { }',
+  '        [TestCase(2, 2, 4)]',
+  '        public void Adds_Case(int a, int b, int expected) =>',
+  '            Assert.That(a + b, Is.EqualTo(expected));',
+  '    }',
+  '}',
+  '',
+].join('\n');
+
+/**
+ * Every MTP fixture, F# FIRST within each framework.
+ *
+ * The ids are the ones the modules really report, read off a built fixture —
+ * the F# backtick names carrying SPACES, the F# MSTest nested-type `+`, and the
+ * data-driven ids carrying NO row data because the listing's `type` block
+ * carries none.
+ */
+export const MTP_FIXTURES: readonly MtpFixture[] = [
+  {
+    key: 'xunit-fsharp',
+    framework: 'xunit',
+    language: 'fsharp',
+    packages: MTP_XUNIT_PACKAGES,
+    projectName: 'XunitMtpFs',
+    projectFileName: 'XunitMtpFs.fsproj',
+    sourceFileName: 'Tests.fs',
+    source: FS_XUNIT_SOURCE,
+    passing: 'Fs.XunitMtp.Fixtures.adds two numbers with spaces',
+    failing: 'Fs.XunitMtp.Fixtures.fails on purpose',
+    skipped: 'Fs.XunitMtp.Fixtures.skipped on purpose',
+    parameterized: 'Fs.XunitMtp.Fixtures.adds theory rows',
+    reportsLocation: true,
+    failureText: 'Assert.Equal() Failure',
+  },
+  {
+    key: 'xunit-csharp',
+    framework: 'xunit',
+    language: 'csharp',
+    packages: MTP_XUNIT_PACKAGES,
+    projectName: 'XunitMtpCs',
+    projectFileName: 'XunitMtpCs.csproj',
+    sourceFileName: 'Tests.cs',
+    source: CS_XUNIT_SOURCE,
+    passing: 'Cs.XunitMtp.Fixtures.CalculatorTests.Adds_TwoNumbers',
+    failing: 'Cs.XunitMtp.Fixtures.CalculatorTests.Fails_OnPurpose',
+    skipped: 'Cs.XunitMtp.Fixtures.CalculatorTests.Skipped_OnPurpose',
+    parameterized: 'Cs.XunitMtp.Fixtures.CalculatorTests.Adds_Theory',
+    mixedParameterized: 'Cs.XunitMtp.Fixtures.CalculatorTests.Mixed_Theory',
+    reportsLocation: true,
+    failureText: 'Assert.Equal() Failure',
+  },
+  {
+    key: 'mstest-fsharp',
+    framework: 'mstest',
+    language: 'fsharp',
+    packages: MTP_MSTEST_PACKAGES,
+    projectName: 'MstestMtpFs',
+    projectFileName: 'MstestMtpFs.fsproj',
+    sourceFileName: 'Tests.fs',
+    source: FS_MSTEST_SOURCE,
+    passing: 'Fs.MstestMtp.Fixtures+CalculatorTests.AddsTwoNumbers',
+    failing: 'Fs.MstestMtp.Fixtures+CalculatorTests.FailsOnPurpose',
+    skipped: 'Fs.MstestMtp.Fixtures+CalculatorTests.SkippedOnPurpose',
+    parameterized: 'Fs.MstestMtp.Fixtures+CalculatorTests.AddsRow',
+    reportsLocation: true,
+    failureText: 'Assertion failed. Expected values to be equal.',
+  },
+  {
+    key: 'mstest-csharp',
+    framework: 'mstest',
+    language: 'csharp',
+    packages: MTP_MSTEST_PACKAGES,
+    projectName: 'MstestMtpCs',
+    projectFileName: 'MstestMtpCs.csproj',
+    sourceFileName: 'Tests.cs',
+    source: CS_MSTEST_SOURCE,
+    passing: 'Cs.MstestMtp.Fixtures.CalculatorTests.Adds_TwoNumbers',
+    failing: 'Cs.MstestMtp.Fixtures.CalculatorTests.Fails_OnPurpose',
+    skipped: 'Cs.MstestMtp.Fixtures.CalculatorTests.Skipped_OnPurpose',
+    parameterized: 'Cs.MstestMtp.Fixtures.CalculatorTests.Adds_Row',
+    reportsLocation: true,
+    failureText: 'Assertion failed. Expected values to be equal.',
+  },
+  {
+    key: 'nunit-fsharp',
+    framework: 'nunit',
+    language: 'fsharp',
+    packages: MTP_NUNIT_PACKAGES,
+    projectName: 'NunitMtpFs',
+    projectFileName: 'NunitMtpFs.fsproj',
+    sourceFileName: 'Tests.fs',
+    source: FS_NUNIT_SOURCE,
+    passing: 'Fs.NunitMtp.Fixtures.adds two numbers with spaces',
+    failing: 'Fs.NunitMtp.Fixtures.fails on purpose',
+    skipped: 'Fs.NunitMtp.Fixtures.skipped on purpose',
+    parameterized: 'Fs.NunitMtp.Fixtures.adds case',
+    reportsLocation: false,
+    failureText: 'Assert.That(',
+  },
+  {
+    key: 'nunit-csharp',
+    framework: 'nunit',
+    language: 'csharp',
+    packages: MTP_NUNIT_PACKAGES,
+    projectName: 'NunitMtpCs',
+    projectFileName: 'NunitMtpCs.csproj',
+    sourceFileName: 'Tests.cs',
+    source: CS_NUNIT_SOURCE,
+    passing: 'Cs.NunitMtp.Fixtures.CalculatorTests.Adds_TwoNumbers',
+    failing: 'Cs.NunitMtp.Fixtures.CalculatorTests.Fails_OnPurpose',
+    skipped: 'Cs.NunitMtp.Fixtures.CalculatorTests.Skipped_OnPurpose',
+    parameterized: 'Cs.NunitMtp.Fixtures.CalculatorTests.Adds_Case',
+    reportsLocation: false,
+    failureText: 'Assert.That(',
+  },
+];
+
+/** Every id one fixture must contribute to the tree. */
+export function idsOf(fixture: MtpFixture): readonly string[] {
+  const mixed = fixture.mixedParameterized === undefined ? [] : [fixture.mixedParameterized];
+  return [fixture.passing, fixture.failing, fixture.skipped, fixture.parameterized, ...mixed];
+}
+
+/** Every id the whole MTP fixture solution must expose. */
+export const ALL_MTP_IDS: readonly string[] = MTP_FIXTURES.flatMap(idsOf);
+
+/** Look a fixture up by key, failing loudly on a typo. */
+export function mtpFixtureFor(key: string): MtpFixture {
+  const fixture = MTP_FIXTURES.find((candidate) => candidate.key === key);
+  if (fixture === undefined) throw new Error(`no MTP fixture named '${key}'`);
+  return fixture;
+}
+
+/** Write one fixture project and return its directory. */
+export function writeMtpProject(root: string, fixture: MtpFixture): string {
+  const compile = fixture.language === 'fsharp' ? [fixture.sourceFileName] : [];
+  return writeProject(
+    path.join(root, fixture.projectName),
+    fixture.projectFileName,
+    mtpProjectXml(fixture.packages, ...compile),
+    fixture.sourceFileName,
+    fixture.source,
+  );
+}
+
+/**
+ * Write every MTP fixture plus the `global.json` opt-in, then produce a real
+ * solution the `dotnet` CLI itself authored.
+ *
+ * The opt-in is the switch a real user throws, and it is what [TEST-MTP-DETECT]
+ * reads first — without it the VSTest passes run and waste a build before the
+ * MSBuild probe rescues the sweep.
+ */
+export async function createMtpSolution(
+  root: string,
+  fixtures: readonly MtpFixture[] = MTP_FIXTURES,
+): Promise<string> {
+  fs.mkdirSync(root, { recursive: true });
+  writeMtpGlobalJson(root);
+  const dirs = fixtures.map((fixture) => writeMtpProject(root, fixture));
+  return await createSolution(root, 'MtpFixtures', dirs);
+}

--- a/src/editors/vscode/src/test/suite/test-explorer-mtp-outcomes.test.ts
+++ b/src/editors/vscode/src/test/suite/test-explorer-mtp-outcomes.test.ts
@@ -1,0 +1,320 @@
+// Running Microsoft.Testing.Platform tests, end to end, inside the real
+// extension host against six REAL projects the `dotnet` CLI built.
+//
+// Discovery is only half of issue #249: an MTP project also could not be RUN.
+// `--filter FullyQualifiedName=` and `--logger trx` do not exist in MTP mode,
+// so the whole outcome pipeline had nothing to read. The MTP path selects with
+// `--filter-uid` and reports with `--report-trx`, and everything after the TRX
+// file is shared with the VSTest path — which is exactly what these assertions
+// prove: the same outcome mapping, the same worst-row merge, the same skip that
+// is never a failure, and the same assertion text.
+//
+// F# comes FIRST throughout (project rule).
+//
+// Covers [TEST-MTP-RUN], and [TEST-RUN-TRX] through the shared reader.
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import type { SharpLspExtensionApi } from '../../extension.js';
+import { runMtpTests } from '../../test-mtp-run.js';
+import { listMtpTests } from '../../test-mtp-discovery.js';
+import {
+  createSolution,
+  mtpProjectXml,
+  writeMtpGlobalJson,
+  writeProject,
+} from './dotnet-project-kit';
+import {
+  ALL_MTP_IDS,
+  createMtpSolution,
+  MTP_FIXTURES,
+  mtpFixtureFor,
+} from './test-explorer-mtp-fixtures';
+import {
+  activateTestExplorer,
+  discoverSolution,
+  runAlreadyCancelled,
+  runViaProfile,
+  teardownFixtureSolution,
+} from './test-explorer-kit';
+import {
+  assertFailed,
+  assertPassed,
+  assertSkipped,
+  cachedFor,
+  itemsFor,
+  sorted,
+} from './test-explorer-outcome-assertions';
+import { removeDirRecursive } from './test-helpers';
+import { DOTNET_CLI_MS, FIXTURE_BUILD_MS } from './test-timeouts';
+
+/** Every id that must come back green. */
+const PASSING: readonly string[] = MTP_FIXTURES.flatMap((fixture) => [
+  fixture.passing,
+  fixture.parameterized,
+]);
+/** Every id that must come back red — the mixed theories included. */
+const FAILING: readonly string[] = MTP_FIXTURES.flatMap((fixture) => [
+  fixture.failing,
+  ...(fixture.mixedParameterized === undefined ? [] : [fixture.mixedParameterized]),
+]);
+/** Every id that must come back skipped, and NEVER as a failure. */
+const SKIPPED: readonly string[] = MTP_FIXTURES.map((fixture) => fixture.skipped);
+
+/** An MTP project WITHOUT the TRX report extension — `--report-trx` fails on it. */
+const NO_TRX_SOURCE = [
+  'using Xunit;',
+  '',
+  'namespace Cs.NoTrxMtp.Fixtures',
+  '{',
+  '    public class CalculatorTests',
+  '    {',
+  '        [Fact] public void Adds_TwoNumbers() => Assert.Equal(3, 1 + 2);',
+  '    }',
+  '}',
+  '',
+].join('\n');
+
+suite('Test Explorer e2e — Microsoft.Testing.Platform runs', () => {
+  let api: SharpLspExtensionApi;
+  let root: string;
+  let slnPath: string;
+
+  suiteSetup(async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    api = await activateTestExplorer();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'sharplsp-mtp-run-'));
+    slnPath = await createMtpSolution(root);
+    await discoverSolution(api, slnPath, ALL_MTP_IDS);
+  });
+
+  teardown(async () => {
+    await api.testController.whenIdle();
+  });
+
+  suiteTeardown(async function () {
+    this.timeout(DOTNET_CLI_MS);
+    await teardownFixtureSolution(api, root, removeDirRecursive);
+  });
+
+  test('▶ on the whole tree attributes a pass, a fail and a skip to each test', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    const items = itemsFor(api, [...PASSING, ...FAILING, ...SKIPPED]);
+
+    // 1. Press ▶ on the whole selection, in ONE run.
+    await runViaProfile(api.testController, vscode.TestRunProfileKind.Run, items);
+    await api.testController.whenIdle();
+
+    // 2. Every pass and every skip is attributed on its own terms, six
+    //    projects at once. A skip is NEVER a failure.
+    for (const id of PASSING) assertPassed(cachedFor(api, id), id);
+    for (const id of SKIPPED) assertSkipped(cachedFor(api, id), id);
+
+    // 3. Every failure carries the text ITS OWN framework wrote — xUnit's
+    //    `Assert.Equal() Failure`, MSTest's `Assertion failed. …`, NUnit's
+    //    `Assert.That(…)` — never a generic "Test failed".
+    for (const fixture of MTP_FIXTURES) {
+      assertFailed(cachedFor(api, fixture.failing), fixture.failing, fixture.failureText);
+      if (fixture.mixedParameterized === undefined) continue;
+      assertFailed(
+        cachedFor(api, fixture.mixedParameterized),
+        fixture.mixedParameterized,
+        fixture.failureText,
+      );
+    }
+  });
+
+  test('a data-driven test whose rows DISAGREE is judged by its worst row', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    const csharp = mtpFixtureFor('xunit-csharp');
+    const mixed = csharp.mixedParameterized;
+    assert.ok(mixed, 'the C# xUnit fixture carries the disagreeing theory');
+    const [item] = itemsFor(api, [mixed]);
+    assert.ok(item, 'the theory must be one row in the tree');
+
+    // 1. Both rows run under the one id, because the id owns both uids.
+    await runViaProfile(api.testController, vscode.TestRunProfileKind.Run, [item]);
+    await api.testController.whenIdle();
+
+    // 2. One row passes and one fails, and the merged outcome is the failure.
+    const result = cachedFor(api, mixed);
+    assert.equal(result.outcome, 'failed', 'a green theory whose second row failed is a lie');
+    assert.equal(result.passed, false);
+    assert.ok(result.message, "and it carries the failing row's assertion text");
+
+    // 3. The all-passing theory of the same class stays green.
+    const [allGreen] = itemsFor(api, [csharp.parameterized]);
+    assert.ok(allGreen);
+    await runViaProfile(api.testController, vscode.TestRunProfileKind.Run, [allGreen]);
+    await api.testController.whenIdle();
+    assert.equal(cachedFor(api, csharp.parameterized).outcome, 'passed');
+  });
+
+  test('▶ on one test runs that test and no other, across every module', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    const fsharp = mtpFixtureFor('xunit-fsharp');
+
+    // 1. Run ONE F# backtick test whose id carries spaces.
+    const [only] = itemsFor(api, [fsharp.passing]);
+    assert.ok(only);
+    await runViaProfile(api.testController, vscode.TestRunProfileKind.Run, [only]);
+    await api.testController.whenIdle();
+
+    const result = cachedFor(api, fsharp.passing);
+    assert.equal(result.outcome, 'passed', 'a uid carrying spaces in its display name still runs');
+    assert.equal(result.passed, true);
+    assert.equal(typeof result.duration, 'number');
+
+    // 2. A module the selection does not touch must not be started, so the run
+    //    is a single invocation rather than six.
+    const listing = await listMtpTests(slnPath, root);
+    assert.ok(listing.mtp);
+    const outcome = await runMtpTests(listing.mtp, [fsharp.passing], root);
+    assert.deepStrictEqual(
+      sorted([...outcome.results.keys()]),
+      [fsharp.passing],
+      'exactly the selected test reported a result',
+    );
+    assert.equal(outcome.failure, undefined, 'a good run reports no process-level failure');
+  });
+
+  test('a class row runs its members, and an NUnit uid is never escaped', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    const nunit = mtpFixtureFor('nunit-csharp');
+    const [parameterized] = itemsFor(api, [nunit.parameterized]);
+    assert.ok(parameterized?.parent, 'the NUnit case sits under its class row');
+
+    // 1. Press ▶ on the CLASS row, which expands to its members.
+    await runViaProfile(api.testController, vscode.TestRunProfileKind.Run, [parameterized.parent]);
+    await api.testController.whenIdle();
+
+    // 2. Its uid is `Ns.Class.Adds_Case(2,2,4)` — parentheses and commas, passed
+    //    literally. Escaping them the way a VSTest filter needs would match
+    //    nothing and report "No result reported" instead.
+    const cased = cachedFor(api, nunit.parameterized);
+    assert.equal(cased.outcome, 'passed', 'a decorated uid must match its own test');
+    assert.equal(cachedFor(api, nunit.passing).outcome, 'passed');
+    assert.equal(cachedFor(api, nunit.failing).outcome, 'failed');
+    assert.equal(cachedFor(api, nunit.skipped).outcome, 'skipped', 'a skip is never a failure');
+  });
+
+  test('⏹ stops the run, and an already-cancelled token starts nothing', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    const items = itemsFor(api, [...PASSING]);
+    const before = api.testController.items.size;
+
+    // 1. Press ⏹ shortly after ▶: the run resolves rather than rejecting.
+    await runViaProfile(api.testController, vscode.TestRunProfileKind.Run, items, 200);
+    await api.testController.whenIdle();
+    assert.equal(api.testController.items.size, before, 'the tree stands after a cancelled run');
+
+    // 2. A token already cancelled when the handler is entered starts nothing.
+    await runAlreadyCancelled(api.testController, vscode.TestRunProfileKind.Run, items);
+    await api.testController.whenIdle();
+    assert.equal(api.testController.items.size, before, 'and still stands');
+
+    // 3. The queue drained, so the next run is not poisoned.
+    const [one] = itemsFor(api, [mtpFixtureFor('xunit-fsharp').passing]);
+    assert.ok(one);
+    await runViaProfile(api.testController, vscode.TestRunProfileKind.Run, [one]);
+    await api.testController.whenIdle();
+    assert.equal(cachedFor(api, mtpFixtureFor('xunit-fsharp').passing).outcome, 'passed');
+  });
+
+  test('an F# [<TestCase>] NUnit selection recovers from the adapter refusing it', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    // NUnit's bridge translates `--filter-uid` back into a VSTest filter
+    // EXPRESSION and then rejects its own translation for any uid carrying a
+    // SPACE — which is every idiomatic F# backtick binding. Without the
+    // unfiltered retry the whole module reports nothing and four perfectly
+    // runnable tests show as phantom failures.
+    const fsharp = mtpFixtureFor('nunit-fsharp');
+    const listing = await listMtpTests(slnPath, root);
+    assert.ok(listing.mtp);
+    const module = listing.mtp.modules.find((candidate) =>
+      candidate.modulePath.includes(fsharp.projectName),
+    );
+    assert.ok(module, `the ${fsharp.projectName} module must be in the run plan`);
+    assert.deepStrictEqual(
+      module.uidsById.get(fsharp.parameterized),
+      ['Fs.NunitMtp.Fixtures.adds case(2,2,4)'],
+      'the uid really does carry a space AND parentheses',
+    );
+
+    // 1. Running the refused selection still reports every test.
+    const ids = [...module.uidsById.keys()];
+    const outcome = await runMtpTests({ modules: [module] }, ids, root);
+    assert.equal(outcome.retriedUnfiltered, true, 'the refusal must trigger ONE unfiltered retry');
+    assert.deepStrictEqual(
+      sorted([...outcome.results.keys()]),
+      sorted(ids),
+      'every selected test reports an outcome after the retry',
+    );
+    assert.equal(outcome.failure, undefined, 'a recovered run reports no process-level failure');
+
+    // 2. The recovered outcomes are the real ones, not a blanket verdict.
+    assert.equal(outcome.results.get(fsharp.passing)?.outcome, 'passed');
+    assert.equal(outcome.results.get(fsharp.failing)?.outcome, 'failed');
+    assert.equal(outcome.results.get(fsharp.skipped)?.outcome, 'skipped');
+    assert.equal(outcome.results.get(fsharp.parameterized)?.outcome, 'passed');
+
+    // 3. The SAME framework in C# has no space in its uids, so it is accepted
+    //    and never retried — the recovery is the adapter's say-so, not a habit.
+    const csharp = mtpFixtureFor('nunit-csharp');
+    const csModule = listing.mtp.modules.find((candidate) =>
+      candidate.modulePath.includes(csharp.projectName),
+    );
+    assert.ok(csModule);
+    const plain = await runMtpTests({ modules: [csModule] }, [csharp.passing], root);
+    assert.equal(plain.retriedUnfiltered, false, 'an accepted selection needs no recovery');
+    assert.deepStrictEqual(
+      [...plain.results.keys()],
+      [csharp.passing],
+      'and only the selected test ran',
+    );
+  });
+
+  test('a module without the TRX extension says which package to reference', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    // `--report-trx` is an EXTENSION, not part of MTP. A module that does not
+    // register it exits with code 5. Reporting that as itself is the whole
+    // point: silence would report every selected test as "No result reported"
+    // and hide the cause.
+    const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'sharplsp-mtp-notrx-'));
+    try {
+      writeMtpGlobalJson(bare);
+      const dir = writeProject(
+        path.join(bare, 'NoTrxMtpCs'),
+        'NoTrxMtpCs.csproj',
+        mtpProjectXml([{ id: 'xunit.v3', version: '4.0.0' }]),
+        'Tests.cs',
+        NO_TRX_SOURCE,
+      );
+      const sln = await createSolution(bare, 'NoTrx', [dir]);
+
+      // 1. Discovery still works: `--list-tests json` needs no extension.
+      const listing = await listMtpTests(sln, bare);
+      assert.deepStrictEqual(
+        [...listing.names],
+        ['Cs.NoTrxMtp.Fixtures.CalculatorTests.Adds_TwoNumbers'],
+        `the test must be discovered; warnings: ${listing.warnings.join(' | ') || '(none)'}`,
+      );
+      assert.ok(listing.mtp, 'and a run plan must come back with it');
+
+      // 2. The RUN cannot report per-test outcomes, and says exactly why.
+      const outcome = await runMtpTests(listing.mtp, [...listing.names], bare);
+      assert.equal(outcome.results.size, 0, 'no TRX means no per-test result');
+      assert.ok(outcome.failure, 'and the run must not fail silently');
+      assert.match(
+        outcome.failure,
+        /Microsoft\.Testing\.Extensions\.TrxReport/,
+        `the message must name the missing package, got: ${outcome.failure}`,
+      );
+      assert.match(outcome.failure, /--report-trx/, 'and the option that was refused');
+    } finally {
+      removeDirRecursive(bare);
+    }
+  });
+});

--- a/src/editors/vscode/src/test/suite/test-explorer-mtp-parsers.test.ts
+++ b/src/editors/vscode/src/test/suite/test-explorer-mtp-parsers.test.ts
@@ -1,0 +1,398 @@
+// The pure readers the Microsoft.Testing.Platform path depends on, exercised
+// against the shapes real modules produce.
+//
+// These readers decide whether an MTP project appears in the Testing view at
+// all, and whether anything in it can be run:
+//
+//   • `mtpRunnerSelected` reads the `global.json` opt-in. It must PARSE, never
+//     search: the string "Microsoft.Testing.Platform" also appears in package
+//     names and in unrelated properties, and a search would put a VSTest
+//     solution on a path that cannot run it.
+//   • `parseMtpTestList` turns a module's `--list-tests json` answer into ids.
+//     The id comes from the listing's `type` block and NEVER from its display
+//     name, because MSTest renders the display name as the BARE method name —
+//     the issue-#180 defect in its MTP shape.
+//   • `mtpUidsById` collapses the rows of a data-driven test onto the one id
+//     they share while keeping every row's uid, so running that id runs them
+//     all.
+//   • `rejectedMtpOption` names the option a module refused, which is what
+//     tells the user to reference `Microsoft.Testing.Extensions.TrxReport`
+//     instead of reporting every test as "No result reported".
+//   • `uidBatches` keeps one invocation under the Windows command-line ceiling.
+//
+// Covers [TEST-MTP-DETECT], [TEST-MTP-DISCOVERY] and [TEST-MTP-RUN].
+import * as assert from 'node:assert/strict';
+import {
+  mtpIds,
+  mtpLocationsById,
+  mtpRunnerSelected,
+  mtpUidsById,
+  parseMtpTestList,
+  rejectedMtpOption,
+} from '../../test-mtp.js';
+import { parseSolutionProjects } from '../../test-mtp-modules.js';
+import { runArgs, trxNameFor, uidBatches, uidsFor } from '../../test-mtp-run.js';
+import { announcedTestHostPid, TestHostWatcher } from '../../test-host-announce.js';
+import { parseMtpSummary } from '../../test-run-output.js';
+
+/** One node of a real `xunit.v3` listing, verbatim but for the shortened uid. */
+const XUNIT_NODE = {
+  uid: '9e472c8a9cdfb972d394daf60a3393384c4a50fdde9096e397d24d3e7521538d',
+  displayName: 'Cs.XunitMtp.Fixtures.CalculatorTests.Adds_TwoNumbers',
+  type: {
+    assemblyFullName: 'XunitMtpCs, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null',
+    namespace: 'Cs.XunitMtp.Fixtures',
+    typeName: 'CalculatorTests',
+    methodName: 'Adds_TwoNumbers',
+  },
+  location: { file: '/repo/XunitMtpCs/Tests.cs', lineStart: 7, lineEnd: 7 },
+};
+
+/** MSTest reports the BARE method name as its display name. */
+const MSTEST_NODE = {
+  uid: '1bc6cc0f-b32c-8a85-9f76-bfe4ce0054a9',
+  displayName: 'Adds_Row (2,2,4)',
+  type: {
+    namespace: 'Cs.MstestMtp.Fixtures',
+    typeName: 'CalculatorTests',
+    methodName: 'Adds_Row',
+  },
+  location: { file: '/repo/MstestMtpCs/Tests.cs', lineStart: 12, lineEnd: 12 },
+};
+
+/** NUnit's uid is a DECORATED name, and it reports NO location. */
+const NUNIT_NODE = {
+  uid: 'Cs.NunitMtp.Fixtures.CalculatorTests.Adds_Case(2,2,4)',
+  displayName: 'Adds_Case(2,2,4)',
+  type: {
+    namespace: 'Cs.NunitMtp.Fixtures',
+    typeName: 'CalculatorTests',
+    methodName: 'Adds_Case',
+  },
+};
+
+/** A second row of the same xUnit theory — its own uid, the same `type`. */
+const THEORY_ROW_ONE = {
+  uid: '7e2c244d8fa669534e414cf9d0084978d32f4128ece29c5934516b47036f5de8',
+  displayName: 'Cs.XunitMtp.Fixtures.CalculatorTests.Mixed_Theory(a: 2, b: 2, expected: 4)',
+  type: {
+    namespace: 'Cs.XunitMtp.Fixtures',
+    typeName: 'CalculatorTests',
+    methodName: 'Mixed_Theory',
+  },
+};
+const THEORY_ROW_TWO = {
+  ...THEORY_ROW_ONE,
+  uid: '1d5d1e9898ba0e8a1b4b2a6b0b6f8c2d1e0a9f8b7c6d5e4f3a2b1c0d9e8f7a6b',
+  displayName: 'Cs.XunitMtp.Fixtures.CalculatorTests.Mixed_Theory(a: 1, b: 1, expected: 99)',
+};
+
+/** A listing document, in the shape a module writes it. */
+function listing(...tests: readonly unknown[]): string {
+  return JSON.stringify({ schemaVersion: 1, tests });
+}
+
+suite('Test Explorer MTP — the readers that decide what is discovered and run', () => {
+  test('the global.json opt-in is PARSED, and nothing that merely mentions MTP counts', function () {
+    const optIn = JSON.stringify({
+      sdk: { version: '10.0.303' },
+      test: { runner: 'Microsoft.Testing.Platform' },
+    });
+    assert.equal(mtpRunnerSelected(optIn), true, 'the documented opt-in must select MTP');
+    assert.equal(
+      mtpRunnerSelected(JSON.stringify({ test: { runner: 'microsoft.testing.platform' } })),
+      true,
+      'the runner name is compared without letter case',
+    );
+    assert.equal(
+      mtpRunnerSelected(JSON.stringify({ test: { runner: 'VSTest' } })),
+      false,
+      'the explicit VSTest runner must NOT select MTP',
+    );
+
+    // A file that merely CONTAINS the words, in every place a real repository
+    // puts them. A string search would switch each of these onto a path that
+    // cannot run them.
+    const decoys = [
+      JSON.stringify({ msbuild: { 'Microsoft.Testing.Platform': '2.4.0' } }),
+      JSON.stringify({ test: { runner: 'Microsoft.Testing.Platform.Extra' } }),
+      JSON.stringify({ tools: { test: 'Microsoft.Testing.Platform' } }),
+      '{ "test": { "runner": "Microsoft.Testing.Platform" ',
+    ];
+    for (const decoy of decoys) {
+      assert.equal(mtpRunnerSelected(decoy), false, `must not select MTP for: ${decoy}`);
+    }
+    assert.equal(mtpRunnerSelected(''), false, 'an empty file selects nothing and never throws');
+  });
+
+  test('an id comes from the type block, so a bare MSTest display name is never one', function () {
+    const parsed = parseMtpTestList(listing(XUNIT_NODE, MSTEST_NODE, NUNIT_NODE));
+
+    assert.deepStrictEqual(parsed.warnings, [], 'a known schema produces no warning');
+    assert.deepStrictEqual(
+      mtpIds(parsed.tests),
+      [
+        'Cs.XunitMtp.Fixtures.CalculatorTests.Adds_TwoNumbers',
+        'Cs.MstestMtp.Fixtures.CalculatorTests.Adds_Row',
+        'Cs.NunitMtp.Fixtures.CalculatorTests.Adds_Case',
+      ],
+      'every id is namespace + type + method, with NO row data',
+    );
+    assert.equal(
+      parsed.tests[1]?.label,
+      'Adds_Row (2,2,4)',
+      'the display name survives as the LABEL, which is not a key',
+    );
+    assert.equal(
+      parsed.tests[2]?.uid,
+      'Cs.NunitMtp.Fixtures.CalculatorTests.Adds_Case(2,2,4)',
+      'an NUnit uid keeps its parentheses and commas verbatim',
+    );
+
+    // The location is optional, and its absence is not an error.
+    const locations = mtpLocationsById(parsed.tests);
+    assert.equal(locations.get('Cs.XunitMtp.Fixtures.CalculatorTests.Adds_TwoNumbers')?.line, 7);
+    assert.equal(
+      locations.get('Cs.XunitMtp.Fixtures.CalculatorTests.Adds_TwoNumbers')?.file,
+      '/repo/XunitMtpCs/Tests.cs',
+    );
+    assert.equal(
+      locations.has('Cs.NunitMtp.Fixtures.CalculatorTests.Adds_Case'),
+      false,
+      'NUnit reports no location, and the reader must not invent one',
+    );
+  });
+
+  test('the rows of a data-driven test collapse onto one id that owns every uid', function () {
+    const parsed = parseMtpTestList(listing(THEORY_ROW_ONE, THEORY_ROW_TWO, XUNIT_NODE));
+    const id = 'Cs.XunitMtp.Fixtures.CalculatorTests.Mixed_Theory';
+
+    assert.equal(mtpIds(parsed.tests).length, 2, 'two rows and one fact make two ids');
+    const uids = mtpUidsById(parsed.tests);
+    assert.deepStrictEqual(
+      uids.get(id),
+      [THEORY_ROW_ONE.uid, THEORY_ROW_TWO.uid],
+      'both rows must run when the one id is selected',
+    );
+
+    // And that is exactly what the run turns into a filter.
+    const module = { modulePath: '/repo/bin/XunitMtpCs.dll', uidsById: uids };
+    assert.deepStrictEqual(uidsFor(module, [id]), [THEORY_ROW_ONE.uid, THEORY_ROW_TWO.uid]);
+    assert.deepStrictEqual(uidsFor(module, []), [], 'an empty selection means "run everything"');
+    assert.deepStrictEqual(uidsFor(module, ['Not.A.Test']), [], 'an unknown id contributes none');
+  });
+
+  test('a hostile listing degrades with a warning and never throws', function () {
+    const bom = `\uFEFF\n  ${listing(XUNIT_NODE)}`;
+    assert.equal(
+      parseMtpTestList(bom).tests.length,
+      1,
+      'a byte-order mark and a leading blank line must not hide the document',
+    );
+
+    const future = JSON.stringify({ schemaVersion: 99, tests: [XUNIT_NODE] });
+    const parsedFuture = parseMtpTestList(future);
+    assert.equal(parsedFuture.tests.length, 1, 'an unknown schema still yields what it can');
+    assert.equal(parsedFuture.warnings.length, 1, 'and says so exactly once');
+    assert.match(parsedFuture.warnings[0] ?? '', /schemaVersion 99/);
+
+    assert.deepStrictEqual(parseMtpTestList(listing()).tests, [], 'an empty listing is empty');
+    assert.deepStrictEqual(
+      parseMtpTestList('Unhandled exception. System.TypeLoadException').tests,
+      [],
+      'a crashed module produces no test',
+    );
+    assert.equal(parseMtpTestList('not json at all').warnings.length, 1);
+    assert.equal(
+      parseMtpTestList(JSON.stringify({ schemaVersion: 1 })).warnings[0],
+      'Test listing carried no "tests" array',
+    );
+
+    // A node with no `type` falls back to the display name rather than vanishing.
+    const untyped = parseMtpTestList(listing({ uid: 'u1', displayName: 'Ns.Type.Method' }));
+    assert.deepStrictEqual(mtpIds(untyped.tests), ['Ns.Type.Method']);
+    assert.deepStrictEqual(
+      parseMtpTestList(listing({ displayName: 'no uid' })).tests,
+      [],
+      'a node with no uid could never be run, so it is dropped',
+    );
+  });
+
+  test('a rejected option is named, so the missing package can be told to the user', function () {
+    const output = [
+      "Unknown option '--report-trx'",
+      'Command line: --report-trx --results-directory /tmp',
+      'Usage dotnet exec XunitMtpCs.dll [option providers]',
+    ].join('\n');
+
+    assert.equal(rejectedMtpOption(output), '--report-trx');
+    assert.equal(rejectedMtpOption("Unknown option '--coverage'"), '--coverage');
+    assert.equal(rejectedMtpOption('Test run summary: Passed!'), undefined);
+    assert.equal(rejectedMtpOption(''), undefined);
+  });
+
+  test('a run is one command line per module, under the Windows ceiling', function () {
+    const args = runArgs(
+      '/repo/bin/XunitMtpCs.dll',
+      ['uid-one', 'uid-two'],
+      '/tmp/results',
+      {},
+      'XunitMtpCs.0.trx',
+    );
+
+    assert.deepStrictEqual(args, [
+      'exec',
+      '/repo/bin/XunitMtpCs.dll',
+      '--filter-uid',
+      'uid-one',
+      'uid-two',
+      '--report-trx',
+      '--report-trx-filename',
+      'XunitMtpCs.0.trx',
+      '--results-directory',
+      '/tmp/results',
+      '--no-banner',
+      '--no-ansi',
+    ]);
+    assert.equal(
+      args.includes('--no-progress'),
+      false,
+      '--no-progress is deprecated since MTP 2.3 and warns on every run',
+    );
+    assert.equal(
+      runArgs('/m.dll', [], '/tmp', {}, 'm.trx').includes('--filter-uid'),
+      false,
+      'an empty selection sends no filter at all',
+    );
+    assert.deepStrictEqual(
+      runArgs('/m.dll', [], '/tmp', { coverage: true }, 'm.trx').slice(-3),
+      ['--coverage', '--coverage-output-format', 'cobertura'],
+      'MTP has no --collect:"XPlat Code Coverage"; it collects Cobertura this way',
+    );
+
+    // Two modules must not write one file name into a shared directory.
+    assert.equal(trxNameFor('/repo/bin/XunitMtpCs.dll', 0), 'XunitMtpCs.0.trx');
+    assert.notEqual(
+      trxNameFor('/repo/bin/XunitMtpCs.dll', 0),
+      trxNameFor('/repo/bin/MstestMtpCs.dll', 0),
+    );
+    assert.notEqual(
+      trxNameFor('/repo/bin/XunitMtpCs.dll', 0),
+      trxNameFor('/repo/bin/XunitMtpCs.dll', 1),
+      'a second batch of one module must not overwrite the first',
+    );
+  });
+
+  test('uids are batched, never dropped and never split', function () {
+    const uids = Array.from(
+      { length: 400 },
+      (_, index) => `uid-${String(index).padStart(64, '0')}`,
+    );
+    const batches = uidBatches(uids, 1_000);
+
+    assert.ok(batches.length > 1, 'a large selection must be split');
+    assert.deepStrictEqual(batches.flat(), uids, 'every uid survives, in order');
+    for (const batch of batches) {
+      const width = batch.reduce((sum, uid) => sum + uid.length + 3, 0);
+      assert.ok(width <= 1_000 || batch.length === 1, 'only a lone over-long uid may exceed');
+    }
+    assert.deepStrictEqual(uidBatches([], 1_000), [], 'nothing selected is nothing to run');
+    assert.deepStrictEqual(
+      uidBatches(['x'.repeat(5_000)], 1_000),
+      [['x'.repeat(5_000)]],
+      'one over-budget uid gets its own batch rather than being dropped',
+    );
+  });
+
+  test('the MTP summary block is read, and a skip is never called a failure', function () {
+    const output = [
+      'Test run summary: Failed! - /repo/bin/XunitMtpCs.dll (net10.0|x64)',
+      '  total: 5',
+      '  failed: 1',
+      '  succeeded: 3',
+      '  skipped: 1',
+      '  duration: 425ms',
+      'Test run summary: Passed! - /repo/bin/MstestMtpCs.dll (net10.0|x64)',
+      '  total: 4',
+      '  failed: 0',
+      '  succeeded: 4',
+      '  skipped: 0',
+    ].join('\n');
+
+    const summary = parseMtpSummary(output);
+    assert.ok(summary, 'two modules print two blocks, and both are read');
+    assert.equal(summary.total, 9, 'the counts of every module are summed');
+    assert.equal(summary.failed, 1);
+    assert.equal(summary.passed, 7);
+    assert.equal(summary.skipped, 1);
+    assert.equal(summary.outcome, 'failed');
+
+    const allSkipped = parseMtpSummary(
+      [
+        'Test run summary: Zero tests ran',
+        '  total: 1',
+        '  failed: 0',
+        '  succeeded: 0',
+        '  skipped: 1',
+      ].join('\n'),
+    );
+    assert.equal(allSkipped?.outcome, 'skipped', 'a skipped run is NOT a failure');
+    assert.equal(parseMtpSummary('nothing here'), undefined, 'no block means no summary');
+  });
+
+  test('a waiting host is found whether it announces itself bare or behind a prefix', function () {
+    // VSTest's `testhost.dll` prints the line on its own. A Microsoft.Testing
+    // .Platform module IS the test host and prints the SAME text behind a
+    // prefix. Anchored to the start of the line, every MTP debug run hung on a
+    // module nothing ever attached to.
+    assert.equal(announcedTestHostPid('Process Id: 4242, Name: testhost'), 4242);
+    assert.equal(
+      announcedTestHostPid('Waiting for debugger to attach... Process Id: 212243, Name: dotnet'),
+      212243,
+      'the MTP announcement carries a prefix, and its pid must still be found',
+    );
+    assert.equal(announcedTestHostPid('  Process Id: 7, Name: x  '), 7, 'indentation is trimmed');
+
+    // Nothing that is not a real pid may aim the debugger.
+    for (const line of [
+      'Process Id: , Name: x',
+      'Process Id: 12ab, Name: x',
+      'Process Id: 0, Name: x',
+      'Process Id: -3, Name: x',
+      'no announcement here',
+      '',
+    ]) {
+      assert.equal(announcedTestHostPid(line), undefined, `must not read a pid from: '${line}'`);
+    }
+
+    // The watcher reassembles split chunks and reports each host exactly once.
+    const seen: number[] = [];
+    const watcher = new TestHostWatcher((pid) => seen.push(pid));
+    watcher.absorb('Waiting for debugger to attach... Proce');
+    watcher.absorb('ss Id: 900, Name: dotnet\nProcess Id: 900, Name: dotnet\n');
+    watcher.absorb('Process Id: 901, Name: testhost\n');
+    assert.deepStrictEqual(seen, [900, 901], 'one report per host, across chunk boundaries');
+  });
+
+  test('the solution project list is classified line by line, not sliced past a header', function () {
+    const output = [
+      'Project(s)',
+      '----------',
+      'XunitMtpFs/XunitMtpFs.fsproj',
+      'XunitMtpCs/XunitMtpCs.csproj',
+      '',
+    ].join('\n');
+    const projects = parseSolutionProjects(output, '/repo');
+
+    assert.deepStrictEqual(projects, [
+      '/repo/XunitMtpFs/XunitMtpFs.fsproj',
+      '/repo/XunitMtpCs/XunitMtpCs.csproj',
+    ]);
+    assert.deepStrictEqual(
+      parseSolutionProjects(['Projekt(e)', '------', 'A/A.csproj'].join('\n'), '/repo'),
+      ['/repo/A/A.csproj'],
+      'a localized header must not become a project path',
+    );
+    assert.deepStrictEqual(parseSolutionProjects('', '/repo'), []);
+  });
+});

--- a/src/editors/vscode/src/test/suite/test-explorer-mtp.test.ts
+++ b/src/editors/vscode/src/test/suite/test-explorer-mtp.test.ts
@@ -1,0 +1,305 @@
+// Microsoft.Testing.Platform discovery, end to end, inside the real extension
+// host against six REAL projects the `dotnet` CLI built.
+//
+// Regression suite for issue #249. The Test Explorer was VSTest end to end, and
+// every one of its commands fails against an MTP project: `--nologo` is not a
+// valid MTP option, `dotnet vstest` cannot load the module, and neither
+// `--filter` nor `--logger trx` exists. On the .NET 10 SDK, MTP v2 removed the
+// VSTest shim and `xunit.v3` 4.0.0 uses MTP v2 by default, so an ordinary xUnit
+// user saw an empty Testing view.
+//
+// F# comes FIRST throughout (project rule). The shapes that must survive are the
+// same three the VSTest matrix protects, in their MTP form:
+//
+//   • an F# backtick binding whose id carries SPACES,
+//   • an F# `[<TestClass>]` nested in a module, whose id carries the CLR `+`,
+//   • MSTest's DISPLAY name, which is the BARE method name and must NEVER
+//     become an id.
+//
+// Covers [TEST-MTP-DETECT], [TEST-MTP-MODULES] and [TEST-MTP-DISCOVERY].
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { SharpLspExtensionApi } from '../../extension.js';
+import { listMtpTests } from '../../test-mtp-discovery.js';
+import { scanMtpProjects } from '../../test-mtp-modules.js';
+import { usesMtpRunner } from '../../test-mtp.js';
+import {
+  ALL_MTP_IDS,
+  createMtpSolution,
+  idsOf,
+  MTP_FIXTURES,
+  mtpFixtureFor,
+  type MtpFixture,
+} from './test-explorer-mtp-fixtures';
+import {
+  activateTestExplorer,
+  collectLeafIds,
+  discoverSolution,
+  findItem,
+  rootsOf,
+  teardownFixtureSolution,
+} from './test-explorer-kit';
+import { sorted } from './test-explorer-outcome-assertions';
+import { removeDirRecursive } from './test-helpers';
+import { DOTNET_CLI_MS, FIXTURE_BUILD_MS } from './test-timeouts';
+
+/** The awkward id shapes, the label each renders as, and why it is hard. */
+const AWKWARD_SHAPES: readonly (readonly [string, string, string])[] = [
+  [
+    'Fs.XunitMtp.Fixtures.adds two numbers with spaces',
+    'adds two numbers with spaces',
+    'an F# backtick binding carries SPACES',
+  ],
+  [
+    'Fs.MstestMtp.Fixtures+CalculatorTests.AddsTwoNumbers',
+    'AddsTwoNumbers',
+    'an F# [<TestClass>] is a CLR nested type, hence the +',
+  ],
+  [
+    'Cs.NunitMtp.Fixtures.CalculatorTests.Adds_Case',
+    'Adds_Case',
+    'an NUnit [TestCase] id carries NO row data, though its uid does',
+  ],
+];
+
+/**
+ * MSTest and NUnit DISPLAY names. Not one of them may reach the tree as an id:
+ * a bare method name cannot be attributed to a class, and it is the issue-#180
+ * defect in its MTP shape.
+ */
+const BARE_DISPLAY_NAMES: readonly string[] = [
+  'Adds_TwoNumbers',
+  'Fails_OnPurpose',
+  'Skipped_OnPurpose',
+  'Adds_Row (2,2,4)',
+  'Adds_Case(2,2,4)',
+];
+
+/** The dotted prefix every id of one fixture shares. */
+function prefixOf(fixture: MtpFixture): string {
+  return fixture.passing.split('.').slice(0, 3).join('.');
+}
+
+suite('Test Explorer e2e — Microsoft.Testing.Platform discovery', () => {
+  let api: SharpLspExtensionApi;
+  let root: string;
+  let slnPath: string;
+
+  suiteSetup(async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    api = await activateTestExplorer();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'sharplsp-mtp-'));
+    slnPath = await createMtpSolution(root);
+  });
+
+  teardown(async () => {
+    // Never leave a `dotnet` invocation in flight across tests: discovery builds
+    // the same `bin/`/`obj/` a run rebuilds, and the overlap breaks both.
+    await api.testController.whenIdle();
+  });
+
+  suiteTeardown(async function () {
+    this.timeout(DOTNET_CLI_MS);
+    await teardownFixtureSolution(api, root, removeDirRecursive);
+  });
+
+  test('the global.json opt-in selects MTP, and the modules come from MSBuild', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+
+    // 1. The switch a real user throws is read from the fixture on disk.
+    assert.equal(usesMtpRunner(root), true, 'the fixture opts into the MTP runner');
+    assert.equal(
+      usesMtpRunner(path.join(root, 'XunitMtpFs')),
+      true,
+      'the opt-in is found from a project directory, exactly as the SDK finds it',
+    );
+
+    // 2. MSBuild — not a banner and not a guess — names every test module.
+    const scan = await scanMtpProjects(slnPath, root);
+    assert.equal(
+      scan.projects.length,
+      MTP_FIXTURES.length,
+      `every MTP project must be found; warnings: ${scan.warnings.join(' | ') || '(none)'}`,
+    );
+    for (const project of scan.projects) {
+      assert.ok(project.modules.length > 0, `${project.projectFile} must report a module`);
+      for (const module of project.modules) {
+        assert.equal(fs.existsSync(module), true, `the module must exist on disk: ${module}`);
+        assert.equal(path.extname(module), '.dll', 'a test module is a built assembly');
+      }
+    }
+    const names = scan.projects.map((project) => path.basename(project.projectFile));
+    assert.deepStrictEqual(
+      sorted(names),
+      sorted(MTP_FIXTURES.map((fixture) => fixture.projectFileName)),
+      'exactly the fixture projects, no more and no fewer',
+    );
+  });
+
+  test('every test of all six framework × language fixtures is discovered by id', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    const ids = await discoverSolution(api, slnPath, ALL_MTP_IDS);
+
+    // 1. Each fixture contributes exactly its own tests — a failing one and a
+    //    skipped one included, because discovery is not a run.
+    for (const fixture of MTP_FIXTURES) {
+      const mine = ids.filter((id) => id.startsWith(prefixOf(fixture)));
+      assert.deepStrictEqual(
+        sorted(mine),
+        sorted(idsOf(fixture)),
+        `${fixture.key} must expose exactly its own tests`,
+      );
+      assert.ok(
+        ids.includes(fixture.failing),
+        `${fixture.key}: a failing test is still discovered`,
+      );
+      assert.ok(
+        ids.includes(fixture.skipped),
+        `${fixture.key}: a skipped test is still discovered`,
+      );
+    }
+
+    // 2. A data-driven test appears ONCE, under an id carrying no row data.
+    for (const fixture of MTP_FIXTURES) {
+      const rows = ids.filter((id) => id === fixture.parameterized);
+      assert.equal(rows.length, 1, `${fixture.key}: the rows collapse onto one id`);
+      assert.equal(
+        fixture.parameterized.includes('('),
+        false,
+        `${fixture.key}: the id carries no row data — ${fixture.parameterized}`,
+      );
+    }
+
+    // 3. No display name, and no listing chatter, ever becomes an id.
+    for (const bare of BARE_DISPLAY_NAMES) {
+      assert.equal(
+        ids.includes(bare),
+        false,
+        `a bare display name must never be an id: '${bare}' (issue #180 in its MTP shape)`,
+      );
+    }
+    for (const id of ids) {
+      assert.equal(id.trim(), id, `a tree id never keeps the listing's spacing: '${id}'`);
+      assert.ok(id.includes('.'), `every MTP id is namespace-qualified: '${id}'`);
+    }
+  });
+
+  test('the awkward F# and NUnit shapes reach the tree verbatim, with their labels', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    const ids = await discoverSolution(api, slnPath, ALL_MTP_IDS);
+
+    for (const [id, label, why] of AWKWARD_SHAPES) {
+      assert.ok(ids.includes(id), `${why}: '${id}' must be discovered`);
+      const item = findItem(api.testController.items, id);
+      assert.ok(item, `${why}: '${id}' must be a row in the tree`);
+      assert.equal(item.label, label, `${why}: the row is labelled by its last segment`);
+      assert.equal(item.description, id, `${why}: the full id stays visible as the description`);
+    }
+  });
+
+  test('the tree is Assembly → Namespace → Class → Test, one root per project', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    await discoverSolution(api, slnPath, ALL_MTP_IDS);
+
+    // 1. One root per test module, labelled by the assembly, and never a leaf.
+    const roots = rootsOf(api.testController.items);
+    const rootLabels = roots.map((item) => item.label);
+    for (const fixture of MTP_FIXTURES) {
+      assert.ok(
+        rootLabels.includes(fixture.projectName),
+        `${fixture.key}: the assembly is a root — saw ${rootLabels.join(', ')}`,
+      );
+    }
+    for (const root_ of roots) {
+      assert.ok(root_.children.size > 0, `an assembly root is a group, not a test: ${root_.label}`);
+      assert.ok(root_.id.startsWith('assembly:'), `a root id names its module: ${root_.id}`);
+    }
+
+    // 2. A test sits under its class, which sits under its namespace.
+    const csharp = mtpFixtureFor('xunit-csharp');
+    const leaf = findItem(api.testController.items, csharp.passing);
+    assert.ok(leaf, 'the C# xUnit passing test must be a row');
+    assert.equal(leaf.children.size, 0, 'a test is a LEAF');
+    assert.ok(leaf.parent, 'a leaf hangs under its class');
+    assert.equal(leaf.parent.label, 'CalculatorTests', 'the class level is labelled by the type');
+    assert.ok(leaf.parent.parent, 'a class hangs under its namespace');
+    assert.equal(
+      leaf.parent.parent.label,
+      'Cs.XunitMtp.Fixtures',
+      'the namespace level is labelled by the namespace',
+    );
+    assert.equal(
+      leaf.parent.parent.parent?.label,
+      csharp.projectName,
+      'and the namespace hangs under the assembly',
+    );
+
+    // 3. Every leaf id is a test id, and no group node is one.
+    const leaves = collectLeafIds(api.testController.items);
+    assert.deepStrictEqual(
+      sorted(leaves),
+      sorted(ALL_MTP_IDS),
+      'exactly the fixture tests are leaves',
+    );
+  });
+
+  test('a source location is used when the framework reports one, and never invented', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    await discoverSolution(api, slnPath, ALL_MTP_IDS);
+
+    for (const fixture of MTP_FIXTURES) {
+      const item = findItem(api.testController.items, fixture.passing);
+      assert.ok(item, `${fixture.key}: the passing test must be a row`);
+      if (!fixture.reportsLocation) {
+        // NUnit reports none. The row still exists, pointed at the target folder.
+        assert.equal(item.range, undefined, `${fixture.key}: no location means no range`);
+        continue;
+      }
+      assert.ok(item.uri, `${fixture.key}: a reported location gives the row a file`);
+      assert.equal(
+        path.basename(item.uri.fsPath),
+        fixture.sourceFileName,
+        `${fixture.key}: the row points at the file the test is written in`,
+      );
+      assert.ok(item.range, `${fixture.key}: a reported location gives the row a range`);
+      assert.ok(
+        item.range.start.line >= 0,
+        `${fixture.key}: the 1-based listing line becomes a 0-based range`,
+      );
+    }
+  });
+
+  test('an MTP project with NO global.json is still found, through MSBuild', async function () {
+    this.timeout(FIXTURE_BUILD_MS);
+    const globalJson = path.join(root, 'global.json');
+    const saved = fs.readFileSync(globalJson, 'utf8');
+    fs.rmSync(globalJson);
+    try {
+      assert.equal(usesMtpRunner(root), false, 'the opt-in is gone, so detection falls through');
+
+      // The VSTest passes cannot enumerate an `xunit.v3` module at all, so the
+      // MSBuild probe is the only thing standing between the user and an empty
+      // Testing view. It must find every project on its own.
+      const listing = await listMtpTests(slnPath, root);
+      assert.equal(listing.ok, true, `the MTP sweep must succeed: ${listing.warnings.join(' | ')}`);
+      assert.deepStrictEqual(
+        sorted([...listing.names]),
+        sorted(ALL_MTP_IDS),
+        'exactly the fixture tests, found without any opt-in',
+      );
+      assert.ok(listing.mtp, 'the sweep must also report HOW to run what it found');
+      assert.equal(
+        listing.mtp.modules.length,
+        MTP_FIXTURES.length,
+        'one run entry per test module',
+      );
+      for (const module of listing.mtp.modules) {
+        assert.ok(module.uidsById.size > 0, `${module.modulePath} must map ids to uids`);
+      }
+    } finally {
+      fs.writeFileSync(globalJson, saved, 'utf8');
+    }
+  });
+});

--- a/src/editors/vscode/src/test/suite/test-explorer-outcome-assertions.ts
+++ b/src/editors/vscode/src/test/suite/test-explorer-outcome-assertions.ts
@@ -82,8 +82,19 @@ export function assertPassed(result: CachedTestResult, id: string): void {
   );
 }
 
+/**
+ * The assertion text xUnit writes. It is the default because every VSTest
+ * fixture that reaches {@link assertFailed} is an xUnit one; a suite whose
+ * fixtures span other frameworks passes each framework's own text instead.
+ */
+export const XUNIT_FAILURE_TEXT = 'Assert.Equal() Failure';
+
 /** A real failure carrying the REAL assertion text, not "Test failed". */
-export function assertFailed(result: CachedTestResult, id: string): void {
+export function assertFailed(
+  result: CachedTestResult,
+  id: string,
+  failureText: string = XUNIT_FAILURE_TEXT,
+): void {
   assert.strictEqual(
     result.outcome,
     'failed',
@@ -97,9 +108,9 @@ export function assertFailed(result: CachedTestResult, id: string): void {
   );
   const message = result.message ?? '';
   assert.strictEqual(
-    message.includes('Assert.Equal() Failure'),
+    message.includes(failureText),
     true,
-    `${id} must surface xUnit's own text: ${message}`,
+    `${id} must surface the framework's own text ('${failureText}'): ${message}`,
   );
   assert.strictEqual(
     message.includes('Expected'),

--- a/src/editors/vscode/src/testing.ts
+++ b/src/editors/vscode/src/testing.ts
@@ -2,35 +2,32 @@ import * as vscode from 'vscode';
 import { effect } from './signals';
 import { info } from './log';
 import * as state from './state';
-import { listTests, type TestAssemblyListing, type TestListing } from './test-discovery';
+import { listTests } from './test-discovery';
+import { mergePlans, type MtpRunPlan, type TestListing } from './test-listing-model';
+import { runMtpTests } from './test-mtp-run';
+import { makeAssemblyItem, makeErrorItem, makeTestItem, type ItemContext } from './test-items';
 import {
   cancelled,
   runOptions,
   runTests,
   type RunInvocation,
+  type TestRunOptions,
   type TestRunOutcome,
 } from './test-execution';
 import { debugSelectedTests, type TestDebugHost } from './test-debug';
-import { forEachLeafIn } from './test-tree';
-import { loadDetailedCoverage } from './test-coverage';
+import { registerRunProfiles, type RunProfileHandlers } from './test-profiles';
 import {
   addCoverage,
   cachedFrom,
   freshCoverageDir,
   reportAll,
   reportOutcome,
-  type CacheWriter,
   type CachedTestResult,
 } from './test-reporting';
+import { DotnetQueue } from './test-queue';
+import { TestResultCache } from './test-result-cache';
 import { cancellationSignal, configureDotnet } from './dotnet-process';
-import {
-  discoveryTargets,
-  dirOf,
-  isExpectoTest,
-  isFsCheckTest,
-  runCwd,
-  runTarget,
-} from './test-targets';
+import { discoveryTargets, dirOf, filterIdsFor, runCwd, runTarget } from './test-targets';
 
 export { buildFilterArgs } from './test-execution';
 export { isExpectoTest, isFsCheckTest } from './test-targets';
@@ -42,12 +39,6 @@ export type { CachedTestResult } from './test-reporting';
  * into a single `dotnet test --list-tests` sweep.
  */
 const DISCOVERY_DEBOUNCE_MS = 1_000;
-
-/**
- * Id prefix marking the row that explains WHY discovery failed. Error rows
- * are leaves that never run; a successful sweep removes them.
- */
-const ERROR_ITEM_PREFIX = 'discovery-error:';
 
 /**
  * Test controller integrating with VS Code's Testing API.
@@ -63,8 +54,7 @@ const ERROR_ITEM_PREFIX = 'discovery-error:';
 export class SharpLspTestController {
   private readonly controller: vscode.TestController;
   private readonly runProfiles: vscode.TestRunProfile[] = [];
-  private readonly results = new Map<string, CachedTestResult>();
-  private readonly resultsChangedEmitter = new vscode.EventEmitter<void>();
+  private readonly results = new TestResultCache();
   /** Cancels the reactive solution-change subscription. */
   private readonly solutionSubscription: () => void;
   /** Cancels the reactive `dotnet` executable subscription. */
@@ -80,37 +70,26 @@ export class SharpLspTestController {
    * being shown does a solution change reactively re-discover.
    */
   private active = false;
+  /** One `dotnet` invocation at a time, discovery and runs alike. */
+  private readonly dotnetQueue = new DotnetQueue();
   /**
-   * Serializes every `dotnet` invocation this controller makes. Discovery BUILDS
-   * the solution and a run rebuilds the same projects, so two overlapping
-   * invocations race on the shared `bin/`/`obj/` output — VSTest then dies with
-   * "The application to execute does not exist: ...testhost.dll". Reactive
-   * re-discovery is debounced, not cancelled, so that overlap is reachable
-   * whenever a user runs a test while a sweep is still building. One at a time.
+   * How to RUN what the last sweep discovered, when the runner was
+   * Microsoft.Testing.Platform. `undefined` means VSTest, whose test ids ARE
+   * the filter values. Spec: [TEST-MTP-RUN].
    */
-  private dotnetQueue: Promise<unknown> = Promise.resolve();
+  private mtpPlan: MtpRunPlan | undefined;
 
   /** Fires after any test run completes and results are cached. */
-  public readonly onResultsChanged = this.resultsChangedEmitter.event;
+  public readonly onResultsChanged = this.results.onChanged;
 
   /** Queue `work` behind any `dotnet` invocation already in flight. */
   private async enqueue<T>(work: () => Promise<T>): Promise<T> {
-    const next = this.dotnetQueue.then(work, work);
-    this.dotnetQueue = next.catch(() => undefined);
-    return await next;
+    return await this.dotnetQueue.enqueue(work);
   }
 
-  /**
-   * Resolve once no `dotnet` invocation is outstanding. Tests use this to settle
-   * reactive re-discovery before touching the fixture on disk; a `dotnet test`
-   * left pointing at a deleted directory hangs and poisons the next run.
-   */
+  /** Resolve once no `dotnet` invocation is outstanding. */
   public async whenIdle(): Promise<void> {
-    let tail: Promise<unknown> | undefined;
-    while (tail !== this.dotnetQueue) {
-      tail = this.dotnetQueue;
-      await tail;
-    }
+    await this.dotnetQueue.whenIdle();
   }
 
   /** Look up the last known result for a fully qualified test name. */
@@ -120,7 +99,7 @@ export class SharpLspTestController {
 
   /** All cached results keyed by fully qualified test name. */
   public get cachedResults(): ReadonlyMap<string, CachedTestResult> {
-    return this.results;
+    return this.results.all;
   }
 
   /** Discovered test items (delegates to the underlying TestController). */
@@ -139,7 +118,7 @@ export class SharpLspTestController {
 
   /** Create a TestItem for `fullName` without adding it to the tree. */
   public createItem(fullName: string, uri: vscode.Uri): vscode.TestItem {
-    return this.makeTestItem(fullName, uri);
+    return makeTestItem({ controller: this.controller, uri, locations: undefined }, fullName);
   }
 
   constructor() {
@@ -147,7 +126,7 @@ export class SharpLspTestController {
       'sharplsp.testController',
       'SharpLsp Tests',
     );
-    this.registerProfiles();
+    this.runProfiles.push(...registerRunProfiles(this.controller, this.profileHandlers()));
     // `dotnet` is not necessarily on `$PATH`: [DIST-RUNTIME-ACQUIRE] resolves an
     // SDK that may live anywhere and publishes its path on a signal. Track it
     // reactively so discovery and runs follow a late or re-acquired SDK instead
@@ -176,38 +155,6 @@ export class SharpLspTestController {
     });
   }
 
-  /** Run, Debug and Coverage, in the order the Test Explorer shows them. */
-  private registerProfiles(): void {
-    this.runProfiles.push(
-      this.controller.createRunProfile(
-        'Run',
-        vscode.TestRunProfileKind.Run,
-        async (request, token) => {
-          await this.runProfileHandler(request, token, false);
-        },
-        true,
-      ),
-      this.controller.createRunProfile(
-        'Debug',
-        vscode.TestRunProfileKind.Debug,
-        async (request, token) => {
-          await this.debugTests(request, token);
-        },
-      ),
-    );
-    const coverage = this.controller.createRunProfile(
-      'Run with Coverage',
-      vscode.TestRunProfileKind.Coverage,
-      async (request, token) => {
-        await this.runProfileHandler(request, token, true);
-      },
-    );
-    coverage.loadDetailedCoverage =
-      // eslint-disable-next-line @typescript-eslint/require-await -- VS Code API requires Thenable return but lookup is synchronous
-      async (_run, fileCoverage, _token) => loadDetailedCoverage(fileCoverage);
-    this.runProfiles.push(coverage);
-  }
-
   /** Mark the Test Explorer active and run a discovery sweep. */
   public async activateAndDiscover(): Promise<void> {
     this.active = true;
@@ -223,7 +170,7 @@ export class SharpLspTestController {
     for (const profile of this.runProfiles) {
       profile.dispose();
     }
-    this.resultsChangedEmitter.dispose();
+    this.results.dispose();
     this.controller.dispose();
   }
 
@@ -250,6 +197,7 @@ export class SharpLspTestController {
     const targets = discoveryTargets();
     const items: vscode.TestItem[] = [];
     const errors: vscode.TestItem[] = [];
+    const plans: MtpRunPlan[] = [];
     let anyOk = targets.length === 0;
     for (const target of targets) {
       // A newer sweep supersedes this one: stop before paying for another build
@@ -257,28 +205,40 @@ export class SharpLspTestController {
       if (generation !== this.discoverGeneration) return;
       const listing = await this.safeList(target);
       anyOk = anyOk || listing.ok;
-      const uri = vscode.Uri.file(dirOf(target));
-      if (!listing.ok && listing.names.length === 0) {
-        // The enumeration itself failed: surface the real diagnostic as a row,
-        // never a silent blank view (MSB1011 ambiguity, build errors, missing
-        // target — the cases the extension log showed going unnoticed).
-        errors.push(this.makeErrorItem(target, uri, listing.warnings));
-        continue;
-      }
-      if (listing.byAssembly.length > 0) {
-        for (const assembly of listing.byAssembly) {
-          items.push(this.makeAssemblyItem(assembly, uri));
-        }
-        continue;
-      }
-      // Display-name fallback: no attribution, so flat rows — weaker, but never
-      // worse than dropping the tests outright.
-      for (const fqn of listing.names) {
-        items.push(this.makeTestItem(fqn, uri));
-      }
+      if (listing.mtp !== undefined) plans.push(listing.mtp);
+      this.rowsFor(target, listing, items, errors);
     }
     if (generation !== this.discoverGeneration) return;
+    this.mtpPlan = mergePlans(plans);
     this.applyDiscovery(items, errors, anyOk, targets.length);
+  }
+
+  /** Turn one target's listing into tree rows, or into the row that explains it. */
+  private rowsFor(
+    target: string,
+    listing: TestListing,
+    items: vscode.TestItem[],
+    errors: vscode.TestItem[],
+  ): void {
+    const context: ItemContext = {
+      controller: this.controller,
+      uri: vscode.Uri.file(dirOf(target)),
+      locations: listing.locations,
+    };
+    if (!listing.ok && listing.names.length === 0) {
+      // The enumeration itself failed: surface the real diagnostic as a row,
+      // never a silent blank view (MSB1011 ambiguity, build errors, missing
+      // target — the cases the extension log showed going unnoticed).
+      errors.push(makeErrorItem(context, target, listing.warnings));
+      return;
+    }
+    if (listing.byAssembly.length > 0) {
+      for (const assembly of listing.byAssembly) items.push(makeAssemblyItem(context, assembly));
+      return;
+    }
+    // Display-name fallback: no attribution, so flat rows — weaker, but never
+    // worse than dropping the tests outright.
+    for (const fqn of listing.names) items.push(makeTestItem(context, fqn));
   }
 
   /**
@@ -303,35 +263,11 @@ export class SharpLspTestController {
       return;
     }
     this.controller.items.replace([...items, ...errors]);
-    this.pruneResults(this.leafIdSet([...items, ...errors]));
+    this.results.pruneTo([...items, ...errors]);
     info(
       `Test discovery: ${String(items.length)} item(s) from ${String(targetCount)} target(s)` +
         (errors.length > 0 ? `; ${String(errors.length)} error row(s)` : ''),
     );
-  }
-
-  /**
-   * Drop cached outcomes for tests no longer in the tree. The cache is keyed
-   * by fully-qualified name and outlives sweeps, so after the loaded solution
-   * changes it would paint an outcome for a test that was never run here —
-   * [TEST-REACTIVITY]: a result must not outlive the test it belongs to.
-   * Listeners hear about it only when something was actually dropped.
-   */
-  private pruneResults(alive: ReadonlySet<string>): void {
-    let dropped = 0;
-    for (const id of [...this.results.keys()]) {
-      if (alive.has(id)) continue;
-      this.results.delete(id);
-      dropped += 1;
-    }
-    if (dropped > 0) this.resultsChangedEmitter.fire();
-  }
-
-  /** Every LEAF id under `items`, recursively — group nodes never hold results. */
-  private leafIdSet(items: readonly vscode.TestItem[]): Set<string> {
-    const ids = new Set<string>();
-    forEachLeafIn(items, (item) => ids.add(item.id));
-    return ids;
   }
 
   /** List one target, logging whatever diagnostics the enumeration produced. */
@@ -341,92 +277,6 @@ export class SharpLspTestController {
       info(`Test discovery (${target}): ${warning}`);
     }
     return listing;
-  }
-
-  /** Build a flat TestItem for a fully-qualified name, tagging F# tests. */
-  private makeTestItem(fullName: string, uri: vscode.Uri): vscode.TestItem {
-    const parts = fullName.split('.');
-    const label = parts.at(-1) ?? fullName;
-    const item = this.controller.createTestItem(fullName, label, uri);
-    item.description = fullName;
-    if (isExpectoTest(fullName) || isFsCheckTest(fullName)) {
-      item.tags = [new vscode.TestTag('fsharp')];
-    }
-    return item;
-  }
-
-  /** A non-test group node: an assembly, a namespace or a class. */
-  private makeGroupItem(id: string, label: string, uri: vscode.Uri): vscode.TestItem {
-    const item = this.controller.createTestItem(id, label, uri);
-    item.canResolveChildren = true;
-    return item;
-  }
-
-  /**
-   * Build one assembly's Assembly → Namespace → Class → Test subtree from its
-   * fully-qualified names. The last dotted segment is the test, the one before
-   * it the class, the rest joined the namespace — deterministic for C#
-   * namespaces and dotted F# modules alike (`Fs.Xunit.Fixtures.adds two
-   * numbers` → `Fs.Xunit` / `Fixtures` / `adds two numbers`). Shorter names
-   * nest under whatever levels exist; nothing is ever dropped.
-   */
-  private makeAssemblyItem(assembly: TestAssemblyListing, uri: vscode.Uri): vscode.TestItem {
-    const root = this.makeGroupItem(`assembly:${assembly.path}`, assembly.name, uri);
-    const namespaces = new Map<string, vscode.TestItem>();
-    const classes = new Map<string, vscode.TestItem>();
-    for (const fqn of assembly.names) {
-      const parts = fqn.split('.');
-      const namespaceLabel = parts.length >= 3 ? parts.slice(0, -2).join('.') : '';
-      const classLabel = parts.length >= 2 ? (parts.at(-2) ?? '') : '';
-      let parent = root;
-      if (namespaceLabel !== '') {
-        const nsId = `namespace:${assembly.path}|${namespaceLabel}`;
-        let nsItem = namespaces.get(nsId);
-        if (nsItem === undefined) {
-          nsItem = this.makeGroupItem(nsId, namespaceLabel, uri);
-          namespaces.set(nsId, nsItem);
-          root.children.add(nsItem);
-        }
-        parent = nsItem;
-      }
-      if (classLabel !== '') {
-        const classId = `class:${assembly.path}|${namespaceLabel}|${classLabel}`;
-        let classItem = classes.get(classId);
-        if (classItem === undefined) {
-          classItem = this.makeGroupItem(classId, classLabel, uri);
-          classes.set(classId, classItem);
-          parent.children.add(classItem);
-        }
-        parent = classItem;
-      }
-      parent.children.add(this.makeTestItem(fqn, uri));
-    }
-    return root;
-  }
-
-  /**
-   * The row that explains WHY discovery failed: the real `dotnet` diagnostic
-   * plus a remedy, so the user acts instead of staring at an empty view.
-   */
-  private makeErrorItem(
-    target: string,
-    uri: vscode.Uri,
-    warnings: readonly string[],
-  ): vscode.TestItem {
-    const item = this.controller.createTestItem(
-      `${ERROR_ITEM_PREFIX}${target}`,
-      'Test discovery failed',
-      uri,
-    );
-    item.description = target;
-    const diagnostics =
-      warnings.length > 0 ? warnings.join('\n\n') : 'dotnet test produced no test listing.';
-    item.error = new vscode.MarkdownString(
-      `SharpLsp could not enumerate tests for \`${target}\`.\n\n` +
-        `${diagnostics}\n\n` +
-        'Load one solution with the **SharpLsp: Select Solution** command, fix the build errors above, then refresh the Testing view.',
-    );
-    return item;
   }
 
   /** The Run and Run-with-Coverage profiles share every step but collection. */
@@ -444,7 +294,7 @@ export class SharpLspTestController {
       await this.executeInto(run, tests, token, coverage, filterIds);
     } finally {
       run.end();
-      this.resultsChangedEmitter.fire();
+      this.results.fire();
     }
   }
 
@@ -458,7 +308,7 @@ export class SharpLspTestController {
   ): Promise<void> {
     const cwd = runCwd();
     if (cwd === undefined) {
-      reportAll(run, tests, 'No workspace folder or solution', this.cacheWriter());
+      reportAll(run, tests, 'No workspace folder or solution', this.results.writer());
       return;
     }
     if (cancelled(token)) return;
@@ -469,7 +319,7 @@ export class SharpLspTestController {
     // the token has just killed mid-flight, so whatever they managed to write
     // is a TRUNCATED account of a run the user abandoned: never cache or paint it.
     if (cancelled(token)) return;
-    reportOutcome(run, tests, outcome, this.cacheWriter());
+    reportOutcome(run, tests, outcome, this.results.writer());
     if (coverage && resultsDirectory !== undefined) addCoverage(run, resultsDirectory);
   }
 
@@ -479,22 +329,22 @@ export class SharpLspTestController {
     const options = runOptions(request, cancellation.signal);
     try {
       return await this.enqueue(
-        async () => await runTests(request.filterIds, request.cwd, options),
+        async () => await this.dispatch(request.filterIds, request.cwd, options),
       );
     } finally {
       cancellation.dispose();
     }
   }
 
-  private cache(testId: string, result: CachedTestResult): void {
-    this.results.set(testId, result);
-  }
-
-  /** The cache writer a real RUN reports through; a debug run passes none. */
-  private cacheWriter(): CacheWriter {
-    return (id, result) => {
-      this.cache(id, result);
-    };
+  /** Send one invocation to the runner the last discovery sweep chose. */
+  private async dispatch(
+    ids: readonly string[],
+    cwd: string,
+    options: TestRunOptions,
+  ): Promise<TestRunOutcome> {
+    const plan = this.mtpPlan;
+    if (plan === undefined) return await runTests(ids, cwd, options);
+    return await runMtpTests(plan, ids, cwd, options);
   }
 
   /**
@@ -528,10 +378,26 @@ export class SharpLspTestController {
     );
   }
 
+  /** The three handlers the Test Explorer's profiles invoke. */
+  private profileHandlers(): RunProfileHandlers {
+    return {
+      run: async (request, token) => {
+        await this.runProfileHandler(request, token, false);
+      },
+      debug: async (request, token) => {
+        await this.debugTests(request, token);
+      },
+      coverage: async (request, token) => {
+        await this.runProfileHandler(request, token, true);
+      },
+    };
+  }
+
   /** The slice of this controller the test-debug flow needs. */
   private debugHost(): TestDebugHost {
     return {
       enqueue: async (work) => await this.enqueue(work),
+      runSelection: async (ids, cwd, options) => await this.dispatch(ids, cwd, options),
       // Run-only reporting: a debug run neither caches results nor announces a
       // results change — the last real run's outcome stands.
       finish: (run, tests, outcome) => {
@@ -578,8 +444,8 @@ export class SharpLspTestController {
       folder === undefined
         ? { outcome: 'notRun' as const, passed: false, message: 'No workspace folder or solution' }
         : await this.runOne(testId, folder, cwd === undefined);
-    this.cache(testId, result);
-    this.resultsChangedEmitter.fire();
+    this.results.set(testId, result);
+    this.results.fire();
     return result;
   }
 
@@ -589,28 +455,14 @@ export class SharpLspTestController {
     // that overrode `cwd` is pointing at a specific project, and naming the
     // solution as well would run the wrong thing.
     const target = useTarget ? runTarget() : undefined;
-    const outcome = await this.enqueue(
-      async () => await runTests([testId], cwd, target === undefined ? {} : { target }),
-    );
+    const options: TestRunOptions = target === undefined ? {} : { target };
+    const outcome = await this.enqueue(async () => await this.dispatch([testId], cwd, options));
     const result = outcome.results.get(testId);
     if (result !== undefined) return cachedFrom(result);
     const message = outcome.failure ?? `No result reported for ${testId}`;
     info(`Test execution produced no result for ${testId}: ${message}`);
     return { outcome: 'notRun', passed: false, duration: outcome.durationMs, message };
   }
-}
-
-/**
- * The filter ids a run uses. "Run everything, nothing excluded" is how VS Code
- * expresses ▶ on the root of the Testing view; passing NO filter then runs every
- * test in ONE `dotnet test` — instead of N command-line-sized filter batches.
- */
-function filterIdsFor(
-  request: vscode.TestRunRequest,
-  tests: readonly vscode.TestItem[],
-): readonly string[] {
-  const unfiltered = request.include === undefined && (request.exclude ?? []).length === 0;
-  return unfiltered ? [] : tests.map((test) => test.id);
 }
 
 /**

--- a/src/editors/vscode/src/utils.ts
+++ b/src/editors/vscode/src/utils.ts
@@ -1,3 +1,15 @@
+/**
+ * A plain, non-null object — the only shape a parsed JSON node, an MSBuild
+ * property bag or a DAP message body can take.
+ *
+ * `typeof null` is `'object'` and so is an array, so both are excluded
+ * explicitly. Five modules had written this out identically before it was
+ * given one home.
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 /** Extract a human-readable message from an unknown error value. */
 export function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);

--- a/src/editors/vscode/test-chunks.json
+++ b/src/editors/vscode/test-chunks.json
@@ -107,7 +107,8 @@
         "test-explorer-names.test.js",
         "testing-lens-e2e.test.js",
         "testing-lens-status.test.js",
-        "test-explorer-coverage.test.js"
+        "test-explorer-coverage.test.js",
+        "test-explorer-mtp-parsers.test.js"
       ]
     },
     "testexplorer-frameworks": {
@@ -117,6 +118,13 @@
         "test-explorer-outcomes.test.js",
         "test-explorer-adapter-ids.test.js",
         "test-explorer-cancellation.test.js"
+      ]
+    },
+    "testexplorer-mtp": {
+      "description": "Microsoft.Testing.Platform (MTP) end to end, its own job because it builds a SECOND six-project fixture solution: `xunit.v3` 4.0.0 (MTP v2 only, no VSTest adapter at all), MSTest and NUnit on their own runners, each in C# and F#. It covers the whole MTP path — the `global.json` opt-in and the `IsTestingPlatformApplication` probe, the modules MSBuild reports, `--list-tests json` discovery with source locations, `--filter-uid` runs, `--report-trx` outcomes, the unfiltered retry an NUnit refusal earns, and the message a module missing `Microsoft.Testing.Extensions.TrxReport` produces ([TEST-MTP-DETECT], [TEST-MTP-MODULES], [TEST-MTP-DISCOVERY], [TEST-MTP-RUN]). Kept apart from `testexplorer-frameworks` because the two together would build twelve test projects in one job and blow the 15-minute ceiling ([DIST-CI-WIN-VSIX]).",
+      "files": [
+        "test-explorer-mtp.test.js",
+        "test-explorer-mtp-outcomes.test.js"
       ]
     },
     "workspace": {


### PR DESCRIPTION
Closes #249. The Test Explorer was VSTest end to end, so a Microsoft.Testing.Platform (MTP) project showed an empty Testing view. On the .NET 10 SDK, MTP v2 removed the VSTest shim and `xunit.v3` 4.0.0 uses MTP v2 by default, so that is now the ordinary case: `--nologo` is rejected in MTP mode (exit 5, zero tests), `dotnet vstest` cannot load an MTP-only module at all, and neither `--filter` nor `--logger trx` exists there.

## Product changes

* **`feat(vscode)`: discover and run MTP projects.** A second path beside VSTest that shares everything after the TRX file. The runner is chosen per target: the `global.json` `test.runner` opt-in selects MTP outright and skips the two doomed VSTest passes; without one, the VSTest passes run first and only a sweep that produced no fully-qualified name asks MSBuild for `IsTestingPlatformApplication` (`IsTestProject` MUST NOT be used — `xunit.v3` leaves it empty). A VSTest solution therefore pays nothing ([TEST-MTP-DETECT]).
* **`feat(vscode)`: ask the test MODULE, not `dotnet test`.** MTP prints no `Test run for …` banner, so the modules come from `dotnet sln list` plus `-getProperty:TargetPath` — the only source that survives a custom `AssemblyName`, `OutputPath`, `ArtifactsPath` or `RuntimeIdentifier`. Each module then answers `dotnet exec <module> --list-tests json` directly; `dotnet test` does not forward the `json` argument (dotnet/sdk#49754) ([TEST-MTP-MODULES], [TEST-MTP-DISCOVERY]).
* **`feat(vscode)`: the id comes from the listing's `type` block.** `namespace` + `typeName` + `methodName` reproduces the [TEST-DISCOVERY-FQN] table exactly — F# backtick names carrying SPACES, the F# `[<TestClass>]` nested-type `+`, and no row data, so a data-driven test's rows collapse onto the one id they share. It must NOT come from `displayName`: MSTest renders that as the BARE method name, which is issue #180 in its MTP shape. The reconstructed id equals the `className` + `.` + `name` pair the TRX report holds, so [TEST-RUN-TRX] attributes MTP outcomes with no change at all. The listing also carries a source location, so MTP rows get a file and line the VSTest path never had.
* **`feat(vscode)`: run by `--filter-uid`, report by `--report-trx`.** One invocation per module, uids batched under the Windows command-line ceiling. The uids are LITERAL, so the [TEST-FILTER-ESCAPE] grammar does not apply and must not be used — an NUnit uid is `Ns.Class.Adds_Case(2,2,4)`, and escaping its parentheses would match nothing ([TEST-MTP-RUN]).
* **`fix(vscode)`: recover when a bridged framework REFUSES the selection.** NUnit translates `--filter-uid` back into a VSTest filter expression and then rejects its own translation for any uid carrying a SPACE — every idiomatic F# backtick binding. The whole module reported nothing and four runnable tests showed as phantom failures. That module is now re-run ONCE unfiltered and the outcomes read back by name, the rule [TEST-FILTER-ESCAPE] already sets for VSTest. A rejected OPTION earns no retry: it would be rejected again.
* **`fix(vscode)`: name the package a module is missing.** `--report-trx` is an extension, not part of MTP; a module without `Microsoft.Testing.Extensions.TrxReport` exits 5. Silence would report every selected test as "No result reported" and hide the cause.
* **`fix(vscode)`: find a waiting host behind a prefix.** An MTP module IS the test host and prints `Waiting for debugger to attach... Process Id: …` — the same text as VSTest behind a prefix. Anchored to the start of the line, every MTP debug run hung on a module nothing ever attached to ([TEST-MTP-DEBUG]).
* **`fix(vscode)`: read Cobertura at both depths.** MTP collects with `--coverage --coverage-output-format cobertura` and writes `<guid>.cobertura.xml` directly into the results directory, where `coverlet.collector` writes one level down ([TEST-COVERAGE]).

## Tests

New `testexplorer-mtp` chunk, its own job because it builds a SECOND six-project fixture solution — `xunit.v3`, MSTest and NUnit, each in C# and F#, F# first. Together with `testexplorer-frameworks` it would build twelve test projects in one job and blow the 15-minute ceiling ([DIST-CI-WIN-VSIX]).

* **`test-explorer-mtp.test.ts`** — the opt-in and the MSBuild probe, module resolution, the tree for all six fixtures, the MSTest bare display name that must never become an id, and the source location that NUnit does not report and must not be invented.
* **`test-explorer-mtp-outcomes.test.ts`** — pass/fail/skip across all six projects with each framework's OWN assertion text, a theory whose rows disagree, the class row, the NUnit refusal recovering and the C# selection that must NOT be retried, and the missing-TrxReport message.
* **`test-explorer-mtp-parsers.test.ts`** — the readers at their boundary: the opt-in against every decoy that merely mentions MTP, a BOM, an unknown `schemaVersion`, a missing `type`, the uid batcher, and the pid line in both its bare and prefixed forms.

The shared `assertFailed` hardcoded xUnit's `Assert.Equal() Failure`, which no MSTest or NUnit failure carries — it had only ever been fed xUnit fixtures. It now takes the framework's own text, defaulting to xUnit's, so every existing caller is unchanged.

## Refactoring

`testing.ts` was 628 lines against a 500 ceiling; it is 480, with the tree builder, the run profiles, the result cache and the `dotnet` queue in their own modules. Deslop found `isRecord` written out identically five times — it now lives in `utils.ts`, re-exported from `dap-emulate` so the ten DAP importers are untouched — and one command-line batcher now serves the assembly list, the VSTest filter and the MTP uids. Duplication measures 15.69% against the 20.0% ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## TLDR
<!-- One sentence: what does this PR do? -->

## Details
<!-- New functionality, new files, new dependencies. What changed? -->

## How Do The Automated Tests Prove It Works?
<!-- Name specific tests or describe what the test output demonstrates. -->
<!-- "Tests pass" is not acceptable. Be specific. -->
